### PR TITLE
feat(database): allow specific users and teams to edit fields

### DIFF
--- a/backend/src/baserow/contrib/database/api/tables/serializers.py
+++ b/backend/src/baserow/contrib/database/api/tables/serializers.py
@@ -13,6 +13,17 @@ class TableImportConfiguration(serializers.Serializer):
     Additional table import configuration.
     """
 
+    import_fields = serializers.ListField(
+        child=serializers.IntegerField(min_value=1),
+        min_length=1,
+        allow_null=True,
+        default=None,
+        help_text=(
+            "The ordered field IDs corresponding to the values in each imported "
+            "row. This snapshots the import schema so field reordering or permission "
+            "changes cannot reinterpret positional values while the job is queued."
+        ),
+    )
     upsert_fields = serializers.ListField(
         child=serializers.IntegerField(min_value=1),
         min_length=1,
@@ -158,7 +169,7 @@ class TableImportSerializer(serializers.Serializer):
             "A list of rows you want to add to the specified table. "
             "Each row is a list of values, one for each **writable** field. "
             "The field values must be ordered according to the field order in the "
-            "table. "
+            "table, or according to `configuration.import_fields` when provided. "
             "All values must be compatible with the corresponding field type.\n\n"
             'Ex: \n```json\n[\n  ["row1_field1_value", "row1_field2_value"],\n'
             '  ["row2_field1_value", "row2_field2_value"],\n]\n```\n'

--- a/backend/src/baserow/contrib/database/file_import/job_types.py
+++ b/backend/src/baserow/contrib/database/file_import/job_types.py
@@ -30,6 +30,7 @@ from baserow.contrib.database.fields.exceptions import (
 )
 from baserow.contrib.database.rows.actions import ImportRowsActionType
 from baserow.contrib.database.rows.exceptions import ReportMaxErrorCountExceeded
+from baserow.contrib.database.rows.handler import RowHandler
 from baserow.contrib.database.rows.types import FileImportDict
 from baserow.contrib.database.table.actions import CreateTableActionType
 from baserow.contrib.database.table.exceptions import (
@@ -157,9 +158,19 @@ class FileImportJobType(JobType):
         Save the data file for the newly created job.
         """
 
+        configuration = dict(values.get("configuration") or {})
+        if job.table is not None and configuration.get("import_fields") is None:
+            configuration["import_fields"] = [
+                field.id
+                for field in RowHandler().get_import_fields(job.user, job.table)
+            ]
+
         data_file = ContentFile(
             json.dumps(
-                {"data": values["data"], "configuration": values.get("configuration")},
+                {
+                    "data": values["data"],
+                    "configuration": configuration or None,
+                },
                 ensure_ascii=False,
             ).encode("utf8")
         )

--- a/backend/src/baserow/contrib/database/rows/handler.py
+++ b/backend/src/baserow/contrib/database/rows/handler.py
@@ -2064,10 +2064,9 @@ class RowHandler:
             import.
         :param send_realtime_update: The parameter passed to the rows_created
             signal indicating if a realtime update should be send.
-
-        :raises InvalidRowLength:
-
         :return: The created row instances and the error report.
+        :raises FieldNotInTable: If a configured skipped field is missing, or an
+            upsert field is absent from the import schema or cannot be written.
         """
 
         workspace = table.database.workspace
@@ -2083,13 +2082,12 @@ class RowHandler:
         model = table.get_model()
 
         error_report = RowErrorReport(data)
+        upsert_field_ids = configuration.get("upsert_fields") or []
         update_handler = UpsertRowsMappingHandler(
             table=table,
-            upsert_fields=configuration.get("upsert_fields") or [],
+            upsert_fields=upsert_field_ids,
             upsert_values=configuration.get("upsert_values") or [],
         )
-        # Pre-run upsert configuration validation.
-        # Can raise InvalidRowLength
         update_handler.validate()
 
         skipped_field_ids = configuration.get("skipped_fields", []) or []
@@ -2101,15 +2099,24 @@ class RowHandler:
         except ValueError:
             raise FieldNotInTable("The field ID is not found in the table.")
 
-        fields = [
-            field_object["field"]
-            for field_object in model._field_objects.values()
-            if not field_object["type"].read_only
-            and not field_object["field"].read_only
-        ]
-
-        # Sort by primary first (descending), then by order, then by id
-        fields.sort(key=lambda f: (not f.primary, f.order, f.id))
+        fields = self.get_import_fields(
+            user,
+            table,
+            model=model,
+            import_field_ids=configuration.get("import_fields"),
+        )
+        initially_unwritable_field_ids = {
+            field.id for field in self._get_unwritable_fields(user, model, fields)
+        }
+        import_field_ids = {field.id for field in fields}
+        if any(
+            field_id not in import_field_ids
+            or field_id in initially_unwritable_field_ids
+            for field_id in upsert_field_ids
+        ):
+            raise FieldNotInTable(
+                "An upsert field is missing from the import schema or not writable."
+            )
 
         for index, row in enumerate(data):
             # Check row length
@@ -2129,6 +2136,7 @@ class RowHandler:
                     {
                         f"field_{fields[index].id}": value
                         for index, value in enumerate(new_row)
+                        if fields[index].id not in initially_unwritable_field_ids
                     },
                 )
 
@@ -2258,6 +2266,58 @@ class RowHandler:
 
         return created_rows, error_report.to_dict()
 
+    def get_import_fields(
+        self,
+        user: AbstractUser,
+        table: Table,
+        model: Optional[GeneratedTableModel] = None,
+        import_field_ids: Optional[List[int]] = None,
+    ) -> List["Field"]:
+        """
+        Returns the ordered fields represented by positional file-import values.
+
+        When ``import_field_ids`` is provided, its order is authoritative and is
+        preserved even if write permissions changed after the import was queued. The
+        write-permission check immediately before persistence still removes values the
+        user can no longer write. Without an explicit snapshot, fields the user cannot
+        currently write are omitted just like structurally read-only fields.
+
+        :param user: The user whose field write permissions should be applied when no
+            explicit import schema is provided.
+        :param table: The table receiving the imported rows.
+        :param model: An optional generated table model to reuse.
+        :param import_field_ids: An optional ordered snapshot of the field IDs
+            represented by each positional row value.
+        :return: The ordered fields represented by the positional import schema.
+        :raises FieldNotInTable: If an explicit field ID is duplicated, missing from
+            the table, or belongs to a structurally read-only field.
+        """
+
+        if model is None:
+            model = table.get_model()
+
+        fields = [
+            field_object["field"]
+            for field_object in model._field_objects.values()
+            if not field_object["type"].read_only
+            and not field_object["field"].read_only
+        ]
+        fields.sort(key=lambda field: (not field.primary, field.order, field.id))
+
+        if import_field_ids is not None:
+            fields_by_id = {field.id: field for field in fields}
+            if len(import_field_ids) != len(set(import_field_ids)) or any(
+                field_id not in fields_by_id for field_id in import_field_ids
+            ):
+                raise FieldNotInTable(
+                    "An import field is duplicated, missing, or not writable."
+                )
+            return [fields_by_id[field_id] for field_id in import_field_ids]
+
+        unwritable_fields = self._get_unwritable_fields(user, model, fields)
+        unwritable_field_ids = {field.id for field in unwritable_fields}
+        return [field for field in fields if field.id not in unwritable_field_ids]
+
     def get_fields_metadata_for_row_history(
         self,
         row: GeneratedTableModelForUpdate,
@@ -2337,22 +2397,39 @@ class RowHandler:
             for fo in model.get_field_objects(include_trash=True)
             if fo["field"].id in field_ids
         ]
-        table = model.baserow_table
-        perm_checks = [
-            PermissionCheck(user, WriteFieldValuesOperationType.type, field)
-            for field in fields
-        ]
-        results = CoreHandler().check_multiple_permissions(
-            perm_checks, table.database.workspace
-        )
-        unwritable_fields = [
-            c.context for (c, has_permissions) in results.items() if not has_permissions
-        ]
+        unwritable_fields = self._get_unwritable_fields(user, model, fields)
         if unwritable_fields and raise_if_not_permitted:
             raise PermissionDenied(
                 f"You don't have permission to update the following fields: {', '.join([f.name for f in unwritable_fields])}"
             )
         return unwritable_fields
+
+    def _get_unwritable_fields(
+        self,
+        user: AbstractUser,
+        model: GeneratedTableModel,
+        fields: List["Field"],
+    ) -> List["Field"]:
+        """Return the fields whose values the user cannot write.
+
+        :param user: The user whose field write permissions should be checked.
+        :param model: The generated table model containing the fields.
+        :param fields: The fields to check.
+        :return: The fields whose values the user cannot write.
+        """
+
+        permission_checks = [
+            PermissionCheck(user, WriteFieldValuesOperationType.type, field)
+            for field in fields
+        ]
+        results = CoreHandler().check_multiple_permissions(
+            permission_checks, model.baserow_table.database.workspace
+        )
+        return [
+            check.context
+            for check, has_permission in results.items()
+            if not has_permission
+        ]
 
     def _raise_if_values_contain_hidden_fields(
         self,

--- a/backend/src/baserow/contrib/database/rows/types.py
+++ b/backend/src/baserow/contrib/database/rows/types.py
@@ -18,6 +18,7 @@ RowsForUpdate = NewType("RowsForUpdate", QuerySet)
 
 
 class FileImportConfiguration(TypedDict):
+    import_fields: list[int]
     upsert_fields: list[int]
     upsert_values: list[list[Any]]
     skipped_fields: list[int]

--- a/backend/tests/baserow/contrib/database/api/tables/test_table_views.py
+++ b/backend/tests/baserow/contrib/database/api/tables/test_table_views.py
@@ -940,8 +940,8 @@ def test_import_table_call(api_client, data_fixture):
     user, token = data_fixture.create_user_and_token()
     database = data_fixture.create_database_application(user=user)
     table = data_fixture.create_database_table(database=database)
-    data_fixture.create_text_field(table=table, user=user)
-    data_fixture.create_number_field(table=table, user=user)
+    text_field = data_fixture.create_text_field(table=table, user=user)
+    number_field = data_fixture.create_number_field(table=table, user=user)
 
     url = reverse("api:database:tables:import_async", kwargs={"table_id": table.id})
 
@@ -960,7 +960,12 @@ def test_import_table_call(api_client, data_fixture):
     assert rdata.get("type") == "file_import"
     Job.objects.all().delete()
 
-    valid_data_with_configuration = {"data": [["1", 1], ["2", 1]], "configuration": {}}
+    valid_data_with_configuration = {
+        "data": [["1", 1], ["2", 1]],
+        "configuration": {
+            "import_fields": [text_field.id, number_field.id],
+        },
+    }
     response = api_client.post(
         url,
         HTTP_AUTHORIZATION=f"JWT {token}",

--- a/backend/tests/baserow/contrib/database/file_import/test_file_import_job_type.py
+++ b/backend/tests/baserow/contrib/database/file_import/test_file_import_job_type.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from baserow.contrib.database.file_import.job_types import FileImportJobType
@@ -9,6 +11,37 @@ from baserow.core.jobs.exceptions import MaxJobCountExceeded
 @pytest.fixture
 def job_type():
     return FileImportJobType()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("explicit_import_fields", [False, True])
+def test_after_job_creation_snapshots_import_fields(
+    data_fixture, job_type, patch_filefield_storage, explicit_import_fields
+):
+    user = data_fixture.create_user()
+    database = data_fixture.create_database_application(user=user)
+    table = data_fixture.create_database_table(database=database)
+    name_field = data_fixture.create_text_field(table=table, name="Name", primary=True)
+    active_field = data_fixture.create_boolean_field(table=table, name="Active")
+    expected_import_fields = [name_field.id, active_field.id]
+    configuration = None
+    if explicit_import_fields:
+        expected_import_fields.reverse()
+        configuration = {"import_fields": expected_import_fields}
+
+    with patch_filefield_storage():
+        job = FileImportJob.objects.create(user=user, database=database, table=table)
+        job_type.after_job_creation(
+            job,
+            {
+                "data": [["Ada", True]],
+                "configuration": configuration,
+            },
+        )
+        with job.data_file.open("r") as data_file:
+            import_data = json.load(data_file)
+
+    assert import_data["configuration"]["import_fields"] == expected_import_fields
 
 
 @pytest.mark.django_db

--- a/changelog/entries/unreleased/feature/5005_adds_field_permissions_for_specific_users_and_teams.json
+++ b/changelog/entries/unreleased/feature/5005_adds_field_permissions_for_specific_users_and_teams.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Adds field permissions for specific users and teams",
+    "issue_origin": "github",
+    "issue_number": 5005,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-21"
+}

--- a/enterprise/backend/src/baserow_enterprise/api/field_permissions/serializers.py
+++ b/enterprise/backend/src/baserow_enterprise/api/field_permissions/serializers.py
@@ -1,6 +1,59 @@
+from django.utils.functional import lazy
+
 from rest_framework import serializers
 
+from baserow.core.registries import subject_type_registry
+from baserow.core.subjects import UserSubjectType
+from baserow_enterprise.api.role.serializers import SubjectField, SubjectTypeField
 from baserow_enterprise.field_permissions.models import FieldPermissionsRoleEnum
+from baserow_enterprise.teams.subjects import TeamSubjectType
+
+
+class FieldPermissionSubjectRequestSerializer(serializers.Serializer):
+    subject_id = serializers.IntegerField(min_value=1)
+    subject_type = serializers.ChoiceField(
+        choices=[UserSubjectType.type, TeamSubjectType.type]
+    )
+
+
+class FieldPermissionSubjectResponseSerializer(serializers.Serializer):
+    subject_id = serializers.IntegerField(read_only=True)
+    subject_type = SubjectTypeField(
+        read_only=True,
+        choices=lazy(subject_type_registry.get_types, list)(),
+    )
+    subject = SubjectField(read_only=True)
+
+
+class CommaSeparatedIntegerListField(serializers.ListField):
+    child = serializers.IntegerField(min_value=1)
+
+    def to_internal_value(self, data):
+        if isinstance(data, str):
+            data = data.split(",") if data else []
+        return super().to_internal_value(data)
+
+
+class FieldPermissionSubjectOptionsRequestSerializer(serializers.Serializer):
+    page = serializers.IntegerField(min_value=1, required=False, default=1)
+    size = serializers.IntegerField(
+        min_value=1, max_value=100, required=False, default=20
+    )
+    search = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True, default=None
+    )
+    exclude_user_ids = CommaSeparatedIntegerListField(required=False, default=list)
+    exclude_team_ids = CommaSeparatedIntegerListField(required=False, default=list)
+
+
+class FieldPermissionSubjectOptionResponseSerializer(serializers.Serializer):
+    subject_id = serializers.IntegerField(read_only=True)
+    subject_type = serializers.ChoiceField(
+        read_only=True, choices=[UserSubjectType.type, TeamSubjectType.type]
+    )
+    name = serializers.CharField(read_only=True)
+    email = serializers.EmailField(read_only=True, allow_null=True)
+    subject_count = serializers.IntegerField(read_only=True, allow_null=True)
 
 
 class UpdateFieldPermissionsRequestSerializer(serializers.Serializer):
@@ -9,6 +62,7 @@ class UpdateFieldPermissionsRequestSerializer(serializers.Serializer):
             (FieldPermissionsRoleEnum.ADMIN.value, "Admin"),
             (FieldPermissionsRoleEnum.BUILDER.value, "Builder"),
             (FieldPermissionsRoleEnum.EDITOR.value, "Editor"),  # default
+            (FieldPermissionsRoleEnum.CUSTOM.value, "Custom"),
             (FieldPermissionsRoleEnum.NOBODY.value, "Nobody"),
         ],
         help_text="The role required to update the data for this field.",
@@ -21,6 +75,23 @@ class UpdateFieldPermissionsRequestSerializer(serializers.Serializer):
             "This setting is only relevant if the role is not 'EDITOR'. "
         ),
     )
+    subjects = FieldPermissionSubjectRequestSerializer(many=True, required=False)
+
+    def validate(self, attrs):
+        subjects = attrs.get("subjects", [])
+        if attrs["role"] != FieldPermissionsRoleEnum.CUSTOM.value and subjects:
+            raise serializers.ValidationError(
+                {"subjects": "Subjects can only be set when the role is CUSTOM."}
+            )
+
+        identifiers = [
+            (subject["subject_type"], subject["subject_id"]) for subject in subjects
+        ]
+        if len(identifiers) != len(set(identifiers)):
+            raise serializers.ValidationError(
+                {"subjects": "The same subject cannot be included more than once."}
+            )
+        return attrs
 
 
 class UpdateFieldPermissionsResponseSerializer(UpdateFieldPermissionsRequestSerializer):
@@ -31,3 +102,4 @@ class UpdateFieldPermissionsResponseSerializer(UpdateFieldPermissionsRequestSeri
         required=False,
         help_text="Whether the user can write values to this field.",
     )
+    subjects = FieldPermissionSubjectResponseSerializer(many=True, read_only=True)

--- a/enterprise/backend/src/baserow_enterprise/api/field_permissions/serializers.py
+++ b/enterprise/backend/src/baserow_enterprise/api/field_permissions/serializers.py
@@ -29,6 +29,12 @@ class CommaSeparatedIntegerListField(serializers.ListField):
     child = serializers.IntegerField(min_value=1)
 
     def to_internal_value(self, data):
+        """Convert a comma-separated query parameter into a validated integer list.
+
+        :param data: The comma-separated string or list value to validate.
+        :return: The validated list of integer IDs.
+        """
+
         if isinstance(data, str):
             data = data.split(",") if data else []
         return super().to_internal_value(data)
@@ -78,6 +84,14 @@ class UpdateFieldPermissionsRequestSerializer(serializers.Serializer):
     subjects = FieldPermissionSubjectRequestSerializer(many=True, required=False)
 
     def validate(self, attrs):
+        """Validate that CUSTOM permissions contain unique subjects.
+
+        :param attrs: The deserialized field-permission request data.
+        :return: The validated request data.
+        :raises serializers.ValidationError: If non-CUSTOM permissions contain
+            subjects or the same subject is included more than once.
+        """
+
         subjects = attrs.get("subjects", [])
         if attrs["role"] != FieldPermissionsRoleEnum.CUSTOM.value and subjects:
             raise serializers.ValidationError(

--- a/enterprise/backend/src/baserow_enterprise/api/field_permissions/urls.py
+++ b/enterprise/backend/src/baserow_enterprise/api/field_permissions/urls.py
@@ -1,9 +1,14 @@
 from django.urls import re_path
 
-from .views import FieldPermissionsView
+from .views import FieldPermissionSubjectOptionsView, FieldPermissionsView
 
 app_name = "baserow_enterprise.api.field_permissions"
 
 urlpatterns = [
-    re_path(r"^(?P<field_id>[0-9]+)/$", FieldPermissionsView.as_view(), name="item")
+    re_path(r"^(?P<field_id>[0-9]+)/$", FieldPermissionsView.as_view(), name="item"),
+    re_path(
+        r"^(?P<field_id>[0-9]+)/subjects/$",
+        FieldPermissionSubjectOptionsView.as_view(),
+        name="subject_options",
+    ),
 ]

--- a/enterprise/backend/src/baserow_enterprise/api/field_permissions/views.py
+++ b/enterprise/backend/src/baserow_enterprise/api/field_permissions/views.py
@@ -1,5 +1,4 @@
 from django.db import transaction
-from django.db.models import Case, CharField, Count, F, IntegerField, Q, Value, When
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
@@ -22,8 +21,6 @@ from baserow.contrib.database.fields.operations import ReadFieldOperationType
 from baserow.core.action.registries import action_type_registry
 from baserow.core.exceptions import UserNotInWorkspace
 from baserow.core.handler import CoreHandler
-from baserow.core.models import WorkspaceUser
-from baserow.core.subjects import UserSubjectType
 from baserow_enterprise.api.errors import (
     ERROR_SUBJECT_DOES_NOT_EXIST,
     ERROR_SUBJECT_TYPE_UNSUPPORTED,
@@ -37,8 +34,6 @@ from baserow_enterprise.field_permissions.handler import FieldPermissionsHandler
 from baserow_enterprise.field_permissions.operations import (
     ReadFieldPermissionsOperationType,
 )
-from baserow_enterprise.teams.models import Team
-from baserow_enterprise.teams.subjects import TeamSubjectType
 from baserow_premium.license.handler import LicenseHandler
 
 from .serializers import (
@@ -219,6 +214,14 @@ class FieldPermissionSubjectOptionsView(APIView):
     )
     @validate_query_parameters(FieldPermissionSubjectOptionsRequestSerializer)
     def get(self, request, field_id, query_params) -> Response:
+        """Return paginated users and teams selectable for a field permission.
+
+        :param request: The authenticated API request.
+        :param field_id: The field whose permission subjects are being selected.
+        :param query_params: The validated pagination, search, and exclusion filters.
+        :return: A paginated response containing selectable users and teams.
+        """
+
         field = FieldHandler().get_field(field_id)
         workspace = field.table.database.workspace
         CoreHandler().check_permissions(
@@ -231,42 +234,11 @@ class FieldPermissionSubjectOptionsView(APIView):
             FIELD_LEVEL_PERMISSIONS, request.user, workspace
         )
 
-        search = (query_params.get("search") or "").strip()
-        users = WorkspaceUser.objects.filter(
-            workspace=workspace,
-            user__is_active=True,
-            user__profile__to_be_deleted=False,
-        ).exclude(user_id__in=query_params["exclude_user_ids"])
-        teams = Team.objects.filter(workspace=workspace).exclude(
-            id__in=query_params["exclude_team_ids"]
-        )
-        if search:
-            users = users.filter(
-                Q(user__first_name__icontains=search)
-                | Q(user__username__icontains=search)
-                | Q(user__email__icontains=search)
-            )
-            teams = teams.filter(name__icontains=search)
-
-        user_options = users.annotate(
-            subject_id=F("user_id"),
-            subject_type=Value(UserSubjectType.type, output_field=CharField()),
-            name=Case(
-                When(user__first_name="", then=F("user__email")),
-                default=F("user__first_name"),
-                output_field=CharField(),
-            ),
-            email=F("user__email"),
-            subject_count=Value(None, output_field=IntegerField()),
-        ).values("subject_id", "subject_type", "name", "email", "subject_count")
-        team_options = teams.annotate(
-            subject_id=F("id"),
-            subject_type=Value(TeamSubjectType.type, output_field=CharField()),
-            email=Value(None, output_field=CharField()),
-            subject_count=Count("subjects"),
-        ).values("subject_id", "subject_type", "name", "email", "subject_count")
-        options = user_options.union(team_options, all=True).order_by(
-            "name", "subject_type", "subject_id"
+        options = FieldPermissionsHandler.get_subject_options(
+            workspace,
+            search=query_params.get("search") or "",
+            exclude_user_ids=query_params["exclude_user_ids"],
+            exclude_team_ids=query_params["exclude_team_ids"],
         )
 
         paginator = PageNumberPagination(limit_page_size=100)

--- a/enterprise/backend/src/baserow_enterprise/api/field_permissions/views.py
+++ b/enterprise/backend/src/baserow_enterprise/api/field_permissions/views.py
@@ -1,29 +1,49 @@
-from urllib.request import Request
-
 from django.db import transaction
+from django.db.models import Case, CharField, Count, F, IntegerField, Q, Value, When
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from baserow.api.decorators import map_exceptions, validate_body
+from baserow.api.decorators import (
+    map_exceptions,
+    validate_body,
+    validate_query_parameters,
+)
 from baserow.api.errors import ERROR_USER_NOT_IN_GROUP
+from baserow.api.pagination import PageNumberPagination
 from baserow.api.schemas import get_error_schema
+from baserow.api.serializers import get_example_pagination_serializer_class
 from baserow.contrib.database.api.fields.errors import ERROR_FIELD_DOES_NOT_EXIST
 from baserow.contrib.database.fields.handler import FieldDoesNotExist, FieldHandler
 from baserow.contrib.database.fields.operations import ReadFieldOperationType
 from baserow.core.action.registries import action_type_registry
 from baserow.core.exceptions import UserNotInWorkspace
 from baserow.core.handler import CoreHandler
+from baserow.core.models import WorkspaceUser
+from baserow.core.subjects import UserSubjectType
+from baserow_enterprise.api.errors import (
+    ERROR_SUBJECT_DOES_NOT_EXIST,
+    ERROR_SUBJECT_TYPE_UNSUPPORTED,
+)
+from baserow_enterprise.exceptions import SubjectNotExist, SubjectUnsupported
 from baserow_enterprise.features import FIELD_LEVEL_PERMISSIONS
 from baserow_enterprise.field_permissions.actions import (
     UpdateFieldPermissionsActionType,
 )
 from baserow_enterprise.field_permissions.handler import FieldPermissionsHandler
+from baserow_enterprise.field_permissions.operations import (
+    ReadFieldPermissionsOperationType,
+)
+from baserow_enterprise.teams.models import Team
+from baserow_enterprise.teams.subjects import TeamSubjectType
 from baserow_premium.license.handler import LicenseHandler
 
 from .serializers import (
+    FieldPermissionSubjectOptionResponseSerializer,
+    FieldPermissionSubjectOptionsRequestSerializer,
     UpdateFieldPermissionsRequestSerializer,
     UpdateFieldPermissionsResponseSerializer,
 )
@@ -54,15 +74,20 @@ class FieldPermissionsView(APIView):
                 [
                     "ERROR_USER_NOT_IN_GROUP",
                     "ERROR_REQUEST_BODY_VALIDATION",
+                    "ERROR_SUBJECT_TYPE_UNSUPPORTED",
                 ]
             ),
-            404: get_error_schema(["ERROR_FIELD_DOES_NOT_EXIST"]),
+            404: get_error_schema(
+                ["ERROR_FIELD_DOES_NOT_EXIST", "ERROR_SUBJECT_DOES_NOT_EXIST"]
+            ),
         },
     )
     @map_exceptions(
         {
             FieldDoesNotExist: ERROR_FIELD_DOES_NOT_EXIST,
             UserNotInWorkspace: ERROR_USER_NOT_IN_GROUP,
+            SubjectNotExist: ERROR_SUBJECT_DOES_NOT_EXIST,
+            SubjectUnsupported: ERROR_SUBJECT_TYPE_UNSUPPORTED,
         }
     )
     @validate_body(UpdateFieldPermissionsRequestSerializer, return_validated=True)
@@ -82,13 +107,17 @@ class FieldPermissionsView(APIView):
 
         role = data["role"]
         allow_in_forms = data.get("allow_in_forms", False)
-        updated_permissions = action_type.do(request.user, field, role, allow_in_forms)
+        subjects = data.get("subjects")
+        updated_permissions = action_type.do(
+            request.user, field, role, allow_in_forms, subjects
+        )
         serializer = UpdateFieldPermissionsResponseSerializer(
             {
                 "field_id": field.id,
                 "role": updated_permissions.role,
                 "allow_in_forms": updated_permissions.allow_in_forms,
                 "can_write_values": updated_permissions.can_write_values,
+                "subjects": updated_permissions.subjects,
             }
         )
         return Response(serializer.data)
@@ -153,5 +182,94 @@ class FieldPermissionsView(APIView):
             request.user, field
         )
 
-        serializer = UpdateFieldPermissionsResponseSerializer(field_permissions)
+        serializer = UpdateFieldPermissionsResponseSerializer(
+            {
+                "field_id": field.id,
+                "role": field_permissions.role,
+                "allow_in_forms": field_permissions.allow_in_forms,
+                "subjects": field_permissions.subjects,
+            }
+        )
         return Response(serializer.data)
+
+
+class FieldPermissionSubjectOptionsView(APIView):
+    @extend_schema(
+        parameters=[FieldPermissionSubjectOptionsRequestSerializer],
+        tags=["Field permissions"],
+        operation_id="list_field_permission_subject_options",
+        description=(
+            "Searches users and teams that can be selected for a field-specific "
+            "permission. Results are paginated and exclude the requested subjects."
+            "\n\nThis is an **enterprise** feature."
+        ),
+        responses={
+            200: get_example_pagination_serializer_class(
+                FieldPermissionSubjectOptionResponseSerializer
+            ),
+            400: get_error_schema(["ERROR_USER_NOT_IN_GROUP"]),
+            404: get_error_schema(["ERROR_FIELD_DOES_NOT_EXIST"]),
+        },
+    )
+    @map_exceptions(
+        {
+            FieldDoesNotExist: ERROR_FIELD_DOES_NOT_EXIST,
+            UserNotInWorkspace: ERROR_USER_NOT_IN_GROUP,
+        }
+    )
+    @validate_query_parameters(FieldPermissionSubjectOptionsRequestSerializer)
+    def get(self, request, field_id, query_params) -> Response:
+        field = FieldHandler().get_field(field_id)
+        workspace = field.table.database.workspace
+        CoreHandler().check_permissions(
+            request.user,
+            ReadFieldPermissionsOperationType.type,
+            workspace=workspace,
+            context=field,
+        )
+        LicenseHandler.raise_if_user_doesnt_have_feature(
+            FIELD_LEVEL_PERMISSIONS, request.user, workspace
+        )
+
+        search = (query_params.get("search") or "").strip()
+        users = WorkspaceUser.objects.filter(
+            workspace=workspace,
+            user__is_active=True,
+            user__profile__to_be_deleted=False,
+        ).exclude(user_id__in=query_params["exclude_user_ids"])
+        teams = Team.objects.filter(workspace=workspace).exclude(
+            id__in=query_params["exclude_team_ids"]
+        )
+        if search:
+            users = users.filter(
+                Q(user__first_name__icontains=search)
+                | Q(user__username__icontains=search)
+                | Q(user__email__icontains=search)
+            )
+            teams = teams.filter(name__icontains=search)
+
+        user_options = users.annotate(
+            subject_id=F("user_id"),
+            subject_type=Value(UserSubjectType.type, output_field=CharField()),
+            name=Case(
+                When(user__first_name="", then=F("user__email")),
+                default=F("user__first_name"),
+                output_field=CharField(),
+            ),
+            email=F("user__email"),
+            subject_count=Value(None, output_field=IntegerField()),
+        ).values("subject_id", "subject_type", "name", "email", "subject_count")
+        team_options = teams.annotate(
+            subject_id=F("id"),
+            subject_type=Value(TeamSubjectType.type, output_field=CharField()),
+            email=Value(None, output_field=CharField()),
+            subject_count=Count("subjects"),
+        ).values("subject_id", "subject_type", "name", "email", "subject_count")
+        options = user_options.union(team_options, all=True).order_by(
+            "name", "subject_type", "subject_id"
+        )
+
+        paginator = PageNumberPagination(limit_page_size=100)
+        page = paginator.paginate_queryset(options, request, view=self)
+        serializer = FieldPermissionSubjectOptionResponseSerializer(page, many=True)
+        return paginator.get_paginated_response(serializer.data)

--- a/enterprise/backend/src/baserow_enterprise/field_permissions/actions.py
+++ b/enterprise/backend/src/baserow_enterprise/field_permissions/actions.py
@@ -17,6 +17,7 @@ from baserow.core.action.registries import (
 )
 
 from .handler import FieldPermissionsHandler, FieldPermissionUpdated
+from .models import FieldPermissionsRoleEnum
 
 
 class UpdateFieldPermissionsActionType(UndoableActionType):
@@ -50,6 +51,8 @@ class UpdateFieldPermissionsActionType(UndoableActionType):
         allow_in_forms: bool
         original_role: str
         original_allow_in_forms: bool
+        subjects: list[dict] | None = None
+        original_subjects: list[dict] | None = None
 
     @classmethod
     def get_field_for_update(cls, field_id: int) -> Field:
@@ -71,6 +74,7 @@ class UpdateFieldPermissionsActionType(UndoableActionType):
         field: Field,
         role: str,
         allow_in_forms: bool = False,
+        subjects: list[dict] | None = None,
     ) -> FieldPermissionUpdated:
         """
         Updates the field permissions for a given field, setting the role and whether
