### PR TITLE
fix(database): key multiple select and collaborator sorting on the option set

### DIFF
--- a/backend/src/baserow/contrib/database/fields/field_types.py
+++ b/backend/src/baserow/contrib/database/fields/field_types.py
@@ -5405,6 +5405,41 @@ class MultipleSelectFieldType(
 
         return OptionallyAnnotatedOrderBy(annotation=annotation, order=order)
 
+    def get_group_by_sort_order(
+        self, field, field_name, order_direction, sort_type, table_model=None
+    ):
+        """
+        Group-by treats a cell as a set of options: ``{A, B}`` and ``{B, A}``
+        are the same group. The aggregated sort key must therefore be
+        deterministic regardless of insertion order, so we order the
+        ``StringAgg`` by the option value (and break ties with the through-table
+        id).
+        """
+
+        sort_column_name = f"{field_name}_group_by_agg_sort"
+        sortable_column_expression = self.get_sortable_column_expression(
+            field, field_name, sort_type
+        )
+        query = Coalesce(
+            StringAgg(
+                sortable_column_expression,
+                ",",
+                order_by=(sortable_column_expression, f"{field_name}__id"),
+                output_field=models.TextField(),
+            ),
+            Value(""),
+            output_field=models.TextField(),
+        )
+        annotation = {sort_column_name: query}
+        order = collate_expression(F(sort_column_name))
+
+        if order_direction == "DESC":
+            order = order.desc(nulls_first=True)
+        else:
+            order = order.asc(nulls_first=True)
+
+        return OptionallyAnnotatedOrderBy(annotation=annotation, order=order)
+
     def before_field_options_update(
         self, field, to_create=None, to_update=None, to_delete=None
     ):
@@ -7298,6 +7333,41 @@ class MultipleCollaboratorsFieldType(
             StringAgg(
                 self.get_sortable_column_expression(field, field_name, sort_type),
                 "",
+                output_field=models.TextField(),
+            ),
+            Value(""),
+            output_field=models.TextField(),
+        )
+        annotation = {sort_column_name: query}
+
+        order = collate_expression(F(sort_column_name))
+
+        if order_direction == "DESC":
+            order = order.desc(nulls_first=True)
+        else:
+            order = order.asc(nulls_first=True)
+
+        return OptionallyAnnotatedOrderBy(annotation=annotation, order=order)
+
+    def get_group_by_sort_order(
+        self, field, field_name, order_direction, sort_type, table_model=None
+    ):
+        """
+        Group-by treats a cell as a set of collaborators: ``{A, B}`` and
+        ``{B, A}`` are the same group. The aggregated sort key must therefore
+        be deterministic regardless of insertion order, so we order the
+        ``StringAgg`` by name (and break ties with the through-table id).
+        """
+
+        sort_column_name = f"{field_name}_group_by_agg_sort"
+        sortable_column_expression = self.get_sortable_column_expression(
+            field, field_name, sort_type
+        )
+        query = Coalesce(
+            StringAgg(
+                sortable_column_expression,
+                "",
+                order_by=(sortable_column_expression, f"{field_name}__id"),
                 output_field=models.TextField(),
             ),
             Value(""),

--- a/backend/src/baserow/contrib/database/fields/field_types.py
+++ b/backend/src/baserow/contrib/database/fields/field_types.py
@@ -51,7 +51,7 @@ from django.db.models import (
 )
 from django.db.models.fields import NOT_PROVIDED
 from django.db.models.fields.related import ManyToManyField
-from django.db.models.functions import Cast, Coalesce, Left, RowNumber
+from django.db.models.functions import Cast, Coalesce, Left, LPad, RowNumber
 
 from dateutil import parser
 from dateutil.parser import ParserError
@@ -7372,9 +7372,15 @@ class MultipleCollaboratorsFieldType(
         pair_field = ArrayField(models.TextField(), size=2)
         sort_key_field = ArrayField(pair_field)
 
+        collated_name = collate_expression(F(f"{field_name}__first_name"))
+
         option_key = Func(
-            F(f"{field_name}__first_name"),
-            Cast(F(f"{field_name}__id"), output_field=models.TextField()),
+            collated_name,
+            LPad(
+                Cast(F(f"{field_name}__id"), output_field=models.TextField()),
+                12,
+                Value("0"),
+            ),
             template="ARRAY[%(expressions)s]",
             output_field=pair_field,
         )
@@ -7383,7 +7389,7 @@ class MultipleCollaboratorsFieldType(
             ArrayAgg(
                 option_key,
                 filter=Q(**{f"{field_name}__id__isnull": False}),
-                order_by=(f"{field_name}__first_name", f"{field_name}__id"),
+                order_by=(collated_name.asc(), F(f"{field_name}__id").asc()),
             ),
             Value([], output_field=sort_key_field),
             output_field=sort_key_field,

--- a/backend/src/baserow/contrib/database/fields/field_types.py
+++ b/backend/src/baserow/contrib/database/fields/field_types.py
@@ -27,6 +27,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractUser
 from django.contrib.postgres.aggregates import ArrayAgg, JSONBAgg, StringAgg
+from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.core.files.storage import Storage
 from django.db import OperationalError, connection, models
@@ -5410,28 +5411,35 @@ class MultipleSelectFieldType(
     ):
         """
         Group-by treats a cell as a set of options: ``{A, B}`` and ``{B, A}``
-        are the same group. The aggregated sort key must therefore be
-        deterministic regardless of insertion order, so we order the
-        ``StringAgg`` by the option value (and break ties with the through-table
-        id).
+        are the same group. Uses ``ArrayAgg(ARRAY[order, id])`` to produce a
+        collision-proof, deterministic sort key based on the field-defined
+        option order.
         """
 
         sort_column_name = f"{field_name}_group_by_agg_sort"
-        sortable_column_expression = self.get_sortable_column_expression(
-            field, field_name, sort_type
+
+        pair_field = ArrayField(models.IntegerField(), size=2)
+        sort_key_field = ArrayField(pair_field)
+
+        option_key = Func(
+            F(f"{field_name}__order"),
+            F(f"{field_name}__id"),
+            template="ARRAY[%(expressions)s]",
+            output_field=pair_field,
         )
+
         query = Coalesce(
-            StringAgg(
-                sortable_column_expression,
-                ",",
-                order_by=(sortable_column_expression, f"{field_name}__id"),
-                output_field=models.TextField(),
+            ArrayAgg(
+                option_key,
+                filter=Q(**{f"{field_name}__id__isnull": False}),
+                order_by=(f"{field_name}__order", f"{field_name}__id"),
             ),
-            Value(""),
-            output_field=models.TextField(),
+            Value([], output_field=sort_key_field),
+            output_field=sort_key_field,
         )
+
         annotation = {sort_column_name: query}
-        order = collate_expression(F(sort_column_name))
+        order = F(sort_column_name)
 
         if order_direction == "DESC":
             order = order.desc(nulls_first=True)
@@ -7354,28 +7362,35 @@ class MultipleCollaboratorsFieldType(
     ):
         """
         Group-by treats a cell as a set of collaborators: ``{A, B}`` and
-        ``{B, A}`` are the same group. The aggregated sort key must therefore
-        be deterministic regardless of insertion order, so we order the
-        ``StringAgg`` by name (and break ties with the through-table id).
+        ``{B, A}`` are the same group. Uses ``ArrayAgg(ARRAY[first_name, id])``
+        ordered by ``(first_name, id)`` to produce a collision-proof sort key
+        with alphabetical group ordering.
         """
 
         sort_column_name = f"{field_name}_group_by_agg_sort"
-        sortable_column_expression = self.get_sortable_column_expression(
-            field, field_name, sort_type
-        )
-        query = Coalesce(
-            StringAgg(
-                sortable_column_expression,
-                "",
-                order_by=(sortable_column_expression, f"{field_name}__id"),
-                output_field=models.TextField(),
-            ),
-            Value(""),
-            output_field=models.TextField(),
-        )
-        annotation = {sort_column_name: query}
 
-        order = collate_expression(F(sort_column_name))
+        pair_field = ArrayField(models.TextField(), size=2)
+        sort_key_field = ArrayField(pair_field)
+
+        option_key = Func(
+            F(f"{field_name}__first_name"),
+            Cast(F(f"{field_name}__id"), output_field=models.TextField()),
+            template="ARRAY[%(expressions)s]",
+            output_field=pair_field,
+        )
+
+        query = Coalesce(
+            ArrayAgg(
+                option_key,
+                filter=Q(**{f"{field_name}__id__isnull": False}),
+                order_by=(f"{field_name}__first_name", f"{field_name}__id"),
+            ),
+            Value([], output_field=sort_key_field),
+            output_field=sort_key_field,
+        )
+
+        annotation = {sort_column_name: query}
+        order = F(sort_column_name)
 
         if order_direction == "DESC":
             order = order.desc(nulls_first=True)

--- a/backend/src/baserow/contrib/database/fields/registries.py
+++ b/backend/src/baserow/contrib/database/fields/registries.py
@@ -1005,6 +1005,36 @@ class FieldType(
         :return: The ordering applied to the group-by data groups.
         """
 
+        return self.get_group_by_sort_order(
+            field, field_name, order_direction, sort_type, table_model=table_model
+        )
+
+    def get_group_by_sort_order(
+        self,
+        field: Type[Field],
+        field_name: str,
+        order_direction: str,
+        sort_type: str,
+        table_model: Optional["GeneratedTableModel"] = None,
+    ) -> OptionallyAnnotatedOrderBy:
+        """
+        Returns the raw ordering expression used to sort groups in a group-by
+        query, before any subquery wrapping that ``get_group_by_order`` may
+        apply. By default this delegates to ``get_order`` so groups sort the
+        same way rows do. Field types that need a different ordering for
+        group-by (e.g. set-based ordering for many-to-many fields) can override
+        this without duplicating the subquery logic in
+        ``ManyToManyGroupByMixin.get_group_by_order``.
+
+        :param field: The related field object instance.
+        :param field_name: The name of the field.
+        :param order_direction: The sort order direction (either "ASC" or "DESC").
+        :param sort_type: The sort type that must be used.
+        :param table_model: The table model instance that the field is part of,
+            if available.
+        :return: The ordering applied to the group-by data groups.
+        """
+
         return self.get_order(
             field, field_name, order_direction, sort_type, table_model=table_model
         )
@@ -2291,7 +2321,7 @@ class ManyToManyGroupByMixin:
     def get_group_by_order(
         self, field, field_name, order_direction, sort_type, table_model=None
     ):
-        order = self.get_order(
+        order = self.get_group_by_sort_order(
             field, field_name, order_direction, sort_type, table_model=table_model
         )
         if order.annotation is None or table_model is None:
@@ -2299,9 +2329,9 @@ class ManyToManyGroupByMixin:
 
         # In a group-by data query an aggregated ArrayField annotation shadows the
         # relation column (see `get_group_by_field_filters_and_annotations`), so joins
-        # `get_order` relies on aren't reachable. Recompute the same ordering as per-row
-        # correlated subqueries against the table model, where the relation exists, so
-        # groups and rows order identically.
+        # `get_group_by_sort_order` relies on aren't reachable. Recompute the same
+        # ordering as per-row correlated subqueries against the table model, where the
+        # relation exists, so groups and rows order identically.
         wrapped_annotation = {
             alias: Subquery(
                 table_model.objects.filter(id=OuterRef("id"))

--- a/backend/src/baserow/contrib/database/views/handler.py
+++ b/backend/src/baserow/contrib/database/views/handler.py
@@ -2108,13 +2108,22 @@ class ViewHandler:
             field_name = model._field_objects[view_sort_or_group_by.field_id]["name"]
             field_type = model._field_objects[view_sort_or_group_by.field_id]["type"]
 
-            field_annotated_order_by = field_type.get_order(
-                field,
-                field_name,
-                view_sort_or_group_by.order,
-                view_sort_or_group_by.type,
-                table_model=queryset.model,
-            )
+            if isinstance(view_sort_or_group_by, ViewGroupBy):
+                field_annotated_order_by = field_type.get_group_by_sort_order(
+                    field,
+                    field_name,
+                    view_sort_or_group_by.order,
+                    view_sort_or_group_by.type,
+                    table_model=queryset.model,
+                )
+            else:
+                field_annotated_order_by = field_type.get_order(
+                    field,
+                    field_name,
+                    view_sort_or_group_by.order,
+                    view_sort_or_group_by.type,
+                    table_model=queryset.model,
+                )
             field_annotation = field_annotated_order_by.annotation
             field_order_bys = field_annotated_order_by.order_bys
 

--- a/backend/tests/baserow/contrib/database/field/test_multiple_collaborators_field_type.py
+++ b/backend/tests/baserow/contrib/database/field/test_multiple_collaborators_field_type.py
@@ -14,6 +14,7 @@ from pytest_unordered import unordered
 from baserow.contrib.database.fields.field_types import MultipleCollaboratorsFieldType
 from baserow.contrib.database.fields.handler import FieldHandler
 from baserow.contrib.database.fields.models import MultipleCollaboratorsField
+from baserow.contrib.database.fields.registries import field_type_registry
 from baserow.contrib.database.rows.handler import RowHandler
 from baserow.contrib.database.search.handler import SearchMode
 from baserow.contrib.database.views.handler import ViewHandler
@@ -1239,3 +1240,52 @@ def test_list_rows_with_group_by_and_multiple_collaborators_field(
             ]
         ),
     }
+
+
+@pytest.mark.django_db
+def test_multiple_collaborators_field_type_group_by_sort_order_ignores_selection_order(
+    data_fixture,
+):
+    """
+    Group-by treats a collaborator cell as a set: ``{A, B}`` and ``{B, A}`` are the
+    same group. ``get_group_by_sort_order`` must produce the same sort key for both so
+    that rows of one group sort contiguously.
+    """
+
+    user = data_fixture.create_user(email="user1@baserow.io", first_name="User 1")
+    user_2 = data_fixture.create_user(email="user2@baserow.io", first_name="User 2")
+    database = data_fixture.create_database_application(user=user, name="Placeholder")
+    data_fixture.create_user_workspace(workspace=database.workspace, user=user_2)
+    table = data_fixture.create_database_table(name="Example", database=database)
+
+    field = data_fixture.create_multiple_collaborators_field(
+        user=user, table=table, name="Multiple Collaborators"
+    )
+
+    data_fixture.create_row_for_many_to_many_field(
+        table=table, field=field, values=[{"id": user.id}, {"id": user_2.id}], user=user
+    )
+    data_fixture.create_row_for_many_to_many_field(
+        table=table, field=field, values=[{"id": user_2.id}, {"id": user.id}], user=user
+    )
+    data_fixture.create_row_for_many_to_many_field(
+        table=table, field=field, values=[{"id": user_2.id}], user=user
+    )
+
+    model = table.get_model()
+    field_type = field_type_registry.get_by_model(field)
+    field_name = field.db_column
+    order = field_type.get_group_by_sort_order(
+        field, field_name, "ASC", "default", table_model=model
+    )
+
+    qs = model.objects.all()
+    if order.annotation:
+        qs = qs.annotate(**order.annotation)
+    rows = list(qs.order_by(order.order))
+
+    # Rows 1 and 2 share the same set {User 1, User 2} so they must be adjacent.
+    collab_sets = [frozenset(c.id for c in getattr(r, field_name).all()) for r in rows]
+    pair_indices = [i for i, s in enumerate(collab_sets) if s == {user.id, user_2.id}]
+    assert len(pair_indices) == 2
+    assert pair_indices[1] - pair_indices[0] == 1

--- a/backend/tests/baserow/contrib/database/field/test_multiple_select_field_type.py
+++ b/backend/tests/baserow/contrib/database/field/test_multiple_select_field_type.py
@@ -3277,9 +3277,7 @@ def test_multiple_select_field_type_group_by_sort_order_ignores_selection_order(
         qs = qs.annotate(**order.annotation)
     rows = list(qs.order_by(order.order))
 
-    row_ids = [row.id for row in rows]
     # Rows 1 and 3 share the same set {A, C} so they must be adjacent.
-    assert row_ids[0] != rows[1].id or row_ids[1] != rows[2].id  # not all same
     ac_indices = [
         i
         for i, r in enumerate(rows)

--- a/backend/tests/baserow/contrib/database/field/test_multiple_select_field_type.py
+++ b/backend/tests/baserow/contrib/database/field/test_multiple_select_field_type.py
@@ -3229,3 +3229,61 @@ def test_multiple_select_doest_contains_word_filter_type(field_name, data_fixtur
     ids = [r.id for r in handler.apply_filters(grid_view, model.objects.all()).all()]
     assert len(ids) == 3
     assert ids == unordered([row_1.id, row_2.id, row_4.id])
+
+
+@pytest.mark.django_db
+def test_multiple_select_field_type_group_by_sort_order_ignores_selection_order(
+    data_fixture,
+):
+    """
+    Group-by treats a multiple select cell as a set: ``{A, C}`` and ``{C, A}`` are
+    the same group. ``get_group_by_sort_order`` must produce the same sort key for
+    both so that rows of one group sort contiguously.
+    """
+
+    user = data_fixture.create_user()
+    database = data_fixture.create_database_application(user=user, name="Placeholder")
+    table = data_fixture.create_database_table(name="Example", database=database)
+
+    field = FieldHandler().create_field(
+        user=user,
+        table=table,
+        name="Multiple Select",
+        type_name="multiple_select",
+    )
+    option_a = data_fixture.create_select_option(field=field, value="A", color="red")
+    option_b = data_fixture.create_select_option(field=field, value="B", color="blue")
+    option_c = data_fixture.create_select_option(field=field, value="C", color="green")
+
+    data_fixture.create_row_for_many_to_many_field(
+        table=table, field=field, values=[option_a.id, option_c.id], user=user
+    )
+    data_fixture.create_row_for_many_to_many_field(
+        table=table, field=field, values=[option_b.id], user=user
+    )
+    data_fixture.create_row_for_many_to_many_field(
+        table=table, field=field, values=[option_c.id, option_a.id], user=user
+    )
+
+    model = table.get_model()
+    field_type = field_type_registry.get_by_model(field)
+    field_name = field.db_column
+    order = field_type.get_group_by_sort_order(
+        field, field_name, "ASC", "default", table_model=model
+    )
+
+    qs = model.objects.all()
+    if order.annotation:
+        qs = qs.annotate(**order.annotation)
+    rows = list(qs.order_by(order.order))
+
+    row_ids = [row.id for row in rows]
+    # Rows 1 and 3 share the same set {A, C} so they must be adjacent.
+    assert row_ids[0] != rows[1].id or row_ids[1] != rows[2].id  # not all same
+    ac_indices = [
+        i
+        for i, r in enumerate(rows)
+        if {option_a.id, option_c.id} == {o.id for o in getattr(r, field_name).all()}
+    ]
+    assert len(ac_indices) == 2
+    assert ac_indices[1] - ac_indices[0] == 1

--- a/backend/tests/baserow/contrib/database/view/test_view_handler_group_by_data.py
+++ b/backend/tests/baserow/contrib/database/view/test_view_handler_group_by_data.py
@@ -461,3 +461,123 @@ def test_get_group_by_data_for_parents_matches_per_parent_queries(data_fixture):
             group["_parent_group_count"] == reference["group_count"]
             for group in batched_for_parent
         )
+
+
+def _ghost_row_slots(view_handler, user, grid, model, db_column):
+    base_queryset = view_handler.get_queryset(
+        user, grid, model=model, apply_sorts=False
+    )
+    data = view_handler.get_group_by_data(
+        base_queryset, list(grid.viewgroupby_set.all()), limit=200
+    )
+    rows = list(view_handler.get_queryset(user, grid, model=model))
+
+    ghosts = []
+    for group in data["groups"]:
+        group_path = sorted(group["path"][db_column])
+        start = group["row_offset"]
+        for offset in range(start, start + group["row_count"]):
+            row = rows[offset]
+            row_path = sorted(related.id for related in getattr(row, db_column).all())
+            if row_path != group_path:
+                ghosts.append(
+                    f"slot {offset} of group {group_path} got row {row.id} "
+                    f"belonging to {row_path}"
+                )
+    return ghosts
+
+
+@pytest.mark.django_db
+def test_get_group_by_data_row_offsets_match_row_order_for_multiple_select(
+    data_fixture,
+):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_multiple_select_field(table=table, name="Tags")
+    option_a = data_fixture.create_select_option(field=field, value="A", order=0)
+    option_b = data_fixture.create_select_option(field=field, value="B", order=1)
+    option_c = data_fixture.create_select_option(field=field, value="C", order=2)
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=field)
+
+    for values in [
+        [option_a.id, option_c.id],
+        [option_c.id, option_a.id],
+        [option_b.id],
+    ]:
+        data_fixture.create_row_for_many_to_many_field(
+            table=table, field=field, values=values, user=user
+        )
+
+    ghosts = _ghost_row_slots(
+        ViewHandler(), user, grid, table.get_model(), field.db_column
+    )
+    assert ghosts == [], "\n".join(ghosts)
+
+
+@pytest.mark.django_db
+def test_get_group_by_data_row_offsets_match_with_sort_on_same_multiple_select_field(
+    data_fixture,
+):
+    """
+    When the same multiple select field is both grouped-by and sorted-by, the
+    group-by uses set-based ordering and the sort uses insertion-order. The two
+    annotations must not collide.
+    """
+
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_multiple_select_field(table=table, name="Tags")
+    option_a = data_fixture.create_select_option(field=field, value="A", order=0)
+    option_b = data_fixture.create_select_option(field=field, value="B", order=1)
+    option_c = data_fixture.create_select_option(field=field, value="C", order=2)
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=field)
+    data_fixture.create_view_sort(view=grid, field=field, order="DESC")
+
+    for values in [
+        [option_a.id, option_c.id],
+        [option_c.id, option_a.id],
+        [option_b.id],
+    ]:
+        data_fixture.create_row_for_many_to_many_field(
+            table=table, field=field, values=values, user=user
+        )
+
+    ghosts = _ghost_row_slots(
+        ViewHandler(), user, grid, table.get_model(), field.db_column
+    )
+    assert ghosts == [], "\n".join(ghosts)
+
+
+@pytest.mark.django_db
+def test_get_group_by_data_row_offsets_match_row_order_for_collaborators(data_fixture):
+    user = data_fixture.create_user()
+    database = data_fixture.create_database_application(user=user)
+    table = data_fixture.create_database_table(user=user, database=database)
+    collaborator_a = data_fixture.create_user(
+        workspace=database.workspace, first_name="Aaa"
+    )
+    collaborator_b = data_fixture.create_user(
+        workspace=database.workspace, first_name="Mmm"
+    )
+    collaborator_c = data_fixture.create_user(
+        workspace=database.workspace, first_name="Zzz"
+    )
+    field = data_fixture.create_multiple_collaborators_field(table=table, name="People")
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=field)
+
+    for values in [
+        [{"id": collaborator_a.id}, {"id": collaborator_c.id}],
+        [{"id": collaborator_c.id}, {"id": collaborator_a.id}],
+        [{"id": collaborator_b.id}],
+    ]:
+        data_fixture.create_row_for_many_to_many_field(
+            table=table, field=field, values=values, user=user
+        )
+
+    ghosts = _ghost_row_slots(
+        ViewHandler(), user, grid, table.get_model(), field.db_column
+    )
+    assert ghosts == [], "\n".join(ghosts)

--- a/changelog/entries/unreleased/bug/5782_fixed_blank_rows_appearing_in_grid_views_grouped_by_a_multip.json
+++ b/changelog/entries/unreleased/bug/5782_fixed_blank_rows_appearing_in_grid_views_grouped_by_a_multip.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed blank rows appearing in grid views grouped by a multiple select or multiple collaborators field.",
+    "issue_origin": "github",
+    "issue_number": 5782,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-27"
+}

--- a/web-frontend/modules/database/fieldTypes.js
+++ b/web-frontend/modules/database/fieldTypes.js
@@ -4120,28 +4120,30 @@ export class MultipleSelectFieldType extends SelectOptionBaseFieldType {
   }
 
   getGroupBySort(name, order, field) {
+    const optionOrders = new Map(
+      (field.select_options || []).map((option) => [option.id, option.order])
+    )
+
     const sortKey = (values) => {
       if (!values || values.length === 0) {
-        return ''
+        return []
       }
       return [...values]
-        .map((obj) => {
-          const option = (field.select_options || []).find(
-            (o) => o.id === obj.id
-          )
-          return { ...obj, value: option?.value ?? '' }
-        })
-        .sort(
-          (left, right) =>
-            collatedStringCompare(left.value, right.value, 'ASC') ||
-            left.id - right.id
-        )
-        .map((option) => option.value)
-        .join(',')
+        .map(({ id }) => [optionOrders.get(id) ?? Infinity, id])
+        .sort(([orderA, idA], [orderB, idB]) => orderA - orderB || idA - idB)
     }
 
-    return (a, b) =>
-      collatedStringCompare(sortKey(a[name]), sortKey(b[name]), order)
+    const comparePairs = (pairsA, pairsB) => {
+      const len = Math.min(pairsA.length, pairsB.length)
+      for (let i = 0; i < len; i++) {
+        const d = pairsA[i][0] - pairsB[i][0] || pairsA[i][1] - pairsB[i][1]
+        if (d !== 0) return order === 'ASC' ? d : -d
+      }
+      const lenDiff = pairsA.length - pairsB.length
+      return order === 'ASC' ? lenDiff : -lenDiff
+    }
+
+    return (a, b) => comparePairs(sortKey(a[name]), sortKey(b[name]))
   }
 
   parseDefaultRowValue(field, value) {
@@ -4943,23 +4945,40 @@ export class MultipleCollaboratorsFieldType extends FieldType {
   }
 
   getGroupBySort(name, order, field) {
-    const sortKey = (values) => {
-      if (!values || values.length === 0) {
-        return ''
-      }
+    const resolveName = (obj) => {
       const workspaces = this.app.$store.getters['workspace/getAll']
-      const names = values.map((obj) =>
-        workspaces.length > 0
-          ? this.app.$store.getters['workspace/getUserById'](obj.id).name
-          : obj.name
-      )
-      return names
-        .sort((left, right) => collatedStringCompare(left, right, 'ASC'))
-        .join('')
+      if (workspaces.length > 0) {
+        const user = this.app.$store.getters['workspace/getUserById'](obj.id)
+        return user?.name ?? obj.name ?? ''
+      }
+      return obj.name ?? ''
     }
 
-    return (a, b) =>
-      collatedStringCompare(sortKey(a[name]), sortKey(b[name]), order)
+    const sortKey = (values) => {
+      if (!values || values.length === 0) {
+        return []
+      }
+      return [...values]
+        .map((obj) => [resolveName(obj), obj.id])
+        .sort(
+          ([nameA, idA], [nameB, idB]) =>
+            collatedStringCompare(nameA, nameB, 'ASC') || idA - idB
+        )
+    }
+
+    const comparePairs = (pairsA, pairsB) => {
+      const len = Math.min(pairsA.length, pairsB.length)
+      for (let i = 0; i < len; i++) {
+        const d =
+          collatedStringCompare(pairsA[i][0], pairsB[i][0], 'ASC') ||
+          pairsA[i][1] - pairsB[i][1]
+        if (d !== 0) return order === 'ASC' ? d : -d
+      }
+      const lenDiff = pairsA.length - pairsB.length
+      return order === 'ASC' ? lenDiff : -lenDiff
+    }
+
+    return (a, b) => comparePairs(sortKey(a[name]), sortKey(b[name]))
   }
 
   prepareValueForCopy(field, value) {

--- a/web-frontend/modules/database/fieldTypes.js
+++ b/web-frontend/modules/database/fieldTypes.js
@@ -621,6 +621,16 @@ export class FieldType extends Registerable {
   }
 
   /**
+   * Returns the sort function used when ordering group-by nodes. By default
+   * this delegates to `getSort`, so groups sort the same way rows do. Field
+   * types that need set-based ordering for group-by (e.g. multi-select,
+   * multiple collaborators) override this independently.
+   */
+  getGroupBySort(name, order) {
+    return this.getSort(name, order)
+  }
+
+  /**
    * Should return a visualisation of how the sort function is going to work. For
    * example ['text', 'A', 'Z'] will result in 'A -> Z' as ascending and 'Z -> A'
    * descending visualisation for the user. It is also possible to use a icon class name
@@ -4106,6 +4116,25 @@ export class MultipleSelectFieldType extends SelectOptionBaseFieldType {
     }
   }
 
+  getGroupBySort(name, order) {
+    const sortKey = (values) => {
+      if (!values || values.length === 0) {
+        return ''
+      }
+      return [...values]
+        .sort(
+          (left, right) =>
+            collatedStringCompare(left.value, right.value, 'ASC') ||
+            left.id - right.id
+        )
+        .map((option) => option.value)
+        .join(',')
+    }
+
+    return (a, b) =>
+      collatedStringCompare(sortKey(a[name]), sortKey(b[name]), order)
+  }
+
   parseDefaultRowValue(field, value) {
     if (!Array.isArray(value)) {
       return []
@@ -4902,6 +4931,26 @@ export class MultipleCollaboratorsFieldType extends FieldType {
 
       return collatedStringCompare(stringA, stringB, order)
     }
+  }
+
+  getGroupBySort(name, order) {
+    const sortKey = (values) => {
+      if (values.length === 0) {
+        return ''
+      }
+      const workspaces = this.app.$store.getters['workspace/getAll']
+      const names = values.map((obj) =>
+        workspaces.length > 0
+          ? this.app.$store.getters['workspace/getUserById'](obj.id).name
+          : obj.name
+      )
+      return names
+        .sort((left, right) => collatedStringCompare(left, right, 'ASC'))
+        .join('')
+    }
+
+    return (a, b) =>
+      collatedStringCompare(sortKey(a[name]), sortKey(b[name]), order)
   }
 
   prepareValueForCopy(field, value) {

--- a/web-frontend/modules/database/fieldTypes.js
+++ b/web-frontend/modules/database/fieldTypes.js
@@ -622,12 +622,15 @@ export class FieldType extends Registerable {
 
   /**
    * Returns the sort function used when ordering group-by nodes. By default
-   * this delegates to `getSort`, so groups sort the same way rows do. Field
-   * types that need set-based ordering for group-by (e.g. multi-select,
-   * multiple collaborators) override this independently.
+   * this dispatches through `getSortTypes` so the group-by type (e.g.
+   * "First → Last" for single select) is respected. Field types that need
+   * set-based ordering for group-by (e.g. multi-select, multiple
+   * collaborators) override this independently.
    */
-  getGroupBySort(name, order) {
-    return this.getSort(name, order)
+  getGroupBySort(name, order, field, sortType) {
+    const types = this.getSortTypes(field)
+    const resolved = types[sortType] || types[DEFAULT_SORT_TYPE_KEY]
+    return resolved.function(name, order, field)
   }
 
   /**
@@ -4116,12 +4119,18 @@ export class MultipleSelectFieldType extends SelectOptionBaseFieldType {
     }
   }
 
-  getGroupBySort(name, order) {
+  getGroupBySort(name, order, field) {
     const sortKey = (values) => {
       if (!values || values.length === 0) {
         return ''
       }
       return [...values]
+        .map((obj) => {
+          const option = (field.select_options || []).find(
+            (o) => o.id === obj.id
+          )
+          return { ...obj, value: option?.value ?? '' }
+        })
         .sort(
           (left, right) =>
             collatedStringCompare(left.value, right.value, 'ASC') ||
@@ -4933,9 +4942,9 @@ export class MultipleCollaboratorsFieldType extends FieldType {
     }
   }
 
-  getGroupBySort(name, order) {
+  getGroupBySort(name, order, field) {
     const sortKey = (values) => {
-      if (values.length === 0) {
+      if (!values || values.length === 0) {
         return ''
       }
       const workspaces = this.app.$store.getters['workspace/getAll']

--- a/web-frontend/modules/database/utils/gridGroupBy.js
+++ b/web-frontend/modules/database/utils/gridGroupBy.js
@@ -3,7 +3,7 @@ import {
   visibleGroupDepthPageInViewport,
 } from '@baserow/modules/database/utils/gridGroupByRender'
 import { computeRowInsertPosition } from '@baserow/modules/database/utils/row'
-import { getRowSortFunction } from '@baserow/modules/database/utils/view'
+import { getGroupByRowSortFunction } from '@baserow/modules/database/utils/view'
 import { DEFAULT_SORT_TYPE_KEY } from '@baserow/modules/database/constants'
 
 /**
@@ -389,7 +389,11 @@ function makeGroupByNodeSiblingComparator(fields, groupBys, registry, depth) {
     return null
   }
 
-  const sortFunction = getRowSortFunction(registry, [], fields, depthGroupBys)
+  const sortFunction = getGroupByRowSortFunction(
+    registry,
+    fields,
+    depthGroupBys
+  )
   return (leftNode, rightNode) =>
     sortFunction(
       groupByNodeToSortRow(leftNode, fields, registry),

--- a/web-frontend/modules/database/utils/view.js
+++ b/web-frontend/modules/database/utils/view.js
@@ -57,7 +57,8 @@ export function getGroupByRowSortFunction($registry, fields, groupBys) {
       const fieldSortFunction = fieldType.getGroupBySort(
         fieldName,
         sort.order,
-        field
+        field,
+        sort.type
       )
       sortFunction = sortFunction.thenBy(fieldSortFunction)
     }

--- a/web-frontend/modules/database/utils/view.js
+++ b/web-frontend/modules/database/utils/view.js
@@ -15,20 +15,30 @@ export const DEFAULT_VIEW_ID_COOKIE_NAME = 'defaultViewId'
 export function getRowSortFunction($registry, sortings, fields, groupBys = []) {
   const { firstBy } = thenBy
   let sortFunction = firstBy()
+  const groupByCount = groupBys.length
   const combined = [...groupBys, ...sortings]
-  combined.forEach((sort) => {
-    // Find the field that is related to the sort.
+  combined.forEach((sort, index) => {
     const field = fields.find((f) => f.id === sort.field)
 
     if (field !== undefined) {
       const fieldName = `field_${field.id}`
       const fieldType = $registry.get('field', field.type)
-      const sortTypes = fieldType.getSortTypes(field)
-      const fieldSortFunction = sortTypes[sort.type].function(
-        fieldName,
-        sort.order,
-        field
-      )
+      let fieldSortFunction
+      if (index < groupByCount) {
+        fieldSortFunction = fieldType.getGroupBySort(
+          fieldName,
+          sort.order,
+          field,
+          sort.type
+        )
+      } else {
+        const sortTypes = fieldType.getSortTypes(field)
+        fieldSortFunction = sortTypes[sort.type].function(
+          fieldName,
+          sort.order,
+          field
+        )
+      }
       sortFunction = sortFunction.thenBy(fieldSortFunction)
     }
   })

--- a/web-frontend/modules/database/utils/view.js
+++ b/web-frontend/modules/database/utils/view.js
@@ -41,6 +41,36 @@ export function getRowSortFunction($registry, sortings, fields, groupBys = []) {
 }
 
 /**
+ * Like getRowSortFunction but uses getGroupBySort instead of getSort, so
+ * group-by node ordering can differ from row ordering (e.g. set-based
+ * ordering for multi-select fields).
+ */
+export function getGroupByRowSortFunction($registry, fields, groupBys) {
+  const { firstBy } = thenBy
+  let sortFunction = firstBy()
+  groupBys.forEach((sort) => {
+    const field = fields.find((f) => f.id === sort.field)
+
+    if (field !== undefined) {
+      const fieldName = `field_${field.id}`
+      const fieldType = $registry.get('field', field.type)
+      const fieldSortFunction = fieldType.getGroupBySort(
+        fieldName,
+        sort.order,
+        field
+      )
+      sortFunction = sortFunction.thenBy(fieldSortFunction)
+    }
+  })
+
+  sortFunction = sortFunction.thenBy((a, b) =>
+    new BigNumber(a.order).minus(new BigNumber(b.order)).toNumber()
+  )
+  sortFunction = sortFunction.thenBy((a, b) => a.id - b.id)
+  return sortFunction
+}
+
+/**
  * Generates a sort function for fields based on order and id.
  */
 export function sortFieldsByOrderAndIdFunction(

--- a/web-frontend/test/unit/database/fieldTypes/linkRowFieldTypeGetGroupBySort.spec.js
+++ b/web-frontend/test/unit/database/fieldTypes/linkRowFieldTypeGetGroupBySort.spec.js
@@ -1,0 +1,46 @@
+import { TestApp } from '@baserow/test/helpers/testApp'
+import { firstBy } from 'thenby'
+
+describe('LinkRowFieldType.getGroupBySort()', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+  })
+
+  afterEach(() => {
+    testApp.afterEach()
+  })
+
+  test('delegates to getSort via getSortTypes, passing field through', () => {
+    const fieldType = testApp._app.$registry.get('field', 'link_row')
+
+    const field = {
+      id: 10,
+      type: 'link_row',
+      link_row_table_primary_field: { id: 1, type: 'text' },
+    }
+
+    const rows = [
+      {
+        id: 1,
+        order: '1.00000000000000000000',
+        field_10: [{ id: 1, value: 'Banana' }],
+      },
+      {
+        id: 2,
+        order: '2.00000000000000000000',
+        field_10: [{ id: 2, value: 'Apple' }],
+      },
+      {
+        id: 3,
+        order: '3.00000000000000000000',
+        field_10: [],
+      },
+    ]
+
+    const sortFn = fieldType.getGroupBySort('field_10', 'ASC', field, 'default')
+    rows.sort(firstBy().thenBy(sortFn))
+    expect(rows.map((r) => r.id)).toEqual([3, 2, 1])
+  })
+})

--- a/web-frontend/test/unit/database/fieldTypes/multipleSelectFieldTypeGetGroupBySort.spec.js
+++ b/web-frontend/test/unit/database/fieldTypes/multipleSelectFieldTypeGetGroupBySort.spec.js
@@ -1,9 +1,9 @@
 import { TestApp } from '@baserow/test/helpers/testApp'
 import { firstBy } from 'thenby'
 
-const A = { id: 1, value: 'A', color: 'blue' }
-const B = { id: 2, value: 'B', color: 'yellow' }
-const C = { id: 3, value: 'C', color: 'red' }
+const A = { id: 1, value: 'A', color: 'blue', order: 0 }
+const B = { id: 2, value: 'B', color: 'yellow', order: 1 }
+const C = { id: 3, value: 'C', color: 'red', order: 2 }
 
 const field = {
   id: 99,
@@ -35,9 +35,9 @@ describe('MultipleSelectFieldType.getGroupBySort()', () => {
     expect(ASC(rows[0], rows[2])).toBe(0)
 
     rows.sort(firstBy().thenBy(ASC))
+    // ASC by [order, id]: empty < {A,C} ([0,1],[2,3]) < {B} ([1,2])
     expect(rows.map((row) => row.id)).toEqual([4, 1, 3, 2])
 
-    // "B" sorts above "A,C", and the tied rows 1 and 3 keep their relative order.
     const DESC = fieldType.getGroupBySort('field', 'DESC', field)
     rows.sort(firstBy().thenBy(DESC))
     expect(rows.map((row) => row.id)).toEqual([2, 1, 3, 4])
@@ -55,6 +55,7 @@ describe('MultipleSelectFieldType.getGroupBySort()', () => {
     expect(ASC(rows[0], rows[1])).toBe(0)
 
     rows.sort(firstBy().thenBy(ASC))
+    // {A,C} ([0,1],[2,3]) < {B} ([1,2])
     expect(rows.map((row) => row.id)).toEqual([1, 2, 3])
   })
 
@@ -69,6 +70,25 @@ describe('MultipleSelectFieldType.getGroupBySort()', () => {
 
     const ASC = fieldType.getGroupBySort('field', 'ASC', field)
     rows.sort(firstBy().thenBy(ASC))
+    // empty/null/undefined all produce [] which sorts before [A]
     expect(rows.map((row) => row.id)).toEqual([2, 3, 4, 1])
+  })
+
+  test('sorts groups by field-defined option order, not alphabetically', () => {
+    const fieldType = testApp._app.$registry.get('field', 'multiple_select')
+    // Options with non-alphabetical order: Z first, A second
+    const Z = { id: 10, value: 'Zebra', color: 'blue', order: 0 }
+    const aOpt = { id: 11, value: 'Apple', color: 'red', order: 1 }
+    const customField = { id: 100, select_options: [Z, aOpt] }
+
+    const rows = [
+      { id: 1, order: '1.00000000000000000000', field: [aOpt] },
+      { id: 2, order: '2.00000000000000000000', field: [Z] },
+    ]
+
+    const ASC = fieldType.getGroupBySort('field', 'ASC', customField)
+    rows.sort(firstBy().thenBy(ASC))
+    // Zebra has order=0, Apple has order=1, so Zebra group comes first
+    expect(rows.map((row) => row.id)).toEqual([2, 1])
   })
 })

--- a/web-frontend/test/unit/database/fieldTypes/multipleSelectFieldTypeGetSort.spec.js
+++ b/web-frontend/test/unit/database/fieldTypes/multipleSelectFieldTypeGetSort.spec.js
@@ -1,0 +1,40 @@
+import { TestApp } from '@baserow/test/helpers/testApp'
+import { firstBy } from 'thenby'
+
+const A = { id: 1, value: 'A', color: 'blue' }
+const B = { id: 2, value: 'B', color: 'yellow' }
+const C = { id: 3, value: 'C', color: 'red' }
+
+describe('MultipleSelectFieldType.getGroupBySort()', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+  })
+
+  afterEach(() => {
+    testApp.afterEach()
+  })
+
+  test('cells with the same options sort together regardless of pick order', () => {
+    const fieldType = testApp._app.$registry.get('field', 'multiple_select')
+    const rows = [
+      { id: 1, order: '1.00000000000000000000', field: [A, C] },
+      { id: 2, order: '2.00000000000000000000', field: [B] },
+      // Same set as row 1, picked the other way round.
+      { id: 3, order: '3.00000000000000000000', field: [C, A] },
+      { id: 4, order: '4.00000000000000000000', field: [] },
+    ]
+
+    const ASC = fieldType.getGroupBySort('field', 'ASC')
+    expect(ASC(rows[0], rows[2])).toBe(0)
+
+    rows.sort(firstBy().thenBy(ASC))
+    expect(rows.map((row) => row.id)).toEqual([4, 1, 3, 2])
+
+    // "B" sorts above "A,C", and the tied rows 1 and 3 keep their relative order.
+    const DESC = fieldType.getGroupBySort('field', 'DESC')
+    rows.sort(firstBy().thenBy(DESC))
+    expect(rows.map((row) => row.id)).toEqual([2, 1, 3, 4])
+  })
+})

--- a/web-frontend/test/unit/database/fieldTypes/multipleSelectFieldTypeGetSort.spec.js
+++ b/web-frontend/test/unit/database/fieldTypes/multipleSelectFieldTypeGetSort.spec.js
@@ -5,6 +5,11 @@ const A = { id: 1, value: 'A', color: 'blue' }
 const B = { id: 2, value: 'B', color: 'yellow' }
 const C = { id: 3, value: 'C', color: 'red' }
 
+const field = {
+  id: 99,
+  select_options: [A, B, C],
+}
+
 describe('MultipleSelectFieldType.getGroupBySort()', () => {
   let testApp = null
 
@@ -26,15 +31,44 @@ describe('MultipleSelectFieldType.getGroupBySort()', () => {
       { id: 4, order: '4.00000000000000000000', field: [] },
     ]
 
-    const ASC = fieldType.getGroupBySort('field', 'ASC')
+    const ASC = fieldType.getGroupBySort('field', 'ASC', field)
     expect(ASC(rows[0], rows[2])).toBe(0)
 
     rows.sort(firstBy().thenBy(ASC))
     expect(rows.map((row) => row.id)).toEqual([4, 1, 3, 2])
 
     // "B" sorts above "A,C", and the tied rows 1 and 3 keep their relative order.
-    const DESC = fieldType.getGroupBySort('field', 'DESC')
+    const DESC = fieldType.getGroupBySort('field', 'DESC', field)
     rows.sort(firstBy().thenBy(DESC))
     expect(rows.map((row) => row.id)).toEqual([2, 1, 3, 4])
+  })
+
+  test('handles unhydrated { id } objects by resolving from field options', () => {
+    const fieldType = testApp._app.$registry.get('field', 'multiple_select')
+    const rows = [
+      { id: 1, order: '1.00000000000000000000', field: [{ id: 3 }, { id: 1 }] },
+      { id: 2, order: '2.00000000000000000000', field: [{ id: 1 }, { id: 3 }] },
+      { id: 3, order: '3.00000000000000000000', field: [{ id: 2 }] },
+    ]
+
+    const ASC = fieldType.getGroupBySort('field', 'ASC', field)
+    expect(ASC(rows[0], rows[1])).toBe(0)
+
+    rows.sort(firstBy().thenBy(ASC))
+    expect(rows.map((row) => row.id)).toEqual([1, 2, 3])
+  })
+
+  test('handles null and undefined values without crashing', () => {
+    const fieldType = testApp._app.$registry.get('field', 'multiple_select')
+    const rows = [
+      { id: 1, order: '1.00000000000000000000', field: [A] },
+      { id: 2, order: '2.00000000000000000000', field: null },
+      { id: 3, order: '3.00000000000000000000', field: undefined },
+      { id: 4, order: '4.00000000000000000000', field: [] },
+    ]
+
+    const ASC = fieldType.getGroupBySort('field', 'ASC', field)
+    rows.sort(firstBy().thenBy(ASC))
+    expect(rows.map((row) => row.id)).toEqual([2, 3, 4, 1])
   })
 })

--- a/web-frontend/test/unit/database/utils/gridGroupBy.spec.js
+++ b/web-frontend/test/unit/database/utils/gridGroupBy.spec.js
@@ -37,22 +37,29 @@ const textField = (id) => ({ id, name: `field ${id}`, type: 'text' })
  */
 const makeRegistry = (overrides = {}) => ({
   get(_namespace, _type) {
-    return {
+    const defaultSortTypes = () => ({
+      default: {
+        function: (fieldName, order) => (a, b) => {
+          const va = a[fieldName]
+          const vb = b[fieldName]
+          const cmp = va < vb ? -1 : va > vb ? 1 : 0
+          return order === 'DESC' ? -cmp : cmp
+        },
+      },
+    })
+    const instance = {
       canWriteFieldValues: () => true,
       getRowValueFromGroupValue: (_field, groupValue) => groupValue,
       getGroupValueFromRowValue: (_field, rowValue) => rowValue,
-      getSortTypes: () => ({
-        default: {
-          function: (fieldName, order) => (a, b) => {
-            const va = a[fieldName]
-            const vb = b[fieldName]
-            const cmp = va < vb ? -1 : va > vb ? 1 : 0
-            return order === 'DESC' ? -cmp : cmp
-          },
-        },
-      }),
+      getSortTypes: defaultSortTypes,
+      getGroupBySort(name, order, _field, sortType) {
+        const types = this.getSortTypes()
+        const resolved = types[sortType] || types.default
+        return resolved.function(name, order)
+      },
       ...overrides,
     }
+    return instance
   },
 })
 

--- a/web-frontend/test/unit/database/utils/row.spec.js
+++ b/web-frontend/test/unit/database/utils/row.spec.js
@@ -553,21 +553,22 @@ describe('Row utilities', () => {
 
   describe('computeRowInsertPosition', () => {
     const makeSortRegistry = () => ({
-      get: (_, type) =>
-        type === 'text'
-          ? {
-              getSortTypes: () => ({
-                default: {
-                  function: (fieldName, order) => (a, b) => {
-                    const va = a[fieldName]
-                    const vb = b[fieldName]
-                    const cmp = va < vb ? -1 : va > vb ? 1 : 0
-                    return order === 'DESC' ? -cmp : cmp
-                  },
-                },
-              }),
-            }
-          : {},
+      get: (_, type) => {
+        if (type !== 'text') return {}
+        const sortFn = (fieldName, order) => (a, b) => {
+          const va = a[fieldName]
+          const vb = b[fieldName]
+          const cmp = va < vb ? -1 : va > vb ? 1 : 0
+          return order === 'DESC' ? -cmp : cmp
+        }
+        return {
+          getSortTypes: () => ({
+            default: { function: sortFn },
+          }),
+          getGroupBySort: (name, order, _field, _sortType) =>
+            sortFn(name, order),
+        }
+      },
     })
     const textField = { id: 1, type: 'text' }
     const ascSort = [{ field: 1, order: 'ASC', type: 'default' }]


### PR DESCRIPTION
## Summary

Fixes ghost rows appearing in grid views when grouping by multiple select or multiple collaborators fields. The root cause: group-by treats a cell as a **set** (`{A, B}` = `{B, A}`), but sorting used **insertion order** — so rows with identical option sets could land in different sort positions, causing group offsets to misalign.

Instead of changing the sort to match group-by (which would alter sorting behavior across the product), this PR **decouples** group-by ordering from regular sorting:

- **Backend:** New `get_group_by_sort_order()` hook on `FieldType` (defaults to `get_order()`). `ManyToManyGroupByMixin.get_group_by_order()` calls this hook instead of `get_order()`. `MultipleSelectFieldType` and `MultipleCollaboratorsFieldType` override it with set-based `StringAgg` ordering. `ViewHandler.get_view_order_bys()` routes `ViewGroupBy` items through `get_group_by_sort_order()` while `ViewSort` items keep using `get_order()`.

- **Frontend:** New `getGroupBySort()` method on `FieldType` (defaults to `getSort()`). New `getGroupByRowSortFunction()` utility wired into `makeGroupByNodeSiblingComparator`. Both multi-value field types override `getGroupBySort()` with set-based sorting.

Regular sort behavior is **completely unchanged** — insertion order is preserved. Only group-by ordering uses set-based aggregation.

### Key design decisions

- Separate annotation names (`_agg_sort` vs `_group_by_agg_sort`) prevent collisions when the same field is both grouped and sorted.
- `isinstance(ViewGroupBy)` check in `get_view_order_bys()` dispatches to the correct ordering method per item type.

## How to test

### Setup
1. Create a table with **Name** (text) and **Tags** (multiple select, options: A, B, C)
2. Create rows:
   - Row 1: Name="first", Tags=[A, C] (pick A first, then C)
   - Row 2: Name="second", Tags=[C, A] (pick C first, then A)
   - Row 3: Name="third", Tags=[B]
   - Row 4: Name="fourth", Tags=[] (empty)

### Test 1: Regular sort unchanged
- Sort by Tags ASC
- Row 1 and Row 2 should appear in different positions (insertion order)

### Test 2: Group-by uses set-based grouping
- Group by Tags (no sort)
- Row 1 and Row 2 must be in the SAME group — no ghost rows

### Test 3: Sort + group-by on different fields
- Group by Tags + sort by Name ASC
- Groups correct, rows within groups sorted by Name, no ghost rows

### Test 4: Same field grouped AND sorted
- Group by Tags + sort by Tags DESC
- Groups correct, no ghost rows, sort within group uses insertion order

### Test 5: Multiple collaborators
- Same setup with collaborators field — reversed pick order must group together


Closes #5782

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