@@ -80,6 +84,7 @@ class UpdateFieldPermissionsActionType(UndoableActionType):
         :param field: The field instance that needs to be updated.
         :param role: The role to set for the field.
         :param allow_in_forms: Whether the field is allowed in forms.
+        :param subjects: The users and teams allowed to edit when role is CUSTOM.
         """
 
         original_field_permissions = FieldPermissionsHandler._get_field_permissions(
@@ -87,9 +92,22 @@ class UpdateFieldPermissionsActionType(UndoableActionType):
         )
         original_role = original_field_permissions.role
         original_allow_in_forms = original_field_permissions.allow_in_forms
+        original_subjects = (
+            FieldPermissionsHandler._get_field_permission_subject_identifiers(field)
+        )
+
+        if role == FieldPermissionsRoleEnum.CUSTOM.value:
+            if subjects is None:
+                subjects = (
+                    original_subjects
+                    if original_role == FieldPermissionsRoleEnum.CUSTOM.value
+                    else []
+                )
+        else:
+            subjects = []
 
         field_permissions = FieldPermissionsHandler.update_field_permissions(
-            user, field, role, allow_in_forms
+            user, field, role, allow_in_forms, subjects
         )
 
         table = field.table
@@ -104,6 +122,8 @@ class UpdateFieldPermissionsActionType(UndoableActionType):
             allow_in_forms,
             original_role,
             original_allow_in_forms,
+            subjects,
+            original_subjects,
         )
         workspace = table.database.workspace
         cls.register_action(user, params, cls.scope(table.id), workspace)
@@ -123,12 +143,20 @@ class UpdateFieldPermissionsActionType(UndoableActionType):
     ):
         field = cls.get_field_for_update(params.field_id)
         FieldPermissionsHandler.update_field_permissions(
-            user, field, params.original_role, params.original_allow_in_forms
+            user,
+            field,
+            params.original_role,
+            params.original_allow_in_forms,
+            params.original_subjects or [],
         )
 
     @classmethod
     def redo(cls, user: AbstractUser, params: Params, action_being_redone: Action):
         field = cls.get_field_for_update(params.field_id)
         FieldPermissionsHandler.update_field_permissions(
-            user, field, params.role, params.allow_in_forms
+            user,
+            field,
+            params.role,
+            params.allow_in_forms,
+            params.subjects or [],
         )

--- a/enterprise/backend/src/baserow_enterprise/field_permissions/handler.py
+++ b/enterprise/backend/src/baserow_enterprise/field_permissions/handler.py
@@ -5,11 +5,23 @@ from typing import TypedDict
 from django.contrib.auth.models import AbstractUser
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
+from django.db.models import (
+    Case,
+    CharField,
+    Count,
+    F,
+    IntegerField,
+    Q,
+    QuerySet,
+    Value,
+    When,
+)
 
 from baserow.contrib.database.fields.models import Field
 from baserow.contrib.database.fields.operations import WriteFieldValuesOperationType
 from baserow.core.cache import local_cache
 from baserow.core.handler import CoreHandler
+from baserow.core.models import Workspace, WorkspaceUser
 from baserow.core.registries import (
     permission_manager_type_registry,
     subject_type_registry,
@@ -31,12 +43,21 @@ from baserow_enterprise.role.constants import FIELD_PERMISSION_EDITOR_ROLE_UID
 from baserow_enterprise.role.handler import RoleAssignmentHandler
 from baserow_enterprise.role.models import RoleAssignment
 from baserow_enterprise.signals import field_permissions_updated
+from baserow_enterprise.teams.models import Team
 from baserow_enterprise.teams.subjects import TeamSubjectType
 
 
 class FieldPermissionSubjectIdentifier(TypedDict):
     subject_id: int
     subject_type: str
+
+
+@dataclass
+class FieldPermissionRead:
+    field: Field
+    role: str
+    allow_in_forms: bool
+    subjects: list[RoleAssignment]
 
 
 @dataclass
@@ -51,6 +72,65 @@ class FieldPermissionUpdated:
 
 class FieldPermissionsHandler:
     allowed_subject_types = {UserSubjectType.type, TeamSubjectType.type}
+
+    @classmethod
+    def get_subject_options(
+        cls,
+        workspace: Workspace,
+        search: str = "",
+        exclude_user_ids: list[int] | None = None,
+        exclude_team_ids: list[int] | None = None,
+    ) -> QuerySet:
+        """Return selectable workspace users and teams for field permissions.
+
+        The returned dictionaries share the response shape expected by the field
+        permission subject-options API and are ordered consistently across both
+        subject types.
+
+        :param workspace: The workspace whose users and teams can be selected.
+        :param search: An optional case-insensitive name, username, or email search.
+        :param exclude_user_ids: User IDs to omit from the result.
+        :param exclude_team_ids: Team IDs to omit from the result.
+        :return: A queryset of user and team option dictionaries.
+        """
+
+        search = (search or "").strip()
+        users = WorkspaceUser.objects.filter(
+            workspace=workspace,
+            user__is_active=True,
+            user__profile__to_be_deleted=False,
+        ).exclude(user_id__in=exclude_user_ids or [])
+        teams = Team.objects.filter(workspace=workspace).exclude(
+            id__in=exclude_team_ids or []
+        )
+        if search:
+            users = users.filter(
+                Q(user__first_name__icontains=search)
+                | Q(user__username__icontains=search)
+                | Q(user__email__icontains=search)
+            )
+            teams = teams.filter(name__icontains=search)
+
+        user_options = users.annotate(
+            subject_id=F("user_id"),
+            subject_type=Value(UserSubjectType.type, output_field=CharField()),
+            name=Case(
+                When(user__first_name="", then=F("user__email")),
+                default=F("user__first_name"),
+                output_field=CharField(),
+            ),
+            email=F("user__email"),
+            subject_count=Value(None, output_field=IntegerField()),
+        ).values("subject_id", "subject_type", "name", "email", "subject_count")
+        team_options = teams.annotate(
+            subject_id=F("id"),
+            subject_type=Value(TeamSubjectType.type, output_field=CharField()),
+            email=Value(None, output_field=CharField()),
+            subject_count=Count("subjects"),
+        ).values("subject_id", "subject_type", "name", "email", "subject_count")
+        return user_options.union(team_options, all=True).order_by(
+            "name", "subject_type", "subject_id"
+        )
 
     @classmethod
     def _check_valid_role_value_or_raise(cls, role: str):
@@ -71,11 +151,15 @@ class FieldPermissionsHandler:
 
     @classmethod
     def _get_field_permission_subjects(cls, field: Field) -> list[RoleAssignment]:
-        """Returns the users and teams explicitly allowed to edit the field."""
+        """Return the marker assignments selecting editors for a field.
 
-        # Field subclasses use multi-table inheritance. Always scope assignments to
-        # the base Field model so that the same assignments are found regardless of
-        # whether the caller has a specific or base field instance.
+        Field subclasses use multi-table inheritance, so assignments are always
+        scoped to the base :class:`Field` content type.
+
+        :param field: The field whose selected subjects should be returned.
+        :return: Ordered user and team role assignments for the field.
+        """
+
         field_content_type = ContentType.objects.get_for_model(Field)
         return list(
             RoleAssignment.objects.filter(
@@ -93,6 +177,12 @@ class FieldPermissionsHandler:
     def _get_field_permission_subject_identifiers(
         cls, field: Field
     ) -> list[FieldPermissionSubjectIdentifier]:
+        """Return serializable identifiers for a field's selected subjects.
+
+        :param field: The field whose selected subjects should be identified.
+        :return: Subject IDs paired with their registered subject-type names.
+        """
+
         return [
             {
                 "subject_id": assignment.subject_id,
@@ -106,9 +196,21 @@ class FieldPermissionsHandler:
     @classmethod
     def _resolve_subjects(
         cls,
-        workspace,
+        workspace: Workspace,
         subject_identifiers: list[FieldPermissionSubjectIdentifier],
-    ):
+    ) -> list[AbstractUser | Team]:
+        """Resolve supported subject identifiers within a workspace.
+
+        Missing subjects and subjects outside the workspace intentionally produce
+        the same exception so callers cannot use this operation to enumerate them.
+
+        :param workspace: The workspace every resolved subject must belong to.
+        :param subject_identifiers: User and team identifiers to resolve.
+        :return: Unique subjects in deterministic type-and-ID order.
+        :raises SubjectUnsupported: If an identifier uses an unsupported type.
+        :raises SubjectNotExist: If a subject is missing or outside the workspace.
+        """
+
         identifiers_by_type = defaultdict(set)
         for identifier in subject_identifiers:
             subject_type_name = identifier["subject_type"]
@@ -139,9 +241,29 @@ class FieldPermissionsHandler:
         field: Field,
         subject_identifiers: list[FieldPermissionSubjectIdentifier],
     ) -> list[RoleAssignment]:
+        """Synchronize the subjects explicitly allowed to edit a field.
+
+        An empty desired set takes a direct deletion path and avoids resolving or
+        reading assignments that will all be removed.
+
+        :param field: The field whose marker assignments should be synchronized.
+        :param subject_identifiers: The complete desired user and team selection.
+        :return: The synchronized marker assignments in deterministic order.
+        """
+
         workspace = field.table.database.workspace
-        subjects = cls._resolve_subjects(workspace, subject_identifiers)
         field_content_type = ContentType.objects.get_for_model(Field)
+        field_assignments = RoleAssignment.objects.filter(
+            workspace=workspace,
+            scope_id=field.id,
+            scope_type=field_content_type,
+            role__uid=FIELD_PERMISSION_EDITOR_ROLE_UID,
+        )
+        if not subject_identifiers:
+            field_assignments.delete()
+            return []
+
+        subjects = cls._resolve_subjects(workspace, subject_identifiers)
         content_types = ContentType.objects.get_for_models(
             *{type(subject) for subject in subjects}
         )
@@ -149,14 +271,7 @@ class FieldPermissionsHandler:
             (content_types[type(subject)].id, subject.id): subject
             for subject in subjects
         }
-        existing = list(
-            RoleAssignment.objects.filter(
-                workspace=workspace,
-                scope_id=field.id,
-                scope_type=field_content_type,
-                role__uid=FIELD_PERMISSION_EDITOR_ROLE_UID,
-            )
-        )
+        existing = list(field_assignments)
         existing_keys = {
             (assignment.subject_type_id, assignment.subject_id): assignment
             for assignment in existing
@@ -216,8 +331,6 @@ class FieldPermissionsHandler:
         :return: A FieldPermissionUpdated object containing the updated permissions and
             wether the user can write values to the field, which requires computing the
             roles on the field.
-        :raises: ValueError if the role provided as string is not a valid
-            FieldPermissionsRoleEnum.
         """
 
         if isinstance(role, FieldPermissionsRoleEnum):
@@ -307,14 +420,15 @@ class FieldPermissionsHandler:
         return field_permissions
 
     @classmethod
-    def get_field_permissions(cls, user, field: Field) -> FieldPermissions:
+    def get_field_permissions(cls, user, field: Field) -> FieldPermissionRead:
         """
         Check permissions for the user and retrieves the field permissions.
         See _get_field_permissions for more details.
 
         :param user: The user requesting the field permissions.
         :param field: The field for which permissions are retrieved.
-        :return: The field's permissions.
+        :return: A typed read result containing the field's permission settings and
+            selected subjects.
         """
 
         CoreHandler().check_permissions(
@@ -325,9 +439,14 @@ class FieldPermissionsHandler:
         )
 
         field_permissions = cls._get_field_permissions(field)
-        field_permissions.subjects = (
+        subjects = (
             cls._get_field_permission_subjects(field)
             if field_permissions.role == FieldPermissionsRoleEnum.CUSTOM.value
             else []
         )
-        return field_permissions
+        return FieldPermissionRead(
+            field=field,
+            role=field_permissions.role,
+            allow_in_forms=field_permissions.allow_in_forms,
+            subjects=subjects,
+        )

--- a/enterprise/backend/src/baserow_enterprise/field_permissions/handler.py
+++ b/enterprise/backend/src/baserow_enterprise/field_permissions/handler.py
@@ -1,12 +1,21 @@
+from collections import defaultdict
 from dataclasses import dataclass
+from typing import TypedDict
 
 from django.contrib.auth.models import AbstractUser
+from django.contrib.contenttypes.models import ContentType
+from django.db import transaction
 
 from baserow.contrib.database.fields.models import Field
 from baserow.contrib.database.fields.operations import WriteFieldValuesOperationType
 from baserow.core.cache import local_cache
 from baserow.core.handler import CoreHandler
-from baserow.core.registries import permission_manager_type_registry
+from baserow.core.registries import (
+    permission_manager_type_registry,
+    subject_type_registry,
+)
+from baserow.core.subjects import UserSubjectType
+from baserow_enterprise.exceptions import SubjectNotExist, SubjectUnsupported
 from baserow_enterprise.field_permissions.models import (
     FieldPermissions,
     FieldPermissionsRoleEnum,
@@ -18,7 +27,16 @@ from baserow_enterprise.field_permissions.operations import (
 from baserow_enterprise.field_permissions.permission_manager import (
     FieldPermissionManagerType,
 )
+from baserow_enterprise.role.constants import FIELD_PERMISSION_EDITOR_ROLE_UID
+from baserow_enterprise.role.handler import RoleAssignmentHandler
+from baserow_enterprise.role.models import RoleAssignment
 from baserow_enterprise.signals import field_permissions_updated
+from baserow_enterprise.teams.subjects import TeamSubjectType
+
+
+class FieldPermissionSubjectIdentifier(TypedDict):
+    subject_id: int
+    subject_type: str
 
 
 @dataclass
@@ -28,9 +46,12 @@ class FieldPermissionUpdated:
     role: str
     allow_in_forms: bool
     can_write_values: bool
+    subjects: list[RoleAssignment]
 
 
 class FieldPermissionsHandler:
+    allowed_subject_types = {UserSubjectType.type, TeamSubjectType.type}
+
     @classmethod
     def _check_valid_role_value_or_raise(cls, role: str):
         """
@@ -49,12 +70,137 @@ class FieldPermissionsHandler:
             )
 
     @classmethod
+    def _get_field_permission_subjects(cls, field: Field) -> list[RoleAssignment]:
+        """Returns the users and teams explicitly allowed to edit the field."""
+
+        # Field subclasses use multi-table inheritance. Always scope assignments to
+        # the base Field model so that the same assignments are found regardless of
+        # whether the caller has a specific or base field instance.
+        field_content_type = ContentType.objects.get_for_model(Field)
+        return list(
+            RoleAssignment.objects.filter(
+                workspace=field.table.database.workspace,
+                scope_id=field.id,
+                scope_type=field_content_type,
+                role__uid=FIELD_PERMISSION_EDITOR_ROLE_UID,
+            )
+            .select_related("role", "subject_type")
+            .prefetch_related("subject")
+            .order_by("subject_type_id", "subject_id")
+        )
+
+    @classmethod
+    def _get_field_permission_subject_identifiers(
+        cls, field: Field
+    ) -> list[FieldPermissionSubjectIdentifier]:
+        return [
+            {
+                "subject_id": assignment.subject_id,
+                "subject_type": subject_type_registry.get_for_class(
+                    assignment.subject_type.model_class()
+                ).type,
+            }
+            for assignment in cls._get_field_permission_subjects(field)
+        ]
+
+    @classmethod
+    def _resolve_subjects(
+        cls,
+        workspace,
+        subject_identifiers: list[FieldPermissionSubjectIdentifier],
+    ):
+        identifiers_by_type = defaultdict(set)
+        for identifier in subject_identifiers:
+            subject_type_name = identifier["subject_type"]
+            if subject_type_name not in cls.allowed_subject_types:
+                raise SubjectUnsupported()
+            identifiers_by_type[subject_type_name].add(identifier["subject_id"])
+
+        subjects_by_identifier = {}
+        for subject_type_name, subject_ids in identifiers_by_type.items():
+            subject_type = subject_type_registry.get(subject_type_name)
+            subjects = list(subject_type.model_class.objects.filter(id__in=subject_ids))
+            if len(subjects) != len(subject_ids) or not all(
+                subject_type.are_in_workspace(subjects, workspace)
+            ):
+                raise SubjectNotExist()
+
+            for subject in subjects:
+                subjects_by_identifier[(subject_type_name, subject.id)] = subject
+
+        return [
+            subjects_by_identifier[(subject_type_name, subject_id)]
+            for subject_type_name, subject_id in sorted(subjects_by_identifier)
+        ]
+
+    @classmethod
+    def _sync_field_permission_subjects(
+        cls,
+        field: Field,
+        subject_identifiers: list[FieldPermissionSubjectIdentifier],
+    ) -> list[RoleAssignment]:
+        workspace = field.table.database.workspace
+        subjects = cls._resolve_subjects(workspace, subject_identifiers)
+        field_content_type = ContentType.objects.get_for_model(Field)
+        content_types = ContentType.objects.get_for_models(
+            *{type(subject) for subject in subjects}
+        )
+        desired = {
+            (content_types[type(subject)].id, subject.id): subject
+            for subject in subjects
+        }
+        existing = list(
+            RoleAssignment.objects.filter(
+                workspace=workspace,
+                scope_id=field.id,
+                scope_type=field_content_type,
+                role__uid=FIELD_PERMISSION_EDITOR_ROLE_UID,
+            )
+        )
+        existing_keys = {
+            (assignment.subject_type_id, assignment.subject_id): assignment
+            for assignment in existing
+        }
+
+        assignment_ids_to_delete = [
+            assignment.id
+            for key, assignment in existing_keys.items()
+            if key not in desired
+        ]
+        if assignment_ids_to_delete:
+            RoleAssignment.objects.filter(id__in=assignment_ids_to_delete).delete()
+
+        assignments_to_create = [
+            subject for key, subject in desired.items() if key not in existing_keys
+        ]
+        if assignments_to_create:
+            marker_role = RoleAssignmentHandler().get_role_by_uid(
+                FIELD_PERMISSION_EDITOR_ROLE_UID
+            )
+            RoleAssignment.objects.bulk_create(
+                [
+                    RoleAssignment(
+                        subject_id=subject.id,
+                        subject_type=content_types[type(subject)],
+                        role=marker_role,
+                        workspace=workspace,
+                        scope_id=field.id,
+                        scope_type=field_content_type,
+                    )
+                    for subject in assignments_to_create
+                ]
+            )
+        return cls._get_field_permission_subjects(field)
+
+    @classmethod
+    @transaction.atomic
     def update_field_permissions(
         cls,
         user: AbstractUser,
         field: Field,
         role: FieldPermissionsRoleEnum | str,
         allow_in_forms: bool = False,
+        subjects: list[FieldPermissionSubjectIdentifier] | None = None,
     ) -> FieldPermissionUpdated:
         """
         Updates the field permissions for a given field, setting the role and whether
@@ -64,6 +210,9 @@ class FieldPermissionsHandler:
         :param field: The field for which the permissions are being updated.
         :param role: The role to set for the field permissions.
         :param allow_in_forms: Whether the field can be updated in forms.
+        :param subjects: The users and teams allowed to edit when the role is CUSTOM.
+            If omitted while updating an existing CUSTOM permission, the current list
+            is preserved.
         :return: A FieldPermissionUpdated object containing the updated permissions and
             wether the user can write values to the field, which requires computing the
             roles on the field.
@@ -82,6 +231,14 @@ class FieldPermissionsHandler:
             workspace=field.table.database.workspace,
             context=field,
         )
+
+        if role == FieldPermissionsRoleEnum.CUSTOM.value:
+            if subjects is None:
+                subjects = cls._get_field_permission_subject_identifiers(field)
+            subject_assignments = cls._sync_field_permission_subjects(field, subjects)
+        else:
+            cls._sync_field_permission_subjects(field, [])
+            subject_assignments = []
 
         if role == FieldPermissionsRoleEnum.EDITOR.value:
             # The default, meaning we can remove any existing permission for this field.
@@ -114,6 +271,7 @@ class FieldPermissionsHandler:
             role=role,
             allow_in_forms=allow_in_forms,
             can_write_values=user_can_write_values,
+            subjects=subject_assignments,
         )
 
     @classmethod
@@ -166,4 +324,10 @@ class FieldPermissionsHandler:
             context=field,
         )
 
-        return cls._get_field_permissions(field)
+        field_permissions = cls._get_field_permissions(field)
+        field_permissions.subjects = (
+            cls._get_field_permission_subjects(field)
+            if field_permissions.role == FieldPermissionsRoleEnum.CUSTOM.value
+            else []
+        )
+        return field_permissions

--- a/enterprise/backend/src/baserow_enterprise/field_permissions/permission_manager.py
+++ b/enterprise/backend/src/baserow_enterprise/field_permissions/permission_manager.py
@@ -358,7 +358,8 @@ class FieldPermissionManagerType(PermissionManagerType):
             field__table__in=table_qs,
         ).select_related("field__table__database__workspace")
 
-        roles_by_scope = RoleAssignmentHandler().get_roles_per_scope(workspace, actor)
+        role_handler = RoleAssignmentHandler()
+        roles_by_scope = role_handler.get_roles_per_scope(workspace, actor)
         custom_field_ids = {
             field_perm.field_id
             for field_perm in field_perms
@@ -373,6 +374,13 @@ class FieldPermissionManagerType(PermissionManagerType):
         computed_roles_by_table_id = {}
         scope_includes_cache = {}
 
+        def get_computed_roles_for_table(table):
+            if table.id not in computed_roles_by_table_id:
+                computed_roles_by_table_id[table.id] = role_handler.get_computed_roles(
+                    roles_by_scope, table, scope_includes_cache
+                )
+            return computed_roles_by_table_id[table.id]
+
         # Verify if the actor has the required permissions for each field permission.
         # If not, add the field id to the exceptions list.
         for field_perm in field_perms:
@@ -382,34 +390,20 @@ class FieldPermissionManagerType(PermissionManagerType):
             if field_perm.role == FieldPermissionsRoleEnum.NOBODY.value:
                 can_write_values_exceptions.add(field_perm.field_id)
             elif field_perm.role == FieldPermissionsRoleEnum.CUSTOM.value:
-                if field_perm.field.table_id not in computed_roles_by_table_id:
-                    computed_roles_by_table_id[field_perm.field.table_id] = (
-                        RoleAssignmentHandler().get_computed_roles(
-                            roles_by_scope,
-                            field_perm.field.table,
-                            scope_includes_cache,
-                        )
-                    )
-                computed_roles = computed_roles_by_table_id[field_perm.field.table_id]
                 can_edit = (
                     field_perm.field_id in selected_custom_field_ids
                     and self._is_operation_allowed(
-                        computed_roles, FieldPermissionsRoleEnum.EDITOR.value
+                        get_computed_roles_for_table(field_perm.field.table),
+                        FieldPermissionsRoleEnum.EDITOR.value,
                     )
                 )
                 if not can_edit:
                     can_write_values_exceptions.add(field_perm.field_id)
             else:
-                if field_perm.field.table_id not in computed_roles_by_table_id:
-                    computed_roles_by_table_id[field_perm.field.table_id] = (
-                        RoleAssignmentHandler().get_computed_roles(
-                            roles_by_scope,
-                            field_perm.field.table,
-                            scope_includes_cache,
-                        )
-                    )
-                computed_roles = computed_roles_by_table_id[field_perm.field.table_id]
-                can_edit = self._is_operation_allowed(computed_roles, field_perm.role)
+                can_edit = self._is_operation_allowed(
+                    get_computed_roles_for_table(field_perm.field.table),
+                    field_perm.role,
+                )
                 if not can_edit:
                     can_write_values_exceptions.add(field_perm.field_id)
 

--- a/enterprise/backend/src/baserow_enterprise/field_permissions/permission_manager.py
+++ b/enterprise/backend/src/baserow_enterprise/field_permissions/permission_manager.py
@@ -3,7 +3,8 @@ from functools import partial
 from typing import Dict, List, Literal, Optional, TypedDict
 
 from django.contrib.auth.models import AbstractUser
-from django.db.models import Exists, OuterRef, QuerySet
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Exists, OuterRef, Q, QuerySet
 
 from baserow.contrib.database.fields.models import Field
 from baserow.contrib.database.fields.operations import (
@@ -22,9 +23,11 @@ from baserow_enterprise.role.constants import (
     ADMIN_ROLE_UID,
     BUILDER_ROLE_UID,
     EDITOR_ROLE_UID,
+    FIELD_PERMISSION_EDITOR_ROLE_UID,
 )
 from baserow_enterprise.role.handler import RoleAssignmentHandler
-from baserow_enterprise.role.models import Role
+from baserow_enterprise.role.models import Role, RoleAssignment
+from baserow_enterprise.teams.models import Team, TeamSubject
 from baserow_premium.license.handler import LicenseHandler
 
 from .models import FieldPermissions, FieldPermissionsRoleEnum
@@ -79,6 +82,64 @@ class FieldPermissionManagerType(PermissionManagerType):
 
         return [c for c in checks if c.operation_name in ops_allowed]
 
+    def _get_custom_field_ids_by_actor(
+        self,
+        workspace: Workspace,
+        actors: List[Actor],
+        field_ids: set[int],
+    ) -> Dict[Actor, set[int]]:
+        """
+        Returns the custom fields selected for each actor, either directly or via a
+        team. The membership and assignments are fetched in batches to avoid queries
+        per permission check.
+        """
+
+        user_model = subject_type_registry.get(UserSubjectType.type).model_class
+        actors_by_id = {
+            actor.id: actor for actor in actors if isinstance(actor, user_model)
+        }
+        result = defaultdict(set)
+        if not actors_by_id or not field_ids:
+            return result
+
+        content_types = ContentType.objects.get_for_models(user_model, Team, Field)
+        user_content_type = content_types[user_model]
+        team_content_type = content_types[Team]
+        field_content_type = content_types[Field]
+
+        actor_ids_by_team_id = defaultdict(set)
+        for team_id, actor_id in TeamSubject.objects.filter(
+            team__workspace=workspace,
+            team__trashed=False,
+            subject_type=user_content_type,
+            subject_id__in=actors_by_id,
+        ).values_list("team_id", "subject_id"):
+            actor_ids_by_team_id[team_id].add(actor_id)
+
+        assignments = RoleAssignment.objects.filter(
+            workspace=workspace,
+            scope_type=field_content_type,
+            scope_id__in=field_ids,
+            role__uid=FIELD_PERMISSION_EDITOR_ROLE_UID,
+        ).filter(
+            Q(subject_type=user_content_type, subject_id__in=actors_by_id)
+            | Q(
+                subject_type=team_content_type,
+                subject_id__in=actor_ids_by_team_id,
+            )
+        )
+
+        for subject_type_id, subject_id, field_id in assignments.values_list(
+            "subject_type_id", "subject_id", "scope_id"
+        ):
+            if subject_type_id == user_content_type.id:
+                result[actors_by_id[subject_id]].add(field_id)
+            else:
+                for actor_id in actor_ids_by_team_id[subject_id]:
+                    result[actors_by_id[actor_id]].add(field_id)
+
+        return result
+
     def check_field_permissions(
         self, checks: List[PermissionCheck], workspace=None, include_trash=False
     ):
@@ -91,7 +152,8 @@ class FieldPermissionManagerType(PermissionManagerType):
         }
         result = {}
 
-        # Some checks can be resolved immediately like NOBODY or CUSTOM roles.
+        # Some checks can be resolved immediately, while role-based and custom checks
+        # also need the actor's effective role on the table.
         # Otherwise, we need to check the actor's roles and permissions later.
         remaining_role_checks = []
         for check in checks:
@@ -114,11 +176,16 @@ class FieldPermissionManagerType(PermissionManagerType):
                 result[check] = PermissionDenied()
                 continue
             elif required_role == FieldPermissionsRoleEnum.CUSTOM.value:
-                continue  # TODO: implement the check here for CUSTOM_ROLE_UID
+                if not isinstance(
+                    check.actor,
+                    subject_type_registry.get(UserSubjectType.type).model_class,
+                ):
+                    result[check] = PermissionDenied()
+                    continue
             else:
-                # check actor role and permissions later
-
-                remaining_role_checks.append(check)
+                # Check actor role and permissions later.
+                pass
+            remaining_role_checks.append(check)
         if not remaining_role_checks:  # All checks resolved
             return result
 
@@ -140,6 +207,18 @@ class FieldPermissionManagerType(PermissionManagerType):
                 )
             )
 
+        custom_field_ids = {
+            check.context.id
+            for check in remaining_role_checks
+            if field_permissions_map[check.context.id].role
+            == FieldPermissionsRoleEnum.CUSTOM.value
+        }
+        custom_field_ids_by_actor = self._get_custom_field_ids_by_actor(
+            workspace,
+            list(checks_by_actor_and_context),
+            custom_field_ids,
+        )
+
         scope_includes_cache = {}
         for actor, table_checks in checks_by_actor_and_context.items():
             for table, checks in table_checks.items():
@@ -147,7 +226,10 @@ class FieldPermissionManagerType(PermissionManagerType):
                     roles_per_scope_by_actor[actor], table, scope_includes_cache
                 )
                 checks_results = self._get_checks_results(
-                    checks, computed_roles, field_permissions_map
+                    checks,
+                    computed_roles,
+                    field_permissions_map,
+                    custom_field_ids_by_actor[actor],
                 )
                 result.update(checks_results)
 
@@ -158,6 +240,7 @@ class FieldPermissionManagerType(PermissionManagerType):
         checks: List[PermissionCheck],
         computed_roles: List[Role],
         field_permissions_map: Dict[int, FieldPermissions],
+        custom_field_ids: set[int],
     ) -> Dict[PermissionCheck, bool | PermissionDenied]:
         """
         Helper function to get the results of all the checks for a given actor defined
@@ -176,7 +259,17 @@ class FieldPermissionManagerType(PermissionManagerType):
         for check in checks:
             field_id = check.context.id
             required_role = field_permissions_map[field_id].role
-            if self._is_operation_allowed(computed_roles, required_role):
+            if required_role == FieldPermissionsRoleEnum.CUSTOM.value:
+                is_allowed = (
+                    field_id in custom_field_ids
+                    and self._is_operation_allowed(
+                        computed_roles, FieldPermissionsRoleEnum.EDITOR.value
+                    )
+                )
+            else:
+                is_allowed = self._is_operation_allowed(computed_roles, required_role)
+
+            if is_allowed:
                 result[check] = True
             else:
                 result[check] = PermissionDenied()
@@ -266,9 +359,19 @@ class FieldPermissionManagerType(PermissionManagerType):
         ).select_related("field__table__database__workspace")
 
         roles_by_scope = RoleAssignmentHandler().get_roles_per_scope(workspace, actor)
+        custom_field_ids = {
+            field_perm.field_id
+            for field_perm in field_perms
+            if field_perm.role == FieldPermissionsRoleEnum.CUSTOM.value
+        }
+        selected_custom_field_ids = self._get_custom_field_ids_by_actor(
+            workspace, [actor], custom_field_ids
+        )[actor]
 
         can_write_values_exceptions = set()
         can_submit_values_exceptions = set()
+        computed_roles_by_table_id = {}
+        scope_includes_cache = {}
 
         # Verify if the actor has the required permissions for each field permission.
         # If not, add the field id to the exceptions list.
@@ -279,12 +382,33 @@ class FieldPermissionManagerType(PermissionManagerType):
             if field_perm.role == FieldPermissionsRoleEnum.NOBODY.value:
                 can_write_values_exceptions.add(field_perm.field_id)
             elif field_perm.role == FieldPermissionsRoleEnum.CUSTOM.value:
-                # TODO: implement the check here.
-                continue
-            else:
-                computed_roles = RoleAssignmentHandler().get_computed_roles(
-                    roles_by_scope, field_perm.field.table
+                if field_perm.field.table_id not in computed_roles_by_table_id:
+                    computed_roles_by_table_id[field_perm.field.table_id] = (
+                        RoleAssignmentHandler().get_computed_roles(
+                            roles_by_scope,
+                            field_perm.field.table,
+                            scope_includes_cache,
+                        )
+                    )
+                computed_roles = computed_roles_by_table_id[field_perm.field.table_id]
+                can_edit = (
+                    field_perm.field_id in selected_custom_field_ids
+                    and self._is_operation_allowed(
+                        computed_roles, FieldPermissionsRoleEnum.EDITOR.value
+                    )
                 )
+                if not can_edit:
+                    can_write_values_exceptions.add(field_perm.field_id)
+            else:
+                if field_perm.field.table_id not in computed_roles_by_table_id:
+                    computed_roles_by_table_id[field_perm.field.table_id] = (
+                        RoleAssignmentHandler().get_computed_roles(
+                            roles_by_scope,
+                            field_perm.field.table,
+                            scope_includes_cache,
+                        )
+                    )
+                computed_roles = computed_roles_by_table_id[field_perm.field.table_id]
                 can_edit = self._is_operation_allowed(computed_roles, field_perm.role)
                 if not can_edit:
                     can_write_values_exceptions.add(field_perm.field_id)

--- a/enterprise/backend/src/baserow_enterprise/field_permissions/permission_manager.py
+++ b/enterprise/backend/src/baserow_enterprise/field_permissions/permission_manager.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from functools import partial
-from typing import Dict, List, Literal, Optional, TypedDict
+from typing import Callable, Dict, List, Literal, Optional, TypedDict
 
 from django.contrib.auth.models import AbstractUser
 from django.contrib.contenttypes.models import ContentType
@@ -92,6 +92,12 @@ class FieldPermissionManagerType(PermissionManagerType):
         Returns the custom fields selected for each actor, either directly or via a
         team. The membership and assignments are fetched in batches to avoid queries
         per permission check.
+
+        :param workspace: The workspace containing the field permission assignments.
+        :param actors: The actors whose selected custom fields should be returned.
+        :param field_ids: The custom field IDs relevant to the permission checks.
+        :return: The selected custom field IDs for each actor. Actors without a
+            matching assignment resolve to an empty set.
         """
 
         user_model = subject_type_registry.get(UserSubjectType.type).model_class
@@ -235,6 +241,28 @@ class FieldPermissionManagerType(PermissionManagerType):
 
         return result
 
+    def _is_custom_permission_allowed(
+        self,
+        field_id: int,
+        custom_field_ids: set[int],
+        get_computed_roles: Callable[[], List[Role]],
+    ) -> bool:
+        """Returns whether a CUSTOM permission allows writing to a field.
+
+        The actor must be selected directly or through a team and must also have an
+        effective Editor-or-higher role on the field's table. The role getter is only
+        evaluated for selected actors.
+
+        :param field_id: The ID of the field being checked.
+        :param custom_field_ids: The IDs of fields for which the actor is selected.
+        :param get_computed_roles: Returns the actor's effective roles on the table.
+        :return: Whether the actor can write to the custom-permission field.
+        """
+
+        return field_id in custom_field_ids and self._is_operation_allowed(
+            get_computed_roles(), FieldPermissionsRoleEnum.EDITOR.value
+        )
+
     def _get_checks_results(
         self,
         checks: List[PermissionCheck],
@@ -243,14 +271,15 @@ class FieldPermissionManagerType(PermissionManagerType):
         custom_field_ids: set[int],
     ) -> Dict[PermissionCheck, bool | PermissionDenied]:
         """
-        Helper function to get the results of all the checks for a given actor defined
-        by the list of computed roles and a required role common to all the checks.
-        This function will return a dictionary with the check as the key and True or
-        PermissionDenied as the value.
+        Returns permission results for field checks sharing an actor and table.
+
+        Each field can require a different role. CUSTOM permissions additionally use
+        ``custom_field_ids`` to determine whether the actor was explicitly selected.
 
         :param checks: The list of checks to perform.
         :param computed_roles: The list of computed roles for the actor.
-        :param required_role: The required role for the checks.
+        :param field_permissions_map: The field permissions keyed by field ID.
+        :param custom_field_ids: The IDs of custom fields selected for the actor.
         :return: A dictionary with the check as the key and True or PermissionDenied
             as the value.
         """
@@ -260,11 +289,10 @@ class FieldPermissionManagerType(PermissionManagerType):
             field_id = check.context.id
             required_role = field_permissions_map[field_id].role
             if required_role == FieldPermissionsRoleEnum.CUSTOM.value:
-                is_allowed = (
-                    field_id in custom_field_ids
-                    and self._is_operation_allowed(
-                        computed_roles, FieldPermissionsRoleEnum.EDITOR.value
-                    )
+                is_allowed = self._is_custom_permission_allowed(
+                    field_id,
+                    custom_field_ids,
+                    lambda: computed_roles,
                 )
             else:
                 is_allowed = self._is_operation_allowed(computed_roles, required_role)
@@ -282,7 +310,7 @@ class FieldPermissionManagerType(PermissionManagerType):
     ) -> bool:
         """
         Given a required role for the operation and a list of computed roles for an
-        actor, verify the actor have the required permissions to perform the operation.
+        actor, verifies that the actor has permission to perform the operation.
 
         :param computed_roles: The list of computed RBAC roles for the actor.
         :param required_role: The required role for the operation.
@@ -375,6 +403,12 @@ class FieldPermissionManagerType(PermissionManagerType):
         scope_includes_cache = {}
 
         def get_computed_roles_for_table(table):
+            """Return and memoize the actor's effective roles for a table.
+
+            :param table: The table whose effective roles should be returned.
+            :return: The actor's effective roles for the table.
+            """
+
             if table.id not in computed_roles_by_table_id:
                 computed_roles_by_table_id[table.id] = role_handler.get_computed_roles(
                     roles_by_scope, table, scope_includes_cache
@@ -390,12 +424,13 @@ class FieldPermissionManagerType(PermissionManagerType):
             if field_perm.role == FieldPermissionsRoleEnum.NOBODY.value:
                 can_write_values_exceptions.add(field_perm.field_id)
             elif field_perm.role == FieldPermissionsRoleEnum.CUSTOM.value:
-                can_edit = (
-                    field_perm.field_id in selected_custom_field_ids
-                    and self._is_operation_allowed(
-                        get_computed_roles_for_table(field_perm.field.table),
-                        FieldPermissionsRoleEnum.EDITOR.value,
-                    )
+                can_edit = self._is_custom_permission_allowed(
+                    field_perm.field_id,
+                    selected_custom_field_ids,
+                    partial(
+                        get_computed_roles_for_table,
+                        field_perm.field.table,
+                    ),
                 )
                 if not can_edit:
                     can_write_values_exceptions.add(field_perm.field_id)

--- a/enterprise/backend/src/baserow_enterprise/populate.py
+++ b/enterprise/backend/src/baserow_enterprise/populate.py
@@ -25,7 +25,7 @@ from baserow_enterprise.integrations.local_baserow.models import (
     LocalBaserowPasswordAppAuthProvider,
     LocalBaserowUserSource,
 )
-from baserow_enterprise.role.default_roles import default_roles
+from baserow_enterprise.role.default_roles import user_role_uids
 
 User = get_user_model()
 
@@ -54,7 +54,7 @@ def load_test_data():
     workspace = user.workspaceuser_set.get(workspace__name="Acme Corp").workspace
 
     print("Add one user per existing role in the same workspace as admin")
-    for i, r in enumerate(default_roles.keys()):
+    for i, r in enumerate(user_role_uids):
         rl = r.lower()
         try:
             user = UserHandler().create_user(rl, f"{rl}@baserow.io", "password")

--- a/enterprise/backend/src/baserow_enterprise/role/constants.py
+++ b/enterprise/backend/src/baserow_enterprise/role/constants.py
@@ -33,6 +33,7 @@ NO_ROLE_LOW_PRIORITY_ROLE_UID = getattr(
 # exclusively by the field permission manager and must never affect regular RBAC role
 # computation.
 FIELD_PERMISSION_EDITOR_ROLE_UID = "FIELD_PERMISSION_EDITOR"
+INTERNAL_ROLE_UIDS = (FIELD_PERMISSION_EDITOR_ROLE_UID,)
 FREE_ROLE_UIDS = [
     COMMENTER_ROLE_UID,
     VIEWER_ROLE_UID,

--- a/enterprise/backend/src/baserow_enterprise/role/constants.py
+++ b/enterprise/backend/src/baserow_enterprise/role/constants.py
@@ -29,6 +29,10 @@ READ_ONLY_ROLE_UID = getattr(settings, "READ_ONLY_ROLE_UID", "READ_ONLY")
 NO_ROLE_LOW_PRIORITY_ROLE_UID = getattr(
     settings, "NO_ROLE_LOW_PRIORITY_UID", "NO_ROLE_LOW_PRIORITY"
 )
+# This hidden role is used as a marker on field-scoped RoleAssignments. It is handled
+# exclusively by the field permission manager and must never affect regular RBAC role
+# computation.
+FIELD_PERMISSION_EDITOR_ROLE_UID = "FIELD_PERMISSION_EDITOR"
 FREE_ROLE_UIDS = [
     COMMENTER_ROLE_UID,
     VIEWER_ROLE_UID,

--- a/enterprise/backend/src/baserow_enterprise/role/default_roles.py
+++ b/enterprise/backend/src/baserow_enterprise/role/default_roles.py
@@ -293,6 +293,7 @@ from baserow_enterprise.role.constants import (
     COMMENTER_ROLE_UID,
     EDITOR_ROLE_UID,
     FIELD_PERMISSION_EDITOR_ROLE_UID,
+    INTERNAL_ROLE_UIDS,
     NO_ACCESS_ROLE_UID,
     NO_ROLE_LOW_PRIORITY_ROLE_UID,
     READ_ONLY_ROLE_UID,
@@ -343,20 +344,17 @@ default_roles = {
     FIELD_PERMISSION_EDITOR_ROLE_UID: [],
 }
 
-# This internal role is a marker for field-specific subject selection, not a user's
-# effective RBAC role, and must not appear in license seat usage summaries.
-seat_usage_role_uids = [
-    uid for uid in default_roles if uid != FIELD_PERMISSION_EDITOR_ROLE_UID
-]
+# Internal roles must be persisted, but they can never become a user's effective role.
+user_role_uids = [uid for uid in default_roles if uid not in INTERNAL_ROLE_UIDS]
 # Virtual roles are only used in-code, and it's not possible for the user to use these.
 # The READ_ONLY role is used give to the user when they don't have access to a lower
 # level object scope, but have access a higher one.
-hidden_roles = [READ_ONLY_ROLE_UID, FIELD_PERMISSION_EDITOR_ROLE_UID]
+hidden_roles = [READ_ONLY_ROLE_UID, *INTERNAL_ROLE_UIDS]
 
-if settings.BASEROW_PERSONAL_VIEW_LOWEST_ROLE_ALLOWED not in default_roles:
+if settings.BASEROW_PERSONAL_VIEW_LOWEST_ROLE_ALLOWED not in user_role_uids:
     raise ImproperlyConfigured(
         f"The env var BASEROW_PERSONAL_VIEW_LOWEST_ROLE_ALLOWED must be set to one of "
-        f"the following values: {default_roles.keys()} but instead it is "
+        f"the following values: {user_role_uids} but instead it is "
         f"{settings.BASEROW_PERSONAL_VIEW_LOWEST_ROLE_ALLOWED}. "
     )
 

--- a/enterprise/backend/src/baserow_enterprise/role/default_roles.py
+++ b/enterprise/backend/src/baserow_enterprise/role/default_roles.py
@@ -292,6 +292,7 @@ from baserow_enterprise.role.constants import (
     BUILDER_ROLE_UID,
     COMMENTER_ROLE_UID,
     EDITOR_ROLE_UID,
+    FIELD_PERMISSION_EDITOR_ROLE_UID,
     NO_ACCESS_ROLE_UID,
     NO_ROLE_LOW_PRIORITY_ROLE_UID,
     READ_ONLY_ROLE_UID,
@@ -339,11 +340,18 @@ default_roles = {
     READ_ONLY_ROLE_UID: [],
     NO_ACCESS_ROLE_UID: [],
     NO_ROLE_LOW_PRIORITY_ROLE_UID: [],
+    FIELD_PERMISSION_EDITOR_ROLE_UID: [],
 }
+
+# This internal role is a marker for field-specific subject selection, not a user's
+# effective RBAC role, and must not appear in license seat usage summaries.
+seat_usage_role_uids = [
+    uid for uid in default_roles if uid != FIELD_PERMISSION_EDITOR_ROLE_UID
+]
 # Virtual roles are only used in-code, and it's not possible for the user to use these.
 # The READ_ONLY role is used give to the user when they don't have access to a lower
 # level object scope, but have access a higher one.
-hidden_roles = [READ_ONLY_ROLE_UID]
+hidden_roles = [READ_ONLY_ROLE_UID, FIELD_PERMISSION_EDITOR_ROLE_UID]
 
 if settings.BASEROW_PERSONAL_VIEW_LOWEST_ROLE_ALLOWED not in default_roles:
     raise ImproperlyConfigured(

--- a/enterprise/backend/src/baserow_enterprise/role/handler.py
+++ b/enterprise/backend/src/baserow_enterprise/role/handler.py
@@ -37,7 +37,7 @@ from baserow_premium.license.handler import LicenseHandler
 
 from .constants import (
     ALLOWED_SUBJECT_TYPE_BY_PRIORITY,
-    FIELD_PERMISSION_EDITOR_ROLE_UID,
+    INTERNAL_ROLE_UIDS,
     NO_ACCESS_ROLE_UID,
     NO_ROLE_LOW_PRIORITY_ROLE_UID,
     READ_ONLY_ROLE_UID,
@@ -423,7 +423,7 @@ class RoleAssignmentHandler:
                 .exclude(
                     role__uid__in=[
                         NO_ROLE_LOW_PRIORITY_ROLE_UID,
-                        FIELD_PERMISSION_EDITOR_ROLE_UID,
+                        *INTERNAL_ROLE_UIDS,
                     ]
                 )
                 .annotate(

--- a/enterprise/backend/src/baserow_enterprise/role/handler.py
+++ b/enterprise/backend/src/baserow_enterprise/role/handler.py
@@ -37,6 +37,7 @@ from baserow_premium.license.handler import LicenseHandler
 
 from .constants import (
     ALLOWED_SUBJECT_TYPE_BY_PRIORITY,
+    FIELD_PERMISSION_EDITOR_ROLE_UID,
     NO_ACCESS_ROLE_UID,
     NO_ROLE_LOW_PRIORITY_ROLE_UID,
     READ_ONLY_ROLE_UID,
@@ -418,7 +419,13 @@ class RoleAssignmentHandler:
                 RoleAssignment.objects.filter(
                     workspace=workspace,
                 )
-                .filter(subjects_q, ~Q(role__uid=NO_ROLE_LOW_PRIORITY_ROLE_UID))
+                .filter(subjects_q)
+                .exclude(
+                    role__uid__in=[
+                        NO_ROLE_LOW_PRIORITY_ROLE_UID,
+                        FIELD_PERMISSION_EDITOR_ROLE_UID,
+                    ]
+                )
                 .annotate(
                     scope_type_order=Case(
                         *scope_cases,

--- a/enterprise/backend/src/baserow_enterprise/role/receivers.py
+++ b/enterprise/backend/src/baserow_enterprise/role/receivers.py
@@ -110,6 +110,7 @@ def connect_to_post_delete_signals_to_cascade_deletion_to_role_assignments():
     all related role_assignments.
     """
 
+    from baserow.contrib.database.fields.models import Field
     from baserow.core.models import WorkspaceUser
     from baserow.core.registries import (
         object_scope_type_registry,
@@ -128,3 +129,8 @@ def connect_to_post_delete_signals_to_cascade_deletion_to_role_assignments():
     for role_assignable_object_type in ROLE_ASSIGNABLE_OBJECT_MAP.keys():
         scope_type = object_scope_type_registry.get(role_assignable_object_type)
         post_delete.connect(cascade_scope_delete, scope_type.model_class)
+
+    # Field permission subjects are stored as internal field-scoped role assignments.
+    # Fields are intentionally not general role-assignable objects, so register their
+    # cascade explicitly.
+    post_delete.connect(cascade_scope_delete, Field)

--- a/enterprise/backend/src/baserow_enterprise/role/seat_usage_calculator.py
+++ b/enterprise/backend/src/baserow_enterprise/role/seat_usage_calculator.py
@@ -14,7 +14,7 @@ from baserow.core.models import (
     WorkspaceUser,
 )
 from baserow_enterprise.role.constants import BUILDER_ROLE_UID, FREE_ROLE_UIDS
-from baserow_enterprise.role.default_roles import seat_usage_role_uids
+from baserow_enterprise.role.default_roles import user_role_uids
 from baserow_enterprise.role.models import RoleAssignment
 from baserow_enterprise.teams.models import Team
 from baserow_premium.license.registries import SeatUsageSummary
@@ -171,7 +171,7 @@ class RoleBasedSeatUsageSummaryCalculator:
         # Always treat custom roles as the highest priority ones to show.
         role_to_priority = defaultdict(lambda: -1)
         num_users_with_highest_role = {}
-        for idx, uid in enumerate(seat_usage_role_uids):
+        for idx, uid in enumerate(user_role_uids):
             role_to_priority[uid] = idx
             num_users_with_highest_role[uid] = 0
 

--- a/enterprise/backend/src/baserow_enterprise/role/seat_usage_calculator.py
+++ b/enterprise/backend/src/baserow_enterprise/role/seat_usage_calculator.py
@@ -14,7 +14,7 @@ from baserow.core.models import (
     WorkspaceUser,
 )
 from baserow_enterprise.role.constants import BUILDER_ROLE_UID, FREE_ROLE_UIDS
-from baserow_enterprise.role.default_roles import default_roles
+from baserow_enterprise.role.default_roles import seat_usage_role_uids
 from baserow_enterprise.role.models import RoleAssignment
 from baserow_enterprise.teams.models import Team
 from baserow_premium.license.registries import SeatUsageSummary
@@ -171,7 +171,7 @@ class RoleBasedSeatUsageSummaryCalculator:
         # Always treat custom roles as the highest priority ones to show.
         role_to_priority = defaultdict(lambda: -1)
         num_users_with_highest_role = {}
-        for idx, uid in enumerate(default_roles.keys()):
+        for idx, uid in enumerate(seat_usage_role_uids):
             role_to_priority[uid] = idx
             num_users_with_highest_role[uid] = 0
 

--- a/enterprise/backend/tests/baserow_enterprise_tests/api/field_permissions/test_field_permissions_actions.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/api/field_permissions/test_field_permissions_actions.py
@@ -12,7 +12,10 @@ from baserow_enterprise.field_permissions.actions import (
     UpdateFieldPermissionsActionType,
 )
 from baserow_enterprise.field_permissions.handler import FieldPermissionsHandler
-from baserow_enterprise.field_permissions.models import FieldPermissionsRoleEnum
+from baserow_enterprise.field_permissions.models import (
+    FieldPermissions,
+    FieldPermissionsRoleEnum,
+)
 from baserow_enterprise.role.handler import RoleAssignmentHandler
 from baserow_enterprise.role.models import Role
 
@@ -73,7 +76,7 @@ def test_can_undo_redo_updating_field_permissions(
     )
 
     original_permissions = FieldPermissionsHandler.get_field_permissions(user, field)
-    assert original_permissions.id is None
+    assert not FieldPermissions.objects.filter(field=field).exists()
     assert original_permissions.role == FieldPermissionsRoleEnum.EDITOR.value
     assert original_permissions.allow_in_forms is True
 

--- a/enterprise/backend/tests/baserow_enterprise_tests/api/field_permissions/test_field_permissions_actions.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/api/field_permissions/test_field_permissions_actions.py
@@ -4,6 +4,7 @@ import pytest
 
 from baserow.contrib.database.action.scopes import TableActionScopeType
 from baserow.core.action.handler import ActionHandler
+from baserow.core.action.models import Action
 from baserow.core.action.registries import action_type_registry
 from baserow.test_utils.helpers import assert_undo_redo_actions_are_valid
 from baserow_enterprise.field_permissions.actions import (
@@ -101,3 +102,60 @@ def test_can_undo_redo_updating_field_permissions(
     )
     assert redone_field_permissions.role == FieldPermissionsRoleEnum.ADMIN.value
     assert redone_field_permissions.allow_in_forms is False
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_can_undo_redo_specific_field_permission_subjects(
+    enterprise_data_fixture, enable_enterprise, synced_roles
+):
+    session_id = "session-id"
+    user = enterprise_data_fixture.create_user(session_id=session_id)
+    first_member = enterprise_data_fixture.create_user()
+    second_member = enterprise_data_fixture.create_user()
+    table = enterprise_data_fixture.create_database_table(name="Car", user=user)
+    workspace = table.database.workspace
+    for member in [first_member, second_member]:
+        enterprise_data_fixture.create_user_workspace(
+            user=member, workspace=workspace, permissions="EDITOR"
+        )
+    field = enterprise_data_fixture.create_text_field(table=table)
+
+    first_subjects = [{"subject_id": first_member.id, "subject_type": "auth.User"}]
+    second_subjects = [{"subject_id": second_member.id, "subject_type": "auth.User"}]
+    FieldPermissionsHandler.update_field_permissions(
+        user, field, FieldPermissionsRoleEnum.CUSTOM, subjects=first_subjects
+    )
+
+    action_type_registry.get_by_type(UpdateFieldPermissionsActionType).do(
+        user,
+        field,
+        role=FieldPermissionsRoleEnum.CUSTOM.value,
+        subjects=second_subjects,
+    )
+    assert (
+        FieldPermissionsHandler._get_field_permission_subject_identifiers(field)
+        == second_subjects
+    )
+    action = Action.objects.filter(type=UpdateFieldPermissionsActionType.type).latest(
+        "id"
+    )
+    assert action.params["original_subjects"] == first_subjects
+    assert action.params["subjects"] == second_subjects
+
+    undone_actions = ActionHandler.undo(
+        user, [TableActionScopeType.value(table_id=table.id)], session_id
+    )
+    assert undone_actions[0].error is None
+    assert (
+        FieldPermissionsHandler._get_field_permission_subject_identifiers(field)
+        == first_subjects
+    )
+
+    ActionHandler.redo(
+        user, [TableActionScopeType.value(table_id=table.id)], session_id
+    )
+    assert (
+        FieldPermissionsHandler._get_field_permission_subject_identifiers(field)
+        == second_subjects
+    )

--- a/enterprise/backend/tests/baserow_enterprise_tests/api/field_permissions/test_field_permissions_handler.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/api/field_permissions/test_field_permissions_handler.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
+from django.core.files.storage import FileSystemStorage
 from django.shortcuts import reverse
 from django.test.utils import override_settings
 
@@ -9,13 +10,21 @@ import pytest
 from pytest_unordered import unordered
 from rest_framework.status import HTTP_200_OK
 
+from baserow.contrib.database.export.handler import ExportHandler
+from baserow.contrib.database.fields.exceptions import FieldNotInTable
 from baserow.contrib.database.fields.models import Field
 from baserow.contrib.database.fields.operations import WriteFieldValuesOperationType
 from baserow.contrib.database.rows.handler import RowHandler
 from baserow.core.exceptions import PermissionDenied
 from baserow.core.handler import CoreHandler
-from baserow_enterprise.field_permissions.handler import FieldPermissionsHandler
-from baserow_enterprise.field_permissions.models import FieldPermissionsRoleEnum
+from baserow_enterprise.field_permissions.handler import (
+    FieldPermissionRead,
+    FieldPermissionsHandler,
+)
+from baserow_enterprise.field_permissions.models import (
+    FieldPermissions,
+    FieldPermissionsRoleEnum,
+)
 from baserow_enterprise.field_permissions.permission_manager import (
     FieldPermissionManagerType,
 )
@@ -49,9 +58,44 @@ def test_only_builder_and_up_can_get_field_permissions(
     )
 
     field_permissions = FieldPermissionsHandler.get_field_permissions(user, field)
+    assert isinstance(field_permissions, FieldPermissionRead)
+    assert not isinstance(field_permissions, FieldPermissions)
     assert field_permissions.field == field
     assert field_permissions.role == "EDITOR"
     assert field_permissions.allow_in_forms is True
+    assert field_permissions.subjects == []
+
+
+@pytest.mark.django_db
+def test_get_field_permissions_reuses_the_loaded_field(
+    enterprise_data_fixture, django_assert_num_queries
+):
+    user = enterprise_data_fixture.create_user()
+    database = enterprise_data_fixture.create_database_application(user=user)
+    table = enterprise_data_fixture.create_database_table(database=database)
+    field = enterprise_data_fixture.create_text_field(table=table)
+    FieldPermissions.objects.create(
+        field=field,
+        role=FieldPermissionsRoleEnum.EDITOR.value,
+        allow_in_forms=True,
+    )
+    persisted_permissions = FieldPermissions.objects.get(field=field)
+    assert "field" not in persisted_permissions._state.fields_cache
+
+    # Resolve the permission-check context before measuring only DTO construction.
+    field.table.database.workspace
+    with (
+        patch.object(CoreHandler, "check_permissions"),
+        patch.object(
+            FieldPermissionsHandler,
+            "_get_field_permissions",
+            return_value=persisted_permissions,
+        ),
+        django_assert_num_queries(0),
+    ):
+        result = FieldPermissionsHandler.get_field_permissions(user, field)
+
+    assert result.field is field
 
 
 @pytest.mark.django_db
@@ -188,7 +232,7 @@ def test_custom_field_permissions_require_selection_and_an_editor_or_higher_role
     assert field.id in write_exceptions_for(selected_viewer)
     assert field.id in write_exceptions_for(admin)
 
-    # The marker assignment must not replace the selected user's ordinary RBAC role.
+    # The marker must not replace the selected user's normal RBAC role.
     roles_by_scope = RoleAssignmentHandler().get_roles_per_scope(
         workspace, selected_editor
     )
@@ -245,6 +289,64 @@ def test_custom_field_subjects_are_resolved_in_two_queries_for_many_actors_and_f
     assert fields_by_actor[directly_selected] == all_field_ids
     assert fields_by_actor[selected_via_team] == all_field_ids
     assert fields_by_actor[unselected] == set()
+
+
+@pytest.mark.django_db
+def test_get_subject_options_returns_searchable_workspace_users_and_teams(
+    enterprise_data_fixture,
+):
+    admin = enterprise_data_fixture.create_user()
+    selected_user = enterprise_data_fixture.create_user(
+        first_name="Selectable user", email="selectable-user@example.com"
+    )
+    outsider = enterprise_data_fixture.create_user(first_name="Selectable outsider")
+    database = enterprise_data_fixture.create_database_application(user=admin)
+    workspace = database.workspace
+    enterprise_data_fixture.create_user_workspace(
+        user=selected_user, workspace=workspace, permissions="EDITOR"
+    )
+    team = enterprise_data_fixture.create_team(
+        name="Selectable team", workspace=workspace, members=[selected_user]
+    )
+
+    options = list(
+        FieldPermissionsHandler.get_subject_options(
+            workspace,
+            search=" selectable ",
+            exclude_user_ids=[],
+            exclude_team_ids=[],
+        )
+    )
+
+    assert {(option["subject_type"], option["subject_id"]) for option in options} == {
+        ("auth.User", selected_user.id),
+        ("baserow_enterprise.Team", team.id),
+    }
+    assert all(option["subject_id"] != outsider.id for option in options)
+    assert (
+        next(
+            option
+            for option in options
+            if option["subject_type"] == "baserow_enterprise.Team"
+        )["subject_count"]
+        == 1
+    )
+
+
+@pytest.mark.django_db
+def test_sync_empty_field_permission_subjects_uses_single_delete_query(
+    enterprise_data_fixture, django_assert_num_queries
+):
+    user = enterprise_data_fixture.create_user()
+    database = enterprise_data_fixture.create_database_application(user=user)
+    table = enterprise_data_fixture.create_database_table(database=database)
+    field = enterprise_data_fixture.create_text_field(table=table)
+    ContentType.objects.get_for_model(Field)
+
+    with django_assert_num_queries(1):
+        subjects = FieldPermissionsHandler._sync_field_permission_subjects(field, [])
+
+    assert subjects == []
 
 
 @pytest.mark.django_db
@@ -359,11 +461,11 @@ def test_cannot_create_or_update_rows_without_proper_permisisons(
             model=model,
         )
 
-    def _import_rows_with_field_value(field, value):
+    def _import_rows_with_values(values):
         return RowHandler().import_rows(
             user=test_user,
             table=table,
-            data=[[value]],
+            data=[values],
             configuration=None,
             validate=False,
         )
@@ -381,7 +483,7 @@ def test_cannot_create_or_update_rows_without_proper_permisisons(
     _update_row_with_field_value(text_field, "editor")
     _create_row_with_field_value(text_field, "editor")
 
-    rows, _ = _import_rows_with_field_value(text_field, "editor")
+    rows, _ = _import_rows_with_values(["editor"])
     assert len(rows) == 1
     assert getattr(rows[0], text_field.db_column) == "editor"
 
@@ -397,10 +499,12 @@ def test_cannot_create_or_update_rows_without_proper_permisisons(
     with pytest.raises(PermissionDenied):
         _create_row_with_field_value(text_field, "builder")
 
-    # Import won't fail, it will just ignore unwritable fields
-    rows, _ = _import_rows_with_field_value(text_field, "builder")
+    # Import treats the unwritable text field like a read-only field and maps the
+    # first value to the remaining writable number field.
+    rows, _ = _import_rows_with_values([10])
     assert len(rows) == 1
     assert getattr(rows[0], text_field.db_column) is None
+    assert getattr(rows[0], number_field.db_column) == 10
 
     # test_user can still edit the number_field
     _update_row_with_field_value(number_field, 1)
@@ -413,7 +517,7 @@ def test_cannot_create_or_update_rows_without_proper_permisisons(
     _update_row_with_field_value(text_field, "builder")
     _create_row_with_field_value(text_field, "builder")
 
-    rows, _ = _import_rows_with_field_value(text_field, "builder")
+    rows, _ = _import_rows_with_values(["builder"])
     assert len(rows) == 1
     assert getattr(rows[0], text_field.db_column) == "builder"
 
@@ -426,9 +530,10 @@ def test_cannot_create_or_update_rows_without_proper_permisisons(
     with pytest.raises(PermissionDenied):
         _create_row_with_field_value(text_field, "admin")
 
-    rows, _ = _import_rows_with_field_value(text_field, "admin")
+    rows, _ = _import_rows_with_values([20])
     assert len(rows) == 1
     assert getattr(rows[0], text_field.db_column) is None
+    assert getattr(rows[0], number_field.db_column) == 20
 
     # they can still edit other fields
     _update_row_with_field_value(number_field, 2)
@@ -440,7 +545,7 @@ def test_cannot_create_or_update_rows_without_proper_permisisons(
     _update_row_with_field_value(text_field, "admin")
     _create_row_with_field_value(text_field, "admin")
 
-    rows, _ = _import_rows_with_field_value(text_field, "admin")
+    rows, _ = _import_rows_with_values(["admin"])
     assert len(rows) == 1
     assert getattr(rows[0], text_field.db_column) == "admin"
 
@@ -453,9 +558,285 @@ def test_cannot_create_or_update_rows_without_proper_permisisons(
     with pytest.raises(PermissionDenied):
         _create_row_with_field_value(text_field, "nobody")
 
-    rows, _ = _import_rows_with_field_value(text_field, "nobody")
+    rows, _ = _import_rows_with_values([30])
     assert len(rows) == 1
     assert getattr(rows[0], text_field.db_column) is None
+    assert getattr(rows[0], number_field.db_column) == 30
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+@pytest.mark.parametrize("use_upsert", [False, True])
+def test_import_rows_excludes_unwritable_fields_from_positional_schema(
+    enterprise_data_fixture, synced_roles, use_upsert
+):
+    admin = enterprise_data_fixture.create_user()
+    importer = enterprise_data_fixture.create_user()
+    workspace = enterprise_data_fixture.create_workspace(users=[admin, importer])
+    database = enterprise_data_fixture.create_database_application(
+        user=admin, workspace=workspace
+    )
+    table = enterprise_data_fixture.create_database_table(database=database)
+    name_field = enterprise_data_fixture.create_text_field(
+        table=table, name="Name", primary=True
+    )
+    notes_field = enterprise_data_fixture.create_long_text_field(
+        table=table, name="Notes"
+    )
+    active_field = enterprise_data_fixture.create_boolean_field(
+        table=table, name="Active"
+    )
+    enterprise_data_fixture.enable_enterprise()
+
+    RoleAssignmentHandler().assign_role(
+        subject=admin,
+        workspace=workspace,
+        role=Role.objects.get(uid="ADMIN"),
+        scope=database,
+    )
+    RoleAssignmentHandler().assign_role(
+        subject=importer,
+        workspace=workspace,
+        role=Role.objects.get(uid="EDITOR"),
+        scope=database,
+    )
+    FieldPermissionsHandler.update_field_permissions(admin, notes_field, "ADMIN")
+
+    model = table.get_model()
+    configuration = {
+        "import_fields": [name_field.id, active_field.id],
+    }
+    if use_upsert:
+        RowHandler().force_create_rows(
+            admin,
+            table,
+            [
+                {
+                    name_field.db_column: "Ada",
+                    notes_field.db_column: "Protected",
+                    active_field.db_column: False,
+                }
+            ],
+            model=model,
+        )
+        configuration.update(
+            {
+                "upsert_fields": [name_field.id],
+                "upsert_values": [["Ada"]],
+            }
+        )
+
+    _, report = RowHandler().import_rows(
+        importer,
+        table,
+        data=[["Ada", True]],
+        configuration=configuration,
+        validate=False,
+    )
+
+    assert report == {}
+    row = model.objects.get()
+    assert getattr(row, name_field.db_column) == "Ada"
+    assert getattr(row, notes_field.db_column) == ("Protected" if use_upsert else None)
+    assert getattr(row, active_field.db_column) is True
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+@pytest.mark.parametrize("permission_revoked_after_snapshot", [False, True])
+def test_import_rows_rejects_unwritable_upsert_fields(
+    enterprise_data_fixture, synced_roles, permission_revoked_after_snapshot
+):
+    admin = enterprise_data_fixture.create_user()
+    importer = enterprise_data_fixture.create_user()
+    workspace = enterprise_data_fixture.create_workspace(users=[admin, importer])
+    database = enterprise_data_fixture.create_database_application(
+        user=admin, workspace=workspace
+    )
+    table = enterprise_data_fixture.create_database_table(database=database)
+    enterprise_data_fixture.create_text_field(table=table, name="Name", primary=True)
+    protected_field = enterprise_data_fixture.create_text_field(
+        table=table, name="Protected"
+    )
+    enterprise_data_fixture.enable_enterprise()
+
+    RoleAssignmentHandler().assign_role(
+        subject=admin,
+        workspace=workspace,
+        role=Role.objects.get(uid="ADMIN"),
+        scope=database,
+    )
+    RoleAssignmentHandler().assign_role(
+        subject=importer,
+        workspace=workspace,
+        role=Role.objects.get(uid="EDITOR"),
+        scope=database,
+    )
+
+    initial_role = "EDITOR" if permission_revoked_after_snapshot else "ADMIN"
+    FieldPermissionsHandler.update_field_permissions(
+        admin, protected_field, initial_role
+    )
+    row_handler = RowHandler()
+    import_field_ids = [
+        field.id for field in row_handler.get_import_fields(importer, table)
+    ]
+
+    if permission_revoked_after_snapshot:
+        assert protected_field.id in import_field_ids
+        FieldPermissionsHandler.update_field_permissions(
+            admin, protected_field, "ADMIN"
+        )
+    else:
+        assert protected_field.id not in import_field_ids
+
+    with pytest.raises(FieldNotInTable):
+        row_handler.import_rows(
+            importer,
+            table,
+            data=[["Ada"] * len(import_field_ids)],
+            configuration={
+                "import_fields": import_field_ids,
+                "upsert_fields": [protected_field.id],
+                "upsert_values": [["Secret"]],
+            },
+            validate=False,
+        )
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+@pytest.mark.parametrize("permission_revoked", [False, True])
+def test_import_rows_preserves_queued_field_positions_when_permissions_change(
+    enterprise_data_fixture, synced_roles, permission_revoked
+):
+    admin = enterprise_data_fixture.create_user()
+    importer = enterprise_data_fixture.create_user()
+    workspace = enterprise_data_fixture.create_workspace(users=[admin, importer])
+    database = enterprise_data_fixture.create_database_application(
+        user=admin, workspace=workspace
+    )
+    table = enterprise_data_fixture.create_database_table(database=database)
+    name_field = enterprise_data_fixture.create_text_field(
+        table=table, name="Name", primary=True
+    )
+    protected_field = enterprise_data_fixture.create_number_field(
+        table=table, name="Protected number"
+    )
+    active_field = enterprise_data_fixture.create_boolean_field(
+        table=table, name="Active"
+    )
+    enterprise_data_fixture.enable_enterprise()
+
+    RoleAssignmentHandler().assign_role(
+        subject=admin,
+        workspace=workspace,
+        role=Role.objects.get(uid="ADMIN"),
+        scope=database,
+    )
+    RoleAssignmentHandler().assign_role(
+        subject=importer,
+        workspace=workspace,
+        role=Role.objects.get(uid="EDITOR"),
+        scope=database,
+    )
+
+    initial_role = "EDITOR" if permission_revoked else "ADMIN"
+    final_role = "ADMIN" if permission_revoked else "EDITOR"
+    FieldPermissionsHandler.update_field_permissions(
+        admin, protected_field, initial_role
+    )
+
+    row_handler = RowHandler()
+    import_field_ids = [
+        field.id for field in row_handler.get_import_fields(importer, table)
+    ]
+    expected_import_field_ids = [name_field.id, active_field.id]
+    data = ["Ada", True]
+    if permission_revoked:
+        expected_import_field_ids.insert(1, protected_field.id)
+        data.insert(1, "Not a number")
+    assert import_field_ids == expected_import_field_ids
+
+    FieldPermissionsHandler.update_field_permissions(admin, protected_field, final_role)
+
+    _, report = row_handler.import_rows(
+        importer,
+        table,
+        data=[data],
+        configuration={"import_fields": import_field_ids},
+        validate=True,
+    )
+
+    assert report == {}
+    row = table.get_model().objects.get()
+    assert getattr(row, name_field.db_column) == "Ada"
+    assert getattr(row, protected_field.db_column) is None
+    assert getattr(row, active_field.db_column) is True
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_unwritable_field_values_can_still_be_exported(
+    enterprise_data_fixture, synced_roles, tmp_path
+):
+    admin = enterprise_data_fixture.create_user()
+    exporter = enterprise_data_fixture.create_user()
+    workspace = enterprise_data_fixture.create_workspace(users=[admin, exporter])
+    database = enterprise_data_fixture.create_database_application(
+        user=admin, workspace=workspace
+    )
+    table = enterprise_data_fixture.create_database_table(database=database)
+    name_field = enterprise_data_fixture.create_text_field(
+        table=table, name="Name", primary=True
+    )
+    notes_field = enterprise_data_fixture.create_long_text_field(
+        table=table, name="Notes"
+    )
+    enterprise_data_fixture.enable_enterprise()
+
+    RoleAssignmentHandler().assign_role(
+        subject=admin,
+        workspace=workspace,
+        role=Role.objects.get(uid="ADMIN"),
+        scope=database,
+    )
+    RoleAssignmentHandler().assign_role(
+        subject=exporter,
+        workspace=workspace,
+        role=Role.objects.get(uid="EDITOR"),
+        scope=database,
+    )
+
+    model = table.get_model()
+    RowHandler().force_create_rows(
+        admin,
+        table,
+        [
+            {
+                name_field.db_column: "Ada",
+                notes_field.db_column: "Protected",
+            }
+        ],
+        model=model,
+    )
+    FieldPermissionsHandler.update_field_permissions(admin, notes_field, "ADMIN")
+
+    storage = FileSystemStorage(location=tmp_path)
+    with patch("baserow.core.storage.get_default_storage", return_value=storage):
+        export_handler = ExportHandler()
+        job = export_handler.create_pending_export_job(
+            exporter,
+            table,
+            None,
+            {"exporter_type": "csv", "export_charset": "utf-8"},
+        )
+        export_handler.run_export_job(job)
+        export_path = ExportHandler.export_file_path(job.exported_file_name)
+        with storage.open(export_path, "rb") as exported_file:
+            contents = exported_file.read().decode("utf-8")
+
+    assert contents == "\ufeffid,Name,Notes\r\n1,Ada,Protected\r\n"
 
 
 @pytest.mark.django_db
@@ -590,11 +971,11 @@ def test_if_license_expires_field_permissions_are_ignored(
             model=model,
         )
 
-    def _import_rows_with_field_value(field, value):
+    def _import_rows_with_values(values):
         return RowHandler().import_rows(
             user=user,
             table=table,
-            data=[[value]],
+            data=[values],
             configuration=None,
             validate=False,
         )
@@ -607,7 +988,7 @@ def test_if_license_expires_field_permissions_are_ignored(
     with pytest.raises(PermissionDenied):
         _create_row_with_field_value(text_field, "nobody")
 
-    rows, _ = _import_rows_with_field_value(text_field, "nobody")
+    rows, _ = _import_rows_with_values([])
     assert len(rows) == 1
     assert getattr(rows[0], text_field.db_column) is None
 
@@ -616,6 +997,6 @@ def test_if_license_expires_field_permissions_are_ignored(
     _update_row_with_field_value(text_field, "nobody")
     _create_row_with_field_value(text_field, "nobody")
 
-    rows, _ = _import_rows_with_field_value(text_field, "nobody")
+    rows, _ = _import_rows_with_values(["nobody"])
     assert len(rows) == 1
     assert getattr(rows[0], text_field.db_column) == "nobody"

--- a/enterprise/backend/tests/baserow_enterprise_tests/api/field_permissions/test_field_permissions_handler.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/api/field_permissions/test_field_permissions_handler.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import reverse
 from django.test.utils import override_settings
 
@@ -7,12 +9,19 @@ import pytest
 from pytest_unordered import unordered
 from rest_framework.status import HTTP_200_OK
 
+from baserow.contrib.database.fields.models import Field
+from baserow.contrib.database.fields.operations import WriteFieldValuesOperationType
 from baserow.contrib.database.rows.handler import RowHandler
 from baserow.core.exceptions import PermissionDenied
+from baserow.core.handler import CoreHandler
 from baserow_enterprise.field_permissions.handler import FieldPermissionsHandler
 from baserow_enterprise.field_permissions.models import FieldPermissionsRoleEnum
+from baserow_enterprise.field_permissions.permission_manager import (
+    FieldPermissionManagerType,
+)
 from baserow_enterprise.role.handler import RoleAssignmentHandler
-from baserow_enterprise.role.models import Role
+from baserow_enterprise.role.models import Role, RoleAssignment
+from baserow_enterprise.teams.models import Team
 
 
 @pytest.mark.django_db
@@ -84,6 +93,184 @@ def test_only_builder_and_up_can_update_field_permissions(
     assert field_permissions.role == "NOBODY"
     assert field_permissions.allow_in_forms is False
     assert field_permissions.can_write_values is False
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_custom_field_permissions_require_selection_and_an_editor_or_higher_role(
+    enterprise_data_fixture, synced_roles
+):
+    admin = enterprise_data_fixture.create_user()
+    selected_editor = enterprise_data_fixture.create_user()
+    unselected_editor = enterprise_data_fixture.create_user()
+    selected_viewer = enterprise_data_fixture.create_user()
+    selected_team_member = enterprise_data_fixture.create_user()
+    database = enterprise_data_fixture.create_database_application(user=admin)
+    workspace = database.workspace
+    for workspace_user in [
+        selected_editor,
+        unselected_editor,
+        selected_viewer,
+        selected_team_member,
+    ]:
+        enterprise_data_fixture.create_user_workspace(
+            user=workspace_user, workspace=workspace, permissions="EDITOR"
+        )
+
+    table = enterprise_data_fixture.create_database_table(database=database)
+    field = enterprise_data_fixture.create_text_field(table=table)
+    team = enterprise_data_fixture.create_team(
+        workspace=workspace, members=[selected_team_member]
+    )
+    enterprise_data_fixture.enable_enterprise()
+
+    editor_role = Role.objects.get(uid="EDITOR")
+    viewer_role = Role.objects.get(uid="VIEWER")
+    for editor in [selected_editor, unselected_editor, selected_team_member]:
+        RoleAssignmentHandler().assign_role(
+            editor, workspace, editor_role, scope=database
+        )
+    RoleAssignmentHandler().assign_role(
+        selected_viewer, workspace, viewer_role, scope=database
+    )
+
+    FieldPermissionsHandler.update_field_permissions(
+        admin,
+        field,
+        FieldPermissionsRoleEnum.CUSTOM,
+        subjects=[
+            {"subject_id": selected_editor.id, "subject_type": "auth.User"},
+            {"subject_id": selected_viewer.id, "subject_type": "auth.User"},
+            {
+                "subject_id": team.id,
+                "subject_type": "baserow_enterprise.Team",
+            },
+        ],
+    )
+
+    def assert_can_write(user, expected):
+        if expected:
+            assert CoreHandler().check_permissions(
+                user,
+                WriteFieldValuesOperationType.type,
+                context=field,
+                workspace=workspace,
+            )
+        else:
+            with pytest.raises(PermissionDenied):
+                CoreHandler().check_permissions(
+                    user,
+                    WriteFieldValuesOperationType.type,
+                    context=field,
+                    workspace=workspace,
+                )
+
+    assert_can_write(selected_editor, True)
+    assert_can_write(selected_team_member, True)
+    assert_can_write(unselected_editor, False)
+    assert_can_write(selected_viewer, False)
+    assert_can_write(admin, False)
+
+    def write_exceptions_for(user):
+        permissions = CoreHandler().get_permissions(user, workspace=workspace)
+        field_manager = next(
+            manager
+            for manager in permissions
+            if manager["name"] == FieldPermissionManagerType.type
+        )
+        return field_manager["permissions"][WriteFieldValuesOperationType.type][
+            "exceptions"
+        ]
+
+    assert field.id not in write_exceptions_for(selected_editor)
+    assert field.id not in write_exceptions_for(selected_team_member)
+    assert field.id in write_exceptions_for(unselected_editor)
+    assert field.id in write_exceptions_for(selected_viewer)
+    assert field.id in write_exceptions_for(admin)
+
+    # The marker assignment must not replace the selected user's ordinary RBAC role.
+    roles_by_scope = RoleAssignmentHandler().get_roles_per_scope(
+        workspace, selected_editor
+    )
+    assert [
+        role.uid
+        for role in RoleAssignmentHandler().get_computed_roles(roles_by_scope, field)
+    ] == ["EDITOR"]
+
+    # Switching away from CUSTOM clears the selected subjects.
+    FieldPermissionsHandler.update_field_permissions(admin, field, "EDITOR")
+    assert FieldPermissionsHandler._get_field_permission_subjects(field) == []
+    assert_can_write(selected_editor, True)
+    assert_can_write(unselected_editor, True)
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_custom_field_subjects_are_resolved_in_two_queries_for_many_actors_and_fields(
+    enterprise_data_fixture, synced_roles, django_assert_num_queries
+):
+    admin = enterprise_data_fixture.create_user()
+    directly_selected = enterprise_data_fixture.create_user()
+    selected_via_team = enterprise_data_fixture.create_user()
+    unselected = enterprise_data_fixture.create_user()
+    database = enterprise_data_fixture.create_database_application(user=admin)
+    workspace = database.workspace
+    for member in [directly_selected, selected_via_team, unselected]:
+        enterprise_data_fixture.create_user_workspace(
+            user=member, workspace=workspace, permissions="EDITOR"
+        )
+
+    table = enterprise_data_fixture.create_database_table(database=database)
+    fields = [enterprise_data_fixture.create_text_field(table=table) for _ in range(5)]
+    team = enterprise_data_fixture.create_team(
+        workspace=workspace, members=[selected_via_team]
+    )
+    subjects = [
+        {"subject_id": directly_selected.id, "subject_type": "auth.User"},
+        {"subject_id": team.id, "subject_type": "baserow_enterprise.Team"},
+    ]
+    for field in fields:
+        FieldPermissionsHandler._sync_field_permission_subjects(field, subjects)
+
+    ContentType.objects.get_for_models(get_user_model(), Team, Field)
+    manager = FieldPermissionManagerType()
+    actors = [directly_selected, selected_via_team, unselected]
+
+    with django_assert_num_queries(2):
+        fields_by_actor = manager._get_custom_field_ids_by_actor(
+            workspace, actors, {field.id for field in fields}
+        )
+
+    all_field_ids = {field.id for field in fields}
+    assert fields_by_actor[directly_selected] == all_field_ids
+    assert fields_by_actor[selected_via_team] == all_field_ids
+    assert fields_by_actor[unselected] == set()
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_deleting_field_cascades_to_custom_field_subject_assignments(
+    enterprise_data_fixture, synced_roles
+):
+    admin = enterprise_data_fixture.create_user()
+    selected_user = enterprise_data_fixture.create_user()
+    database = enterprise_data_fixture.create_database_application(user=admin)
+    workspace = database.workspace
+    enterprise_data_fixture.create_user_workspace(
+        user=selected_user, workspace=workspace, permissions="EDITOR"
+    )
+    table = enterprise_data_fixture.create_database_table(database=database)
+    field = enterprise_data_fixture.create_text_field(table=table)
+
+    FieldPermissionsHandler._sync_field_permission_subjects(
+        field,
+        [{"subject_id": selected_user.id, "subject_type": "auth.User"}],
+    )
+    assert RoleAssignment.objects.filter(scope_id=field.id).exists()
+
+    field.delete()
+
+    assert not RoleAssignment.objects.filter(scope_id=field.id).exists()
 
 
 @pytest.mark.django_db(transaction=True)

--- a/enterprise/backend/tests/baserow_enterprise_tests/api/field_permissions/test_field_permissions_views.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/api/field_permissions/test_field_permissions_views.py
@@ -474,6 +474,9 @@ def test_can_search_paginated_field_permission_subject_options(
         workspace=workspace,
         members=[first_user, second_user],
     )
+    enterprise_data_fixture.create_team(
+        name="Person trashed team", workspace=workspace, trashed=True
+    )
     table = enterprise_data_fixture.create_database_table(database=database)
     field = enterprise_data_fixture.create_text_field(table=table)
     enterprise_data_fixture.enable_enterprise()

--- a/enterprise/backend/tests/baserow_enterprise_tests/api/field_permissions/test_field_permissions_views.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/api/field_permissions/test_field_permissions_views.py
@@ -154,7 +154,7 @@ def test_cannot_update_field_permissions(api_client, enterprise_data_fixture):
 
     assert rsp.status_code == HTTP_401_UNAUTHORIZED
 
-    # Custom role not working (it needs to be implemented)
+    # CUSTOM is valid and starts with an empty subject list when none is provided.
     builder_role = Role.objects.get(uid="BUILDER")
     RoleAssignmentHandler().assign_role(
         subject=user, workspace=database.workspace, role=builder_role, scope=database
@@ -170,7 +170,9 @@ def test_cannot_update_field_permissions(api_client, enterprise_data_fixture):
         data={"role": "CUSTOM"},
     )
 
-    assert rsp.status_code == HTTP_400_BAD_REQUEST
+    assert rsp.status_code == HTTP_200_OK
+    assert rsp.json()["role"] == "CUSTOM"
+    assert rsp.json()["subjects"] == []
 
     rsp = api_client.patch(
         reverse(
@@ -217,6 +219,7 @@ def test_builders_can_get_field_permissions(api_client, enterprise_data_fixture)
         "field_id": field.id,
         "role": "EDITOR",
         "allow_in_forms": True,
+        "subjects": [],
     }
 
     FieldPermissionsHandler.update_field_permissions(user, field, "NOBODY", False)
@@ -234,6 +237,7 @@ def test_builders_can_get_field_permissions(api_client, enterprise_data_fixture)
         "field_id": field.id,
         "role": "NOBODY",
         "allow_in_forms": False,
+        "subjects": [],
     }
 
 
@@ -292,6 +296,7 @@ def test_builders_can_update_field_permissions(api_client, enterprise_data_fixtu
         "role": "NOBODY",
         "allow_in_forms": False,
         "can_write_values": False,
+        "subjects": [],
     }
     _assert_field_permissions_exceptions(
         can_write_exc=[field.id], allow_in_forms_exc=[field.id]
@@ -313,6 +318,7 @@ def test_builders_can_update_field_permissions(api_client, enterprise_data_fixtu
         "role": "ADMIN",
         "allow_in_forms": True,
         "can_write_values": False,
+        "subjects": [],
     }
     _assert_field_permissions_exceptions(
         can_write_exc=[field.id], allow_in_forms_exc=[]
@@ -334,6 +340,7 @@ def test_builders_can_update_field_permissions(api_client, enterprise_data_fixtu
         "role": "BUILDER",
         "allow_in_forms": True,
         "can_write_values": True,
+        "subjects": [],
     }
     _assert_field_permissions_exceptions(can_write_exc=[], allow_in_forms_exc=[])
 
@@ -354,6 +361,229 @@ def test_builders_can_update_field_permissions(api_client, enterprise_data_fixtu
         "role": "EDITOR",
         "allow_in_forms": True,
         "can_write_values": True,
+        "subjects": [],
     }
     assert FieldPermissions.objects.count() == 0
     _assert_field_permissions_exceptions(can_write_exc=[], allow_in_forms_exc=[])
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_can_configure_specific_field_permission_users_and_teams(
+    api_client, enterprise_data_fixture, synced_roles
+):
+    user, token = enterprise_data_fixture.create_user_and_token(first_name="Builder")
+    selected_user = enterprise_data_fixture.create_user(first_name="Ada")
+    database = enterprise_data_fixture.create_database_application(user=user)
+    workspace = database.workspace
+    enterprise_data_fixture.create_user_workspace(
+        user=selected_user, workspace=workspace, permissions="EDITOR"
+    )
+    team = enterprise_data_fixture.create_team(
+        name="Development", workspace=workspace, members=[selected_user]
+    )
+    table = enterprise_data_fixture.create_database_table(database=database)
+    field = enterprise_data_fixture.create_text_field(table=table)
+    enterprise_data_fixture.enable_enterprise()
+
+    url = reverse(
+        "api:enterprise:field_permissions:item", kwargs={"field_id": field.id}
+    )
+    subjects = [
+        {"subject_id": user.id, "subject_type": "auth.User"},
+        {
+            "subject_id": team.id,
+            "subject_type": "baserow_enterprise.Team",
+        },
+    ]
+    rsp = api_client.patch(
+        url,
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+        data={"role": "CUSTOM", "subjects": subjects},
+    )
+
+    assert rsp.status_code == HTTP_200_OK
+    assert rsp.json()["role"] == "CUSTOM"
+    assert rsp.json()["can_write_values"] is True
+    assert {
+        (subject["subject_type"], subject["subject_id"])
+        for subject in rsp.json()["subjects"]
+    } == {
+        ("auth.User", user.id),
+        ("baserow_enterprise.Team", team.id),
+    }
+    team_subject = next(
+        subject
+        for subject in rsp.json()["subjects"]
+        if subject["subject_type"] == "baserow_enterprise.Team"
+    )
+    assert team_subject["subject"]["name"] == "Development"
+
+    rsp = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {token}")
+    assert rsp.status_code == HTTP_200_OK
+    assert len(rsp.json()["subjects"]) == 2
+
+    # Updating another CUSTOM setting without sending subjects preserves the list.
+    rsp = api_client.patch(
+        url,
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+        data={"role": "CUSTOM", "allow_in_forms": True},
+    )
+    assert rsp.status_code == HTTP_200_OK
+    assert rsp.json()["allow_in_forms"] is True
+    assert len(rsp.json()["subjects"]) == 2
+
+    # Removing the requester from the explicit list immediately removes their write
+    # permission, even though they remain an Admin in the workspace.
+    rsp = api_client.patch(
+        url,
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+        data={"role": "CUSTOM", "subjects": [subjects[1]]},
+    )
+    assert rsp.status_code == HTTP_200_OK
+    assert rsp.json()["can_write_values"] is False
+    assert len(rsp.json()["subjects"]) == 1
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_can_search_paginated_field_permission_subject_options(
+    api_client, enterprise_data_fixture, synced_roles
+):
+    user, token = enterprise_data_fixture.create_user_and_token(
+        first_name="Builder", email="builder@else.test"
+    )
+    first_user = enterprise_data_fixture.create_user(
+        first_name="Person A", email="first@else.test"
+    )
+    second_user = enterprise_data_fixture.create_user(
+        first_name="Person B", email="second@else.test"
+    )
+    outsider = enterprise_data_fixture.create_user(first_name="Person Outside")
+    database = enterprise_data_fixture.create_database_application(user=user)
+    workspace = database.workspace
+    for member in [first_user, second_user]:
+        enterprise_data_fixture.create_user_workspace(
+            user=member, workspace=workspace, permissions="EDITOR"
+        )
+    team = enterprise_data_fixture.create_team(
+        name="Person team",
+        workspace=workspace,
+        members=[first_user, second_user],
+    )
+    table = enterprise_data_fixture.create_database_table(database=database)
+    field = enterprise_data_fixture.create_text_field(table=table)
+    enterprise_data_fixture.enable_enterprise()
+    builder_role = Role.objects.get(uid="BUILDER")
+    RoleAssignmentHandler().assign_role(
+        subject=user,
+        workspace=workspace,
+        role=builder_role,
+        scope=database,
+    )
+    url = reverse(
+        "api:enterprise:field_permissions:subject_options",
+        kwargs={"field_id": field.id},
+    )
+
+    first_page = api_client.get(
+        url,
+        {"search": "person", "page": 1, "size": 2},
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    second_page = api_client.get(
+        url,
+        {"search": "person", "page": 2, "size": 2},
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert first_page.status_code == HTTP_200_OK
+    assert second_page.status_code == HTTP_200_OK
+    assert first_page.json()["count"] == 3
+    assert len(first_page.json()["results"]) == 2
+    options = first_page.json()["results"] + second_page.json()["results"]
+    assert {(option["subject_type"], option["subject_id"]) for option in options} == {
+        ("auth.User", first_user.id),
+        ("auth.User", second_user.id),
+        ("baserow_enterprise.Team", team.id),
+    }
+    team_option = next(
+        option
+        for option in options
+        if option["subject_type"] == "baserow_enterprise.Team"
+    )
+    assert team_option["subject_count"] == 2
+    assert all(option["subject_id"] != outsider.id for option in options)
+
+    response = api_client.get(
+        url,
+        {
+            "search": "person",
+            "exclude_user_ids": str(first_user.id),
+            "exclude_team_ids": str(team.id),
+        },
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    assert response.status_code == HTTP_200_OK
+    assert response.json()["count"] == 1
+    assert response.json()["results"][0]["subject_id"] == second_user.id
+    assert response.json()["results"][0]["subject_type"] == "auth.User"
+
+    editor_role = Role.objects.get(uid="EDITOR")
+    RoleAssignmentHandler().assign_role(
+        subject=user,
+        workspace=workspace,
+        role=editor_role,
+        scope=database,
+    )
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {token}")
+    assert response.status_code == HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_cannot_add_invalid_specific_field_permission_subjects(
+    api_client, enterprise_data_fixture, synced_roles
+):
+    user, token = enterprise_data_fixture.create_user_and_token()
+    outsider = enterprise_data_fixture.create_user()
+    database = enterprise_data_fixture.create_database_application(user=user)
+    table = enterprise_data_fixture.create_database_table(database=database)
+    field = enterprise_data_fixture.create_text_field(table=table)
+    enterprise_data_fixture.enable_enterprise()
+    url = reverse(
+        "api:enterprise:field_permissions:item", kwargs={"field_id": field.id}
+    )
+
+    rsp = api_client.patch(
+        url,
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+        data={
+            "role": "CUSTOM",
+            "subjects": [{"subject_id": outsider.id, "subject_type": "auth.User"}],
+        },
+    )
+    assert rsp.status_code == HTTP_404_NOT_FOUND
+    assert not FieldPermissions.objects.filter(field=field).exists()
+    assert FieldPermissionsHandler._get_field_permission_subjects(field) == []
+
+    duplicate = {"subject_id": user.id, "subject_type": "auth.User"}
+    rsp = api_client.patch(
+        url,
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+        data={"role": "CUSTOM", "subjects": [duplicate, duplicate]},
+    )
+    assert rsp.status_code == HTTP_400_BAD_REQUEST
+
+    rsp = api_client.patch(
+        url,
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+        data={"role": "NOBODY", "subjects": [duplicate]},
+    )
+    assert rsp.status_code == HTTP_400_BAD_REQUEST

--- a/enterprise/backend/tests/baserow_enterprise_tests/enterprise/test_enterprise_license.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/enterprise/test_enterprise_license.py
@@ -23,7 +23,7 @@ from baserow.core.trash.handler import TrashHandler
 from baserow.core.user_files.handler import UserFileHandler
 from baserow_enterprise.features import ENTERPRISE_SETTINGS, RBAC, SSO
 from baserow_enterprise.license_types import EnterpriseLicenseType
-from baserow_enterprise.role.default_roles import default_roles
+from baserow_enterprise.role.default_roles import seat_usage_role_uids
 from baserow_enterprise.role.handler import RoleAssignmentHandler
 from baserow_enterprise.role.models import Role, RoleAssignment
 from baserow_enterprise.role.seat_usage_calculator import (
@@ -1885,7 +1885,7 @@ def test_order_of_roles_is_as_expected(
         "BUILDER",
         "ADMIN",
     ]
-    assert set(expected_role_order) == set(default_roles.keys())
+    assert set(expected_role_order) == set(seat_usage_role_uids)
     for idx, uid in enumerate(expected_role_order):
         table = data_fixture.create_database_table(
             name=f"table{idx}", database=database

--- a/enterprise/backend/tests/baserow_enterprise_tests/enterprise/test_enterprise_license.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/enterprise/test_enterprise_license.py
@@ -23,7 +23,7 @@ from baserow.core.trash.handler import TrashHandler
 from baserow.core.user_files.handler import UserFileHandler
 from baserow_enterprise.features import ENTERPRISE_SETTINGS, RBAC, SSO
 from baserow_enterprise.license_types import EnterpriseLicenseType
-from baserow_enterprise.role.default_roles import seat_usage_role_uids
+from baserow_enterprise.role.default_roles import user_role_uids
 from baserow_enterprise.role.handler import RoleAssignmentHandler
 from baserow_enterprise.role.models import Role, RoleAssignment
 from baserow_enterprise.role.seat_usage_calculator import (
@@ -1885,7 +1885,7 @@ def test_order_of_roles_is_as_expected(
         "BUILDER",
         "ADMIN",
     ]
-    assert set(expected_role_order) == set(seat_usage_role_uids)
+    assert set(expected_role_order) == set(user_role_uids)
     for idx, uid in enumerate(expected_role_order):
         table = data_fixture.create_database_table(
             name=f"table{idx}", database=database

--- a/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/all.scss
+++ b/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/all.scss
@@ -28,3 +28,4 @@
 @import 'date_dependency';
 @import 'data_scanner';
 @import 'restricted_view_filter_context';
+@import 'field_permissions';

--- a/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/field_permissions.scss
+++ b/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/field_permissions.scss
@@ -1,0 +1,137 @@
+.field-permission-subjects {
+  padding-top: 16px;
+  border-top: 1px solid $palette-neutral-200;
+}
+
+.field-permission-subjects__section {
+  h3 {
+    margin: 0 0 12px;
+    font-size: 14px;
+    font-weight: 600;
+  }
+}
+
+.field-permission-subjects__section-heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+
+  h3 {
+    margin-bottom: 0;
+  }
+}
+
+.field-permission-subjects__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 7px;
+  border-radius: 12px;
+  background: $palette-neutral-100;
+  color: $palette-neutral-700;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.field-permission-subjects__list {
+  max-height: 224px;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  border: 1px solid $palette-neutral-200;
+  border-radius: 8px;
+  list-style: none;
+}
+
+.field-permission-subjects__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 64px;
+  padding: 10px 12px;
+
+  & + & {
+    border-top: 1px solid $palette-neutral-200;
+  }
+}
+
+.field-permission-subjects__identity {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 12px;
+
+  small {
+    display: block;
+    margin-top: 2px;
+    overflow: hidden;
+    color: $palette-neutral-700;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.field-permission-subjects__dropdown-option {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  width: 100%;
+  gap: 10px;
+
+  small {
+    display: block;
+    margin-top: 2px;
+    overflow: hidden;
+    color: $palette-neutral-700;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 16px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.field-permission-subjects__details {
+  min-width: 0;
+}
+
+.field-permission-subjects__label {
+  display: block;
+  overflow: hidden;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.field-permission-subjects__team-icon {
+  display: flex;
+  flex: 0 0 32px;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: $palette-neutral-100;
+  color: $palette-neutral-700;
+  font-size: 16px;
+}
+
+.field-permission-subjects__team-icon--dropdown {
+  flex-basis: 32px;
+}
+
+.field-permission-subjects__empty {
+  display: flex;
+  min-height: 72px;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  color: $palette-neutral-700;
+  text-align: center;
+}

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/fieldPermissions/FieldPermissionSubjectDropdownItem.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/fieldPermissions/FieldPermissionSubjectDropdownItem.vue
@@ -1,0 +1,72 @@
+<template>
+  <li
+    v-if="visible"
+    class="select__item select__item--no-options"
+    :class="{
+      hidden: !isVisible(query),
+      visible: isVisible(query),
+      active: isActive(value),
+      disabled,
+      hover: isHovering(value),
+    }"
+    role="listitem"
+  >
+    <a
+      class="select__item-link"
+      @click="select(value, disabled)"
+      @mousemove="hover(value, disabled)"
+    >
+      <div class="select__item-name">
+        <div class="field-permission-subjects__dropdown-option">
+          <Avatar
+            v-if="result.subjectType === userSubjectType"
+            rounded
+            size="large"
+            :initials="nameAbbreviation(result.label)"
+          ></Avatar>
+          <span
+            v-else
+            class="field-permission-subjects__team-icon field-permission-subjects__team-icon--dropdown"
+          >
+            <i class="iconoir-group"></i>
+          </span>
+          <span class="field-permission-subjects__details">
+            <span class="field-permission-subjects__label">
+              {{ result.label }}
+            </span>
+            <small v-if="result.description">
+              {{ result.description }}
+            </small>
+          </span>
+        </div>
+      </div>
+    </a>
+    <i class="select__item-active-icon iconoir-check"></i>
+  </li>
+</template>
+
+<script>
+import nameAbbreviation from '@baserow/modules/core/filters/nameAbbreviation'
+import dropdownItem from '@baserow/modules/core/mixins/dropdownItem'
+
+const USER_SUBJECT_TYPE = 'auth.User'
+
+export default {
+  name: 'FieldPermissionSubjectDropdownItem',
+  mixins: [dropdownItem],
+  props: {
+    result: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      userSubjectType: USER_SUBJECT_TYPE,
+    }
+  },
+  methods: {
+    nameAbbreviation,
+  },
+}
+</script>

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/fieldPermissions/FieldPermissionSubjectsSelector.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/fieldPermissions/FieldPermissionSubjectsSelector.vue
@@ -1,0 +1,239 @@
+<template>
+  <div class="field-permission-subjects margin-top-2">
+    <Alert type="info-neutral" class="margin-bottom-2">
+      <p>{{ $t('fieldPermissionSubjectsSelector.accessNote') }}</p>
+    </Alert>
+
+    <section class="field-permission-subjects__section">
+      <h3>{{ $t('fieldPermissionSubjectsSelector.addPeopleOrTeams') }}</h3>
+      <PaginatedDropdown
+        ref="subjectDropdown"
+        :value="null"
+        :fetch-page="fetchSubjectOptions"
+        :value-name="getOptionDisplayName"
+        :result-item-component="fieldPermissionSubjectDropdownItem"
+        id-name="key"
+        size="large"
+        :fixed-items="true"
+        :fetch-on-open="true"
+        :add-empty-item="false"
+        :include-display-name-in-selected-event="true"
+        :not-selected-text="
+          $t('fieldPermissionSubjectsSelector.searchPlaceholder')
+        "
+        :search-text="$t('fieldPermissionSubjectsSelector.searchHint')"
+        @input="addSubjectFromDropdown"
+      />
+    </section>
+
+    <section class="field-permission-subjects__section margin-top-3">
+      <div class="field-permission-subjects__section-heading">
+        <h3>{{ $t('fieldPermissionSubjectsSelector.canEdit') }}</h3>
+        <span class="field-permission-subjects__count">
+          {{ selectedSubjects.length }}
+        </span>
+      </div>
+
+      <div
+        v-if="selectedSubjects.length === 0"
+        class="field-permission-subjects__empty"
+      >
+        {{ $t('fieldPermissionSubjectsSelector.noSelectedSubjects') }}
+      </div>
+      <ul v-else class="field-permission-subjects__list">
+        <li
+          v-for="subject in selectedSubjects"
+          :key="subject.key"
+          class="field-permission-subjects__item"
+        >
+          <div class="field-permission-subjects__identity">
+            <Avatar
+              v-if="subject.subjectType === userSubjectType"
+              rounded
+              size="large"
+              :initials="nameAbbreviation(subject.label)"
+            ></Avatar>
+            <span v-else class="field-permission-subjects__team-icon">
+              <i class="iconoir-group"></i>
+            </span>
+            <span class="field-permission-subjects__details">
+              <span class="field-permission-subjects__label">
+                {{ subject.label }}
+              </span>
+              <small v-if="subject.description">{{
+                subject.description
+              }}</small>
+            </span>
+          </div>
+          <ButtonIcon
+            size="small"
+            icon="iconoir-cancel"
+            :aria-label="
+              $t('fieldPermissionSubjectsSelector.remove', {
+                subject: subject.label,
+              })
+            "
+            @click="removeSubject(subject)"
+          />
+        </li>
+      </ul>
+    </section>
+  </div>
+</template>
+
+<script>
+import { markRaw } from 'vue'
+
+import nameAbbreviation from '@baserow/modules/core/filters/nameAbbreviation'
+import PaginatedDropdown from '@baserow/modules/core/components/PaginatedDropdown'
+import FieldPermissionSubjectDropdownItem from '@baserow_enterprise/components/fieldPermissions/FieldPermissionSubjectDropdownItem'
+import FieldPermissionService from '@baserow_enterprise/services/fieldPermissions'
+
+const USER_SUBJECT_TYPE = 'auth.User'
+const TEAM_SUBJECT_TYPE = 'baserow_enterprise.Team'
+
+export default {
+  name: 'FieldPermissionSubjectsSelector',
+  components: { PaginatedDropdown },
+  props: {
+    fieldId: {
+      type: Number,
+      required: true,
+    },
+    subjects: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  emits: ['selection-change'],
+  data() {
+    return {
+      pageSize: 20,
+      selectedSubjects: [],
+      userSubjectType: USER_SUBJECT_TYPE,
+      fieldPermissionSubjectDropdownItem: markRaw(
+        FieldPermissionSubjectDropdownItem
+      ),
+    }
+  },
+  computed: {
+    selectedKeys() {
+      return new Set(this.selectedSubjects.map(({ key }) => key))
+    },
+    selectedUserIds() {
+      return this.selectedSubjects
+        .filter(({ subjectType }) => subjectType === USER_SUBJECT_TYPE)
+        .map(({ subjectId }) => subjectId)
+    },
+    selectedTeamIds() {
+      return this.selectedSubjects
+        .filter(({ subjectType }) => subjectType === TEAM_SUBJECT_TYPE)
+        .map(({ subjectId }) => subjectId)
+    },
+  },
+  watch: {
+    subjects: {
+      handler() {
+        this.reset()
+      },
+      deep: true,
+      immediate: true,
+    },
+  },
+  methods: {
+    reset() {
+      this.selectedSubjects = this.subjects.map(this.normalizeAssignment)
+      this.emitSelectionChange()
+      this.resetSubjectDropdown()
+    },
+    resetSubjectDropdown() {
+      this.$nextTick(() => this.$refs.subjectDropdown?.reset())
+    },
+    subjectKey(subjectType, subjectId) {
+      return `${subjectType}:${subjectId}`
+    },
+    normalizeAssignment(assignment) {
+      const subject = assignment.subject
+      const isUser = assignment.subject_type === USER_SUBJECT_TYPE
+      const label = isUser
+        ? subject.first_name || subject.username || subject.email
+        : subject.name
+      return {
+        key: this.subjectKey(assignment.subject_type, assignment.subject_id),
+        subjectId: assignment.subject_id,
+        subjectType: assignment.subject_type,
+        label,
+        description: isUser
+          ? null
+          : this.$t('fieldPermissionSubjectsSelector.teamDescription'),
+      }
+    },
+    normalizeOption(option) {
+      const isUser = option.subject_type === USER_SUBJECT_TYPE
+      return {
+        key: this.subjectKey(option.subject_type, option.subject_id),
+        subjectId: option.subject_id,
+        subjectType: option.subject_type,
+        label: option.name,
+        searchText: option.email || '',
+        description: isUser
+          ? null
+          : this.$t('fieldPermissionSubjectsSelector.teamSearchDescription', {
+              count: option.subject_count,
+            }),
+      }
+    },
+    getOptionDisplayName(subject) {
+      return [subject.label, subject.searchText].filter(Boolean).join(' ')
+    },
+    async fetchSubjectOptions(page, search) {
+      const normalizedSearch = (search || '').trim()
+      const response = await FieldPermissionService(
+        this.$client
+      ).fetchSubjectOptions(this.fieldId, {
+        page,
+        size: this.pageSize,
+        search: normalizedSearch,
+        exclude_user_ids: this.selectedUserIds.join(','),
+        exclude_team_ids: this.selectedTeamIds.join(','),
+      })
+      return {
+        ...response,
+        data: {
+          ...response.data,
+          results: response.data.results.map(this.normalizeOption),
+        },
+      }
+    },
+    addSubjectFromDropdown(selection) {
+      if (selection?.item) {
+        this.addSubject(selection.item)
+      }
+      this.resetSubjectDropdown()
+    },
+    addSubject(subject) {
+      if (!this.selectedKeys.has(subject.key)) {
+        this.selectedSubjects.push(subject)
+        this.emitSelectionChange()
+      }
+    },
+    removeSubject(subject) {
+      this.selectedSubjects = this.selectedSubjects.filter(
+        ({ key }) => key !== subject.key
+      )
+      this.emitSelectionChange()
+      this.resetSubjectDropdown()
+    },
+    emitSelectionChange() {
+      this.$emit('selection-change', this.selectedSubjects.length)
+    },
+    getSelectedSubjects() {
+      return this.selectedSubjects.map(({ subjectId, subjectType }) => ({
+        subject_id: subjectId,
+        subject_type: subjectType,
+      }))
+    },
+    nameAbbreviation,
+  },
+}
+</script>

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/fieldPermissions/FieldPermissionsModal.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/fieldPermissions/FieldPermissionsModal.vue
@@ -1,57 +1,84 @@
 <template>
-  <Modal ref="modal" @show="init()">
-    <h2 class="box__title">{{ $t('fieldPermissionModal.title') }}</h2>
-    <p>
-      <i18n-t
-        scope="global"
-        keypath="fieldPermissionModal.description"
-        tag="span"
-      >
-        <template #fieldName>
-          <strong>{{ field.name }}</strong>
-        </template>
-      </i18n-t>
-    </p>
-    <div class="margin-bottom-2" :style="{ fontWeight: '500' }">
-      {{ $t('fieldPermissionModal.question') }}
-    </div>
-    <div v-if="loading" class="loading"></div>
-    <template v-else>
-      <Dropdown
-        :value="role"
-        :show-search="false"
-        :fixed-items="true"
-        size="large"
-        @input="onRoleChanged"
-      >
-        <DropdownItem
-          v-for="r in roles"
-          :key="r.uid"
-          :name="r.title"
-          :value="r.uid"
-          :description="r.desc"
-        ></DropdownItem>
-      </Dropdown>
-      <FormGroup v-if="showAllowInForms" class="margin-bottom-2 margin-top-3">
-        <SwitchInput small :value="allowInForms" @input="toggleAllowInForms">
-          {{ $t('fieldPermissionModal.allowInForms') }}
-        </SwitchInput>
-      </FormGroup>
-      <Alert v-if="isLinkRowFieldType" type="info-neutral">
-        <p>{{ $t('fieldPermissionModal.linkRowWarning') }}</p>
-      </Alert>
-    </template>
-  </Modal>
+  <div>
+    <Modal ref="modal" wide @show="init()">
+      <h2 class="box__title">{{ $t('fieldPermissionModal.title') }}</h2>
+      <p>
+        <i18n-t
+          scope="global"
+          keypath="fieldPermissionModal.description"
+          tag="span"
+        >
+          <template #fieldName>
+            <strong>{{ field.name }}</strong>
+          </template>
+        </i18n-t>
+      </p>
+      <div class="margin-bottom-2" :style="{ fontWeight: '500' }">
+        {{ $t('fieldPermissionModal.question') }}
+      </div>
+      <div v-if="loading" class="loading"></div>
+      <template v-else>
+        <Dropdown
+          :value="role"
+          :show-search="false"
+          :fixed-items="true"
+          size="large"
+          @input="onRoleChanged"
+        >
+          <DropdownItem
+            v-for="r in roles"
+            :key="r.uid"
+            :name="r.title"
+            :value="r.uid"
+            :description="r.desc"
+          ></DropdownItem>
+        </Dropdown>
+        <FormGroup v-if="showAllowInForms" class="margin-bottom-2 margin-top-3">
+          <SwitchInput small :value="allowInForms" @input="toggleAllowInForms">
+            {{ $t('fieldPermissionModal.allowInForms') }}
+          </SwitchInput>
+        </FormGroup>
+        <FieldPermissionSubjectsSelector
+          v-if="role === customRole"
+          ref="subjectsSelector"
+          :field-id="field.id"
+          :subjects="subjects"
+          @selection-change="customSubjectCount = $event"
+        />
+        <Alert v-if="isLinkRowFieldType" type="info-neutral">
+          <p>{{ $t('fieldPermissionModal.linkRowWarning') }}</p>
+        </Alert>
+        <div
+          v-if="role === customRole"
+          class="actions actions--right actions--gap margin-bottom-0 margin-top-3"
+        >
+          <Button type="secondary" size="large" @click="cancelCustomSubjects">
+            {{ $t('action.cancel') }}
+          </Button>
+          <Button
+            size="large"
+            :loading="updating"
+            :disabled="customSubjectCount === 0"
+            @click="saveCustomSubjects"
+          >
+            {{ $t('action.save') }}
+          </Button>
+        </div>
+      </template>
+    </Modal>
+  </div>
 </template>
 
 <script>
 import modal from '@baserow/modules/core/mixins/modal'
 import { notifyIf } from '@baserow/modules/core/utils/error'
+import FieldPermissionSubjectsSelector from '@baserow_enterprise/components/fieldPermissions/FieldPermissionSubjectsSelector'
 import FieldPermissionService from '@baserow_enterprise/services/fieldPermissions'
 import { WriteFieldValuesPermissionManagerType } from '@baserow_enterprise/permissionManagerTypes'
 
 export default {
   name: 'FieldPermissionsModal',
+  components: { FieldPermissionSubjectsSelector },
   mixins: [modal],
   props: {
     field: {
@@ -69,11 +96,14 @@ export default {
       updating: false,
       role: null,
       allowInForms: false,
+      subjects: [],
+      customSubjectCount: 0,
+      customRole: 'CUSTOM',
       roles: [
         {
-          uid: 'ADMIN',
-          title: this.$t('fieldPermissionModal.adminTitle'),
-          desc: this.$t('fieldPermissionModal.adminDescription'),
+          uid: 'EDITOR',
+          title: this.$t('fieldPermissionModal.editorTitle'),
+          desc: this.$t('fieldPermissionModal.editorDescription'),
         },
         {
           uid: 'BUILDER',
@@ -81,9 +111,14 @@ export default {
           desc: this.$t('fieldPermissionModal.builderDescription'),
         },
         {
-          uid: 'EDITOR',
-          title: this.$t('fieldPermissionModal.editorTitle'),
-          desc: this.$t('fieldPermissionModal.editorDescription'),
+          uid: 'ADMIN',
+          title: this.$t('fieldPermissionModal.adminTitle'),
+          desc: this.$t('fieldPermissionModal.adminDescription'),
+        },
+        {
+          uid: 'CUSTOM',
+          title: this.$t('fieldPermissionModal.customTitle'),
+          desc: this.$t('fieldPermissionModal.customDescription'),
         },
         {
           uid: 'NOBODY',
@@ -131,13 +166,16 @@ export default {
       )
       this.role = data.role
       this.allowInForms = data.allow_in_forms
+      this.subjects = data.subjects || []
+      this.customSubjectCount = this.subjects.length
       this.loading = false
     },
     /* Update the field permission data on the server. */
-    async update({ role, allowInForms }) {
+    async update({ role, allowInForms, subjects }) {
       this.updating = true
       const originalRole = this.role
       const originalAllowInForms = this.allowInForms
+      const originalSubjects = this.subjects
 
       this.role = role
       if (!this.canAllowInForms(role, originalRole)) {
@@ -147,8 +185,9 @@ export default {
       try {
         const { data } = await FieldPermissionService(this.$client).update(
           this.field.id,
-          { role, allowInForms }
+          { role, allowInForms, subjects }
         )
+        this.subjects = data.subjects || []
         const opName = WriteFieldValuesPermissionManagerType.getType()
         this.$registry
           .get('permissionManager', opName)
@@ -163,29 +202,61 @@ export default {
       } catch (error) {
         this.role = originalRole
         this.allowInForms = originalAllowInForms
+        this.subjects = originalSubjects
         notifyIf(error, 'settings')
+        return null
       } finally {
         this.updating = false
       }
     },
     /* Update the role and the workspace permissions to reflect the changes. */
     async onRoleChanged(role) {
+      if (role === this.customRole) {
+        if (!this.canAllowInForms(role, this.role)) {
+          this.allowInForms = false
+        }
+        this.role = role
+        return
+      }
       await this.update({ role, allowInForms: this.allowInForms })
+    },
+    async saveCustomSubjects() {
+      const subjects = this.$refs.subjectsSelector.getSelectedSubjects()
+      const data = await this.update({
+        role: this.customRole,
+        allowInForms: this.allowInForms,
+        subjects,
+      })
+      if (data) {
+        this.hide()
+      }
+    },
+    cancelCustomSubjects() {
+      this.hide()
     },
     /* Update the allow_in_forms property. */
     async toggleAllowInForms(allowInForms) {
+      if (this.role === this.customRole) {
+        this.allowInForms = allowInForms
+        return
+      }
       await this.update({ role: this.role, allowInForms })
     },
     /*
      * Forcefully refresh the field permission data. This is triggered when updates
      * are received via websockets to ensure real-time synchronization.
      */
-    forceUpdate({ fieldId, role, allowInForms }) {
+    async forceUpdate({ fieldId, role, allowInForms }) {
       if (fieldId !== this.field.id) {
         return
       }
       this.role = role
       this.allowInForms = allowInForms
+      if (role === this.customRole) {
+        await this.init()
+      } else {
+        this.subjects = []
+      }
     },
   },
 }

--- a/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
+++ b/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
@@ -737,10 +737,23 @@
     "builderDescription": "Users with Builder and Admin roles",
     "adminTitle": "Admins only",
     "adminDescription": "Users with Admin roles",
+    "customTitle": "Specific users or teams",
+    "customDescription": "Only selected users and team members who already have an Editor, Builder, or Admin role",
     "nobodyTitle": "Nobody",
     "nobodyDescription": "No users",
     "allowInForms": "Allow this field to be set in rows created through forms",
     "linkRowWarning": "This is a 'Link to table' field. To ensure values cannot be changed from the linked table, please make ensure to set the right permissions on the linked table as well."
+  },
+  "fieldPermissionSubjectsSelector": {
+    "accessNote": "Selection does not grant table access. A selected user, or a member of a selected team, must also have an Editor, Builder, or Admin role where this table is located.",
+    "canEdit": "Selected users and teams",
+    "noSelectedSubjects": "Nobody is selected yet. Use the search above to add a user or team.",
+    "addPeopleOrTeams": "Add users or teams",
+    "searchPlaceholder": "Search users or teams",
+    "searchHint": "Search by name",
+    "teamDescription": "Team",
+    "teamSearchDescription": "Team · {count} member | Team · {count} members",
+    "remove": "Remove {subject}"
   },
   "builderSettingTypes": {
     "customCode": "Custom CSS/JS"

--- a/enterprise/web-frontend/modules/baserow_enterprise/services/fieldPermissions.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/services/fieldPermissions.js
@@ -3,13 +3,19 @@ export default (client) => {
     get(fieldId) {
       return client.get(`/field-permissions/${fieldId}/`)
     },
-    update(fieldId, { role, allowInForms }) {
+    fetchSubjectOptions(fieldId, params) {
+      return client.get(`/field-permissions/${fieldId}/subjects/`, { params })
+    },
+    update(fieldId, { role, allowInForms, subjects }) {
       const data = {}
       if (role !== undefined) {
         data.role = role
       }
       if (allowInForms !== undefined) {
         data.allow_in_forms = allowInForms
+      }
+      if (subjects !== undefined) {
+        data.subjects = subjects
       }
       return client.patch(`/field-permissions/${fieldId}/`, data)
     },

--- a/enterprise/web-frontend/test/unit/enterprise/fieldPermissions/fieldPermissionSubjectsSelector.spec.js
+++ b/enterprise/web-frontend/test/unit/enterprise/fieldPermissions/fieldPermissionSubjectsSelector.spec.js
@@ -1,0 +1,158 @@
+import { defineComponent } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+
+import FieldPermissionSubjectsSelector from '@baserow_enterprise/components/fieldPermissions/FieldPermissionSubjectsSelector'
+import FieldPermissionService from '@baserow_enterprise/services/fieldPermissions'
+
+vi.mock('@baserow_enterprise/services/fieldPermissions', () => ({
+  default: vi.fn(),
+}))
+
+const ButtonIconStub = defineComponent({
+  name: 'ButtonIcon',
+  props: ['disabled', 'icon'],
+  template:
+    '<button class="remove-subject" :disabled="disabled"><i v-if="icon" :class="icon"></i><slot /></button>',
+})
+
+const AvatarStub = defineComponent({
+  name: 'Avatar',
+  props: ['initials'],
+  template: '<div class="avatar-stub">{{ initials }}</div>',
+})
+
+const simpleStub = (name) =>
+  defineComponent({ name, template: '<div><slot /></div>' })
+
+const selectedUser = {
+  subject_id: 1,
+  subject_type: 'auth.User',
+  subject: {
+    id: 1,
+    first_name: 'Ada Lovelace',
+    username: 'ada@example.com',
+    email: 'ada@example.com',
+  },
+}
+
+async function mountComponent() {
+  return await mountSuspended(FieldPermissionSubjectsSelector, {
+    props: {
+      fieldId: 10,
+      subjects: [selectedUser],
+    },
+    global: {
+      stubs: {
+        ButtonIcon: ButtonIconStub,
+        Avatar: AvatarStub,
+        Alert: simpleStub('Alert'),
+      },
+      mocks: {
+        $client: {},
+        $t: (key, params = {}) =>
+          `${key}${params.subject ? `:${params.subject}` : ''}`,
+      },
+    },
+  })
+}
+
+describe('FieldPermissionSubjectsSelector', () => {
+  let fetchSubjectOptions
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    fetchSubjectOptions = vi.fn().mockResolvedValue({
+      data: {
+        count: 2,
+        results: [
+          {
+            subject_id: 2,
+            subject_type: 'auth.User',
+            name: 'Alan Turing',
+            email: 'alan@example.com',
+            subject_count: null,
+          },
+          {
+            subject_id: 3,
+            subject_type: 'baserow_enterprise.Team',
+            name: 'Development team',
+            email: null,
+            subject_count: 4,
+          },
+        ],
+      },
+    })
+    FieldPermissionService.mockReturnValue({ fetchSubjectOptions })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  test('loads the first page on open and renders collaborator-style options', async () => {
+    const wrapper = await mountComponent()
+
+    const sections = wrapper.findAll('.field-permission-subjects__section')
+    expect(sections[0].find('.dropdown').exists()).toBe(true)
+    expect(sections[1].text()).toContain('Ada Lovelace')
+    expect(wrapper.text()).not.toContain('ada@example.com')
+    expect(fetchSubjectOptions).not.toHaveBeenCalled()
+
+    await wrapper.find('.dropdown__selected').trigger('click')
+    await flushPromises()
+
+    expect(fetchSubjectOptions).toHaveBeenCalledWith(10, {
+      page: 1,
+      size: 20,
+      search: '',
+      exclude_user_ids: '1',
+      exclude_team_ids: '',
+    })
+    const options = wrapper.findAll(
+      '.field-permission-subjects__dropdown-option'
+    )
+    expect(options).toHaveLength(2)
+    expect(options[0].text()).toContain('Alan Turing')
+    expect(options[0].text()).not.toContain('alan@example.com')
+    expect(options[0].find('.avatar-stub').text()).toBe('AT')
+    expect(options[1].find('.iconoir-group').exists()).toBe(true)
+
+    expect(wrapper.find('.remove-subject .iconoir-cancel').exists()).toBe(true)
+    expect(wrapper.find('.remove-subject .iconoir-bin').exists()).toBe(false)
+    await wrapper.find('.remove-subject').trigger('click')
+    expect(wrapper.text()).not.toContain('Ada Lovelace')
+    expect(wrapper.emitted('selection-change').at(-1)).toEqual([0])
+  })
+
+  test('paginates server search and adds the selected dropdown result', async () => {
+    const wrapper = await mountComponent()
+
+    await wrapper.find('.dropdown__selected').trigger('click')
+    await flushPromises()
+    await wrapper.find('.select__search-input').setValue('al')
+    await vi.advanceTimersByTimeAsync(400)
+    await flushPromises()
+
+    expect(fetchSubjectOptions).toHaveBeenCalledWith(10, {
+      page: 1,
+      size: 20,
+      search: 'al',
+      exclude_user_ids: '1',
+      exclude_team_ids: '',
+    })
+    expect(wrapper.find('.dropdown__items').text()).toContain('Alan Turing')
+    expect(wrapper.find('.dropdown__items').text()).toContain(
+      'Development team'
+    )
+
+    await wrapper.findAll('.select__item-link')[0].trigger('click')
+    await flushPromises()
+
+    expect(wrapper.findAll('.field-permission-subjects__item')).toHaveLength(2)
+    expect(wrapper.text()).toContain('Alan Turing')
+    expect(wrapper.find('.dropdown__items').classes()).toContain('hidden')
+    expect(wrapper.emitted('selection-change').at(-1)).toEqual([2])
+  })
+})

--- a/enterprise/web-frontend/test/unit/enterprise/fieldPermissions/fieldPermissionsModal.spec.js
+++ b/enterprise/web-frontend/test/unit/enterprise/fieldPermissions/fieldPermissionsModal.spec.js
@@ -1,0 +1,146 @@
+import { defineComponent } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+
+import FieldPermissionsModal from '@baserow_enterprise/components/fieldPermissions/FieldPermissionsModal'
+import FieldPermissionService from '@baserow_enterprise/services/fieldPermissions'
+
+vi.mock('@baserow_enterprise/services/fieldPermissions', () => ({
+  default: vi.fn(),
+}))
+
+const MainModalStub = defineComponent({
+  name: 'Modal',
+  emits: ['show'],
+  data() {
+    return { visible: true }
+  },
+  mounted() {
+    this.$emit('show')
+  },
+  methods: {
+    show() {
+      this.$emit('show')
+    },
+    hide() {
+      this.visible = false
+    },
+  },
+  template: '<div v-if="visible" class="modal-stub"><slot /></div>',
+})
+
+const SubjectsSelectorStub = defineComponent({
+  name: 'FieldPermissionSubjectsSelector',
+  props: ['fieldId'],
+  emits: ['selection-change'],
+  mounted() {
+    this.$emit('selection-change', 1)
+  },
+  methods: {
+    getSelectedSubjects() {
+      return [{ subject_id: 2, subject_type: 'auth.User' }]
+    },
+  },
+  template: '<div class="subjects-editor"></div>',
+})
+
+const DropdownStub = defineComponent({
+  name: 'Dropdown',
+  emits: ['input'],
+  template:
+    '<div><button class="choose-custom" @click="$emit(\'input\', \'CUSTOM\')">Custom</button><slot /></div>',
+})
+
+const simpleStub = (name) =>
+  defineComponent({ name, template: '<div><slot /></div>' })
+
+async function mountComponent() {
+  return await mountSuspended(FieldPermissionsModal, {
+    props: {
+      field: { id: 10, name: 'Last name', type: 'text' },
+      workspaceId: 20,
+    },
+    global: {
+      stubs: {
+        Modal: MainModalStub,
+        FieldPermissionSubjectsSelector: SubjectsSelectorStub,
+        Dropdown: DropdownStub,
+        DropdownItem: simpleStub('DropdownItem'),
+        FormGroup: defineComponent({
+          name: 'FormGroup',
+          template: '<div class="forms-toggle"><slot /></div>',
+        }),
+        SwitchInput: simpleStub('SwitchInput'),
+        Alert: simpleStub('Alert'),
+        Button: defineComponent({
+          name: 'Button',
+          template: '<button><slot /></button>',
+        }),
+      },
+      mocks: {
+        $client: {},
+        $t: (key) => key,
+        $bus: { $on: vi.fn(), $off: vi.fn() },
+        $registry: {
+          get: () => ({ updateWritePermissionsForField: vi.fn() }),
+        },
+      },
+    },
+  })
+}
+
+describe('FieldPermissionsModal', () => {
+  let get
+  let update
+
+  beforeEach(() => {
+    get = vi.fn().mockResolvedValue({
+      data: { role: 'EDITOR', allow_in_forms: true, subjects: [] },
+    })
+    update = vi.fn().mockResolvedValue({
+      data: {
+        role: 'CUSTOM',
+        allow_in_forms: false,
+        can_write_values: true,
+        subjects: [
+          {
+            subject_id: 2,
+            subject_type: 'auth.User',
+            subject: { id: 2, first_name: 'Alan Turing' },
+          },
+        ],
+      },
+    })
+    FieldPermissionService.mockReturnValue({ get, update })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('shows the selector inline before persisting the custom permission', async () => {
+    const wrapper = await mountComponent()
+    await flushPromises()
+
+    await wrapper.find('.choose-custom').trigger('click')
+
+    expect(wrapper.find('.subjects-editor').exists()).toBe(true)
+    expect(wrapper.find('.forms-toggle').element.nextElementSibling).toBe(
+      wrapper.find('.subjects-editor').element
+    )
+    expect(update).not.toHaveBeenCalled()
+
+    const saveButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'action.save')
+    await saveButton.trigger('click')
+    await flushPromises()
+
+    expect(update).toHaveBeenCalledWith(10, {
+      role: 'CUSTOM',
+      allowInForms: false,
+      subjects: [{ subject_id: 2, subject_type: 'auth.User' }],
+    })
+    expect(wrapper.find('.modal-stub').exists()).toBe(false)
+  })
+})

--- a/web-frontend/modules/core/components/PaginatedDropdown.vue
+++ b/web-frontend/modules/core/components/PaginatedDropdown.vue
@@ -53,16 +53,24 @@
           :name="emptyItemDisplayName"
           :value="null"
         ></DropdownItem>
-        <DropdownItem
-          v-for="result in results"
-          :key="result[idName]"
-          :name="
-            typeof valueName === 'function'
-              ? valueName(result)
-              : result[valueName]
-          "
-          :value="result[idName]"
-        ></DropdownItem>
+        <template v-if="resultItemComponent">
+          <component
+            :is="resultItemComponent"
+            v-for="result in results"
+            :key="result[idName]"
+            :name="getResultName(result)"
+            :value="result[idName]"
+            :result="result"
+          ></component>
+        </template>
+        <template v-else>
+          <DropdownItem
+            v-for="result in results"
+            :key="result[idName]"
+            :name="getResultName(result)"
+            :value="result[idName]"
+          ></DropdownItem>
+        </template>
         <div v-if="loading" class="select__items-loading"></div>
       </ul>
     </div>
@@ -84,6 +92,18 @@ export default {
       type: Boolean,
       required: false,
       default: false,
+    },
+    resultItemComponent: {
+      type: [Object, Function],
+      required: false,
+      default: null,
+    },
+  },
+  methods: {
+    getResultName(result) {
+      return typeof this.valueName === 'function'
+        ? this.valueName(result)
+        : result[this.valueName]
     },
   },
 }

--- a/web-frontend/modules/core/mixins/paginatedDropdown.js
+++ b/web-frontend/modules/core/mixins/paginatedDropdown.js
@@ -133,10 +133,10 @@ export default {
         if (replace) {
           this.results = results
         } else {
-          const resultIds = new Set(this.results.map((res) => res.id))
+          const resultIds = new Set(this.results.map((res) => res[this.idName]))
           this.results.push(
             ...results.filter((res) => {
-              return !resultIds.has(res.id)
+              return !resultIds.has(res[this.idName])
             })
           )
         }

--- a/web-frontend/modules/database/components/table/ImportFileModal.vue
+++ b/web-frontend/modules/database/components/table/ImportFileModal.vue
@@ -307,7 +307,7 @@ export default {
           (value) => this.fieldIndexMap[value] !== undefined
         ) &&
         (!this.useUpsertField ||
-          Object.values(this.mapping).includes(this.upsertField))
+          this.availableUpsertFields.some(({ id }) => id === this.upsertField))
       )
     },
     fieldTypes() {
@@ -359,8 +359,8 @@ export default {
       return Object.entries(this.mapping)
         .filter(
           ([, targetFieldId]) =>
-            !!targetFieldId ||
-            // Check if we have an id from a removed field
+            !!targetFieldId &&
+            // Check if we have an id from an unavailable field
             this.fieldIndexMap[targetFieldId] !== undefined
         )
         .map(([importIndex, targetFieldId]) => {
@@ -407,7 +407,7 @@ export default {
     },
     availableUpsertFields() {
       const selected = Object.values(this.mapping)
-      return this.sortedFields.filter((field) => {
+      return this.writableFields.filter((field) => {
         return (
           selected.includes(field.id) && this.fieldTypes[field.type].canUpsert()
         )
@@ -541,23 +541,31 @@ export default {
       this.showProgressBar = false
       this.reset(false)
       let data = null
-      const importConfiguration = {}
+      const writableFields = [...this.writableFields]
+      const fieldIndexMap = Object.fromEntries(
+        writableFields.map((field, index) => [field.id, index])
+      )
+      const mapping = { ...this.mapping }
+      const upsertField = this.useUpsertField ? this.upsertField : undefined
+      const importConfiguration = {
+        import_fields: writableFields.map(({ id }) => id),
+      }
 
-      if (this.upsertField) {
+      if (upsertField) {
         // at the moment we use only one field, but the key may be composed of several
         // fields.
-        importConfiguration.upsert_fields = [this.upsertField]
+        importConfiguration.upsert_fields = [upsertField]
         importConfiguration.upsert_values = []
       }
 
-      const mappedFieldIds = Object.values(this.mapping).filter(
-        (id) => id !== 0
+      const mappedFieldIds = Object.values(mapping).filter(
+        (id) => fieldIndexMap[id] !== undefined
       )
-      const skippedFieldIds = this.writableFields
+      const skippedFieldIds = writableFields
         .filter((field) => !mappedFieldIds.includes(field.id))
         .map((field) => field.id)
 
-      if (skippedFieldIds.length > 0) {
+      if (upsertField && skippedFieldIds.length > 0) {
         importConfiguration.skipped_fields = skippedFieldIds
       }
 
@@ -572,32 +580,30 @@ export default {
           const upsertValues = importConfiguration.upsert_values || []
           const upsertFieldIndexes = []
 
-          Object.entries(this.mapping).forEach(
-            ([importIndex, targetFieldId]) => {
-              if (upsertFields.includes(targetFieldId)) {
-                upsertFieldIndexes.push(importIndex)
-              }
+          Object.entries(mapping).forEach(([importIndex, targetFieldId]) => {
+            if (upsertFields.includes(targetFieldId)) {
+              upsertFieldIndexes.push(importIndex)
             }
-          )
+          })
 
-          const fieldMapping = Object.entries(this.mapping)
+          const fieldMapping = Object.entries(mapping)
             .filter(
               ([, targetFieldId]) =>
-                !!targetFieldId ||
-                // Check if we have an id from a removed field
-                this.fieldIndexMap[targetFieldId] !== undefined
+                !!targetFieldId &&
+                // Check if we have an id from an unavailable field
+                fieldIndexMap[targetFieldId] !== undefined
             )
             .map(([importIndex, targetFieldId]) => {
-              return [importIndex, this.fieldIndexMap[targetFieldId]]
+              return [importIndex, fieldIndexMap[targetFieldId]]
             })
 
           // Template row with default values
-          const defaultRow = this.writableFields.map((field) =>
+          const defaultRow = writableFields.map((field) =>
             this.fieldTypes[field.type].getDefaultValue(field, true)
           )
 
           // Precompute the prepare value function for each field
-          const prepareValueByField = this.writableFields.map(
+          const prepareValueByField = writableFields.map(
             (field) => (value) =>
               this.fieldTypes[field.type].prepareValueForUpdate(
                 field,
@@ -668,7 +674,7 @@ export default {
           {
             onUploadProgress,
           },
-          importConfiguration.upsert_fields ? importConfiguration : null,
+          importConfiguration,
           {
             importer_type: this.importer,
             original_file_name: this.$refs.importerRef?.values?.filename || '',

--- a/web-frontend/test/unit/core/components/paginatedDropdown.spec.js
+++ b/web-frontend/test/unit/core/components/paginatedDropdown.spec.js
@@ -1,3 +1,5 @@
+import { defineComponent } from 'vue'
+
 import PaginatedDropdown from '@baserow/modules/core/components/PaginatedDropdown'
 import { TestApp } from '@baserow/test/helpers/testApp'
 import flushPromises from 'flush-promises'
@@ -38,6 +40,56 @@ describe('PaginatedDropdown component', () => {
     await wrapper.vm.fetch(1, null)
     await flushPromises()
     expect(wrapper.text()).toContain('Alpha')
+  })
+
+  test('exposes each result to a custom item component', async () => {
+    const CustomResult = defineComponent({
+      props: {
+        result: { type: Object, required: true },
+        name: { type: String, required: true },
+        value: { type: Number, required: true },
+      },
+      template:
+        '<li class="custom-result">{{ value }}:{{ name }}:{{ result.value }}</li>',
+    })
+    const wrapper = await testApp.mount(PaginatedDropdown, {
+      props: {
+        fetchPage,
+        valueName: labelFn,
+        resultItemComponent: CustomResult,
+      },
+    })
+    await wrapper.vm.fetch(1, null)
+    await flushPromises()
+
+    expect(wrapper.findAll('.custom-result')).toHaveLength(2)
+    expect(wrapper.findAll('.custom-result')[1].text()).toBe('2:Unnamed 2:')
+  })
+
+  test('uses idName to de-duplicate appended pages', async () => {
+    const pagedFetch = (page) =>
+      Promise.resolve({
+        data: {
+          results: [{ key: page, value: `Page ${page}` }],
+          count: 2,
+        },
+      })
+    const wrapper = await testApp.mount(PaginatedDropdown, {
+      props: {
+        fetchPage: pagedFetch,
+        idName: 'key',
+        valueName: 'value',
+      },
+    })
+
+    await wrapper.vm.fetch(1, null)
+    await wrapper.vm.fetch(2, null, false)
+    await flushPromises()
+
+    expect(wrapper.vm.results).toEqual([
+      { key: 1, value: 'Page 1' },
+      { key: 2, value: 'Page 2' },
+    ])
   })
 
   test('select includes the resolved item when includeDisplayNameInSelectedEvent', async () => {

--- a/web-frontend/test/unit/database/components/importFileModal.spec.js
+++ b/web-frontend/test/unit/database/components/importFileModal.spec.js
@@ -1,0 +1,298 @@
+import { flushPromises } from '@vue/test-utils'
+import { defineComponent, nextTick, ref } from 'vue'
+
+import { TestApp } from '@baserow/test/helpers/testApp'
+import ImportFileModal from '@baserow/modules/database/components/table/ImportFileModal'
+
+let getDataHook = async () => {}
+
+const ModalStub = defineComponent({
+  name: 'Modal',
+  methods: {
+    show() {},
+    hide() {},
+  },
+  template: '<div><slot name="content" /><slot name="sidebar" /></div>',
+})
+
+const CSVImporterStub = defineComponent({
+  name: 'TableCSVImporter',
+  emits: ['data', 'getData'],
+  mounted() {
+    this.$emit('data', {
+      header: ['Name', 'Notes', 'Active'],
+      previewData: [['Ada', 'Cannot write this', 'true']],
+    })
+    this.$emit('getData', async () => {
+      await getDataHook()
+      return [['Ada', 'Cannot write this', 'true']]
+    })
+  },
+  template:
+    '<div class="csv-importer-stub"><slot name="upsertMapping" /></div>',
+})
+
+const CheckboxStub = defineComponent({
+  name: 'Checkbox',
+  props: ['modelValue', 'disabled'],
+  emits: ['update:modelValue'],
+  template:
+    '<button class="enable-upsert" :disabled="disabled" @click="$emit(\'update:modelValue\', true)"><slot /></button>',
+})
+
+const DropdownStub = defineComponent({
+  name: 'Dropdown',
+  props: ['modelValue', 'disabled'],
+  emits: ['update:modelValue'],
+  template:
+    '<div class="dropdown-stub" :data-model-value="modelValue"><button class="choose-name-field" :disabled="disabled" @click="$emit(\'update:modelValue\', 1)">Name</button><slot /></div>',
+})
+
+const DropdownItemStub = defineComponent({
+  name: 'DropdownItem',
+  props: ['name', 'value', 'disabled'],
+  template:
+    '<span class="dropdown-item-stub" :data-value="value">{{ name }}</span>',
+})
+
+describe('ImportFileModal', () => {
+  let testApp
+  let notesFieldType
+  let originalNotesFieldTypeApp
+  let notesWritable
+
+  const table = { id: 5, name: 'People' }
+  const database = {
+    id: 1,
+    workspace: { id: 10 },
+    tables: [table],
+  }
+  const fields = [
+    {
+      id: 1,
+      name: 'Name',
+      type: 'text',
+      primary: true,
+      order: 0,
+      read_only: false,
+      workspace_id: 10,
+      _: { type: { iconClass: 'iconoir-text' } },
+    },
+    {
+      id: 2,
+      name: 'Notes',
+      type: 'long_text',
+      primary: false,
+      order: 1,
+      read_only: false,
+      workspace_id: 10,
+      _: { type: { iconClass: 'iconoir-align-left' } },
+    },
+    {
+      id: 3,
+      name: 'Active',
+      type: 'boolean',
+      primary: false,
+      order: 2,
+      read_only: false,
+      workspace_id: 10,
+      _: { type: { iconClass: 'iconoir-check-circle' } },
+    },
+  ]
+
+  beforeEach(() => {
+    testApp = new TestApp()
+    getDataHook = async () => {}
+    notesWritable = ref(false)
+    notesFieldType = testApp.$registry.get('field', 'long_text')
+    originalNotesFieldTypeApp = notesFieldType.app
+    notesFieldType.app = new Proxy(notesFieldType.app, {
+      get(target, property) {
+        return property === '$hasPermission'
+          ? () => notesWritable.value
+          : Reflect.get(target, property)
+      },
+    })
+  })
+
+  afterEach(async () => {
+    notesFieldType.app = originalNotesFieldTypeApp
+    await testApp.afterEach()
+  })
+
+  test.each([
+    ['normal import', false],
+    ['upsert', true],
+  ])(
+    'omits a denied middle field from the mapping and %s payload',
+    async (_, useUpsert) => {
+      let requestBody
+      testApp.mock
+        .onPost(`/database/tables/${table.id}/import/async/`)
+        .reply((request) => {
+          requestBody = JSON.parse(request.data)
+          return [
+            200,
+            {
+              id: useUpsert ? 2 : 1,
+              type: 'file_import',
+              state: 'finished',
+              progress_percentage: 100,
+              table_id: table.id,
+              database_id: database.id,
+              report: { failing_rows: {} },
+            },
+          ]
+        })
+
+      const wrapper = await testApp.mount(ImportFileModal, {
+        props: { database, table, fields },
+        global: {
+          stubs: {
+            Modal: ModalStub,
+            TableCSVImporter: CSVImporterStub,
+            Checkbox: CheckboxStub,
+            Dropdown: DropdownStub,
+            DropdownItem: DropdownItemStub,
+            SimpleGrid: true,
+            ImportErrorReport: true,
+          },
+        },
+      })
+
+      await wrapper.find('.choice-items__link').trigger('click')
+      await flushPromises()
+
+      const mappingPanel = wrapper.find('.import-modal__field-mapping-body')
+      const availableFieldNames = mappingPanel
+        .findAll('.dropdown-item-stub')
+        .map((item) => item.text())
+      expect(availableFieldNames).not.toContain('Notes')
+      expect(availableFieldNames).toContain('Name')
+      expect(availableFieldNames).toContain('Active')
+      expect(
+        mappingPanel
+          .findAll('.dropdown-stub')
+          .map((dropdown) => Number(dropdown.attributes('data-model-value')))
+      ).toStrictEqual([1, 0, 3])
+
+      if (useUpsert) {
+        const importer = wrapper.find('.csv-importer-stub')
+        await importer.find('.enable-upsert').trigger('click')
+        await importer.find('.choose-name-field').trigger('click')
+      }
+
+      await wrapper.find('.modal-progress__primary-button').trigger('click')
+      await vi.waitFor(() => expect(requestBody).toBeDefined())
+
+      expect(requestBody.data).toStrictEqual([['Ada', true]])
+      if (useUpsert) {
+        expect(requestBody.configuration).toStrictEqual({
+          import_fields: [1, 3],
+          upsert_fields: [1],
+          upsert_values: [['Ada']],
+        })
+      } else {
+        expect(requestBody.configuration).toStrictEqual({
+          import_fields: [1, 3],
+        })
+      }
+    }
+  )
+
+  test('uses one field snapshot while preparing import data', async () => {
+    notesWritable.value = true
+    let requestBody
+    testApp.mock
+      .onPost(`/database/tables/${table.id}/import/async/`)
+      .reply((request) => {
+        requestBody = JSON.parse(request.data)
+        return [
+          200,
+          {
+            id: 1,
+            type: 'file_import',
+            state: 'finished',
+            progress_percentage: 100,
+            table_id: table.id,
+            database_id: database.id,
+            report: { failing_rows: {} },
+          },
+        ]
+      })
+
+    const wrapper = await testApp.mount(ImportFileModal, {
+      props: { database, table, fields },
+      global: {
+        stubs: {
+          Modal: ModalStub,
+          TableCSVImporter: CSVImporterStub,
+          Checkbox: CheckboxStub,
+          Dropdown: DropdownStub,
+          DropdownItem: DropdownItemStub,
+          SimpleGrid: true,
+          ImportErrorReport: true,
+        },
+      },
+    })
+
+    await wrapper.find('.choice-items__link').trigger('click')
+    await flushPromises()
+    expect(wrapper.vm.writableFields.map(({ id }) => id)).toStrictEqual([
+      1, 2, 3,
+    ])
+
+    getDataHook = async () => {
+      notesWritable.value = false
+      await nextTick()
+      expect(wrapper.vm.writableFields.map(({ id }) => id)).toStrictEqual([
+        1, 3,
+      ])
+    }
+
+    await wrapper.find('.modal-progress__primary-button').trigger('click')
+    await vi.waitFor(() => expect(requestBody).toBeDefined())
+
+    expect(requestBody.data).toStrictEqual([['Ada', 'Cannot write this', true]])
+    expect(requestBody.configuration).toStrictEqual({
+      import_fields: [1, 2, 3],
+    })
+  })
+
+  test('rejects a stale mapping when its field becomes denied', async () => {
+    notesWritable.value = true
+    const wrapper = await testApp.mount(ImportFileModal, {
+      props: { database, table, fields },
+      global: {
+        stubs: {
+          Modal: ModalStub,
+          TableCSVImporter: CSVImporterStub,
+          Checkbox: CheckboxStub,
+          Dropdown: DropdownStub,
+          DropdownItem: DropdownItemStub,
+          SimpleGrid: true,
+          ImportErrorReport: true,
+        },
+      },
+    })
+
+    await wrapper.find('.choice-items__link').trigger('click')
+    await flushPromises()
+    wrapper.vm.useUpsertField = true
+    wrapper.vm.upsertField = 2
+    await nextTick()
+    expect(wrapper.vm.canBeSubmitted).toBe(true)
+
+    notesWritable.value = false
+    await nextTick()
+
+    expect(wrapper.vm.fieldMapping).toStrictEqual([
+      ['0', 0],
+      ['2', 1],
+    ])
+    expect(wrapper.vm.availableUpsertFields.map(({ id }) => id)).not.toContain(
+      2
+    )
+    expect(wrapper.vm.canBeSubmitted).toBe(false)
+  })
+})


### PR DESCRIPTION
## What this adds

Field permissions now include a **Specific users or teams** option. Workspace members can search for and select the people or teams allowed to edit a field, while selected subjects must still have Editor, Builder, or Admin access to the table. Changes are staged until Save, and the existing form exception remains available.


https://github.com/user-attachments/assets/07093513-6f44-4b94-85e3-419555457f10

## How to test

1. In an Enterprise workspace, prepare an unselected Editor, a selected Editor, a Viewer, and a team containing another Editor.
2. As a Builder or Admin, open the context menu for a field, choose **Edit field permissions**, then select **Specific users or teams**.
3. Search for and select the selected Editor, the Viewer, and the team. Cancel once and reopen the modal to confirm changes are staged until **Save**.
4. Repeat the selection, save, and reopen the modal to confirm it persists.
5. Confirm the selected Editor and the Editor in the selected team can edit the field.
6. Confirm the unselected Editor and the selected Viewer cannot edit it; selection must not grant or elevate table access.
7. Remove a subject and save, then switch away from **Specific users or teams** and confirm the standard role-based behavior is restored. Optionally verify the existing form exception still works.

Closes #5005
