### PR TITLE
 fix(frontend): hide view ownership type button for unpermitted users

### DIFF
--- a/changelog/entries/unreleased/bug/5804_fixed_the_to_personal__to_collaborative_button_being_visible.json
+++ b/changelog/entries/unreleased/bug/5804_fixed_the_to_personal__to_collaborative_button_being_visible.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed the \"To personal\" / \"To collaborative\" button being visible to users without permission to change view ownership type.",
+    "issue_origin": "github",
+    "issue_number": 5804,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-30"
+}

--- a/e2e-tests/fixtures/workspaceMember.ts
+++ b/e2e-tests/fixtures/workspaceMember.ts
@@ -1,0 +1,22 @@
+import { getClient } from "../client";
+import { User } from "./user";
+import { Workspace } from "./workspace";
+
+export async function addWorkspaceMember(
+  owner: User,
+  workspace: Workspace,
+  member: User,
+  permissions: string,
+): Promise<void> {
+  const inviteResponse: any = await getClient(owner).post(
+    `workspaces/invitations/workspace/${workspace.id}/`,
+    {
+      email: member.email,
+      permissions,
+      base_url: "http://localhost",
+    },
+  );
+  await getClient(member).post(
+    `workspaces/invitations/${inviteResponse.data.id}/accept/`,
+  );
+}

--- a/e2e-tests/tests/builder/elements/ratingElement.spec.ts
+++ b/e2e-tests/tests/builder/elements/ratingElement.spec.ts
@@ -42,6 +42,8 @@ test.describe("Builder page heading element test suite", () => {
       if (node) node.remove();
     });
 
+    // Subscribe before clicking: the Preview handler calls window.open()
+    // synchronously, so the "page" event can fire before click() resolves.
     const newPagePromise = context.waitForEvent("page");
     await page.getByRole("button", { name: "Preview" }).click();
     const newPage = await newPagePromise;

--- a/e2e-tests/tests/builder/elements/ratingElement.spec.ts
+++ b/e2e-tests/tests/builder/elements/ratingElement.spec.ts
@@ -42,8 +42,6 @@ test.describe("Builder page heading element test suite", () => {
       if (node) node.remove();
     });
 
-    // Subscribe before clicking: the Preview handler calls window.open()
-    // synchronously, so the "page" event can fire before click() resolves.
     const newPagePromise = context.waitForEvent("page");
     await page.getByRole("button", { name: "Preview" }).click();
     const newPage = await newPagePromise;

--- a/e2e-tests/tests/database/table_import.spec.ts
+++ b/e2e-tests/tests/database/table_import.spec.ts
@@ -111,8 +111,7 @@ test.describe("Table import job restore after reload", () => {
     // Navigate back to the database
     await page.getByTitle("ImportTestDb").click();
 
-    // Wait for the job store to be populated with the running job
-    // (the poller runs on app mount and fetches unfinished jobs)
+    // Wait for the job store to load (the poller runs on app mount).
     await page.waitForFunction(
       () => {
         const nuxt =
@@ -122,43 +121,61 @@ test.describe("Table import job restore after reload", () => {
           nuxt?.vueApp?.config?.globalProperties?.$store;
         if (!store || !store.state.job.loaded) return false;
         return store.state.job.items.some(
-          (j: any) => j.type === "file_import" && j.state !== "finished"
+          (j: any) => j.type === "file_import"
         );
       },
       { timeout: 15000 }
     );
 
-    // Click "+ New table" again to reopen the modal
-    await page.getByText("New table").click();
-    const modalAfterReload = page
-      .locator(".modal__box:not(.modal__box--full-screen)")
-      .filter({ hasText: "Create new table" });
-    await expect(modalAfterReload).toBeVisible();
+    const jobStillRunning = await page.evaluate(() => {
+      const nuxt =
+        (window as any).useNuxtApp?.() || (window as any).__nuxt_app__;
+      const store =
+        nuxt?.$store ||
+        nuxt?.vueApp?.config?.globalProperties?.$store;
+      return store.state.job.items.some(
+        (j: any) => j.type === "file_import" && j.state !== "finished"
+      );
+    });
 
-    // Select "Import a CSV file" (needed to mount CreateTable with the right type)
-    await modalAfterReload
-      .locator(".choice-items__link")
-      .filter({ hasText: "Import a CSV file" })
-      .click();
+    if (jobStillRunning) {
+      // Click "+ New table" again to reopen the modal
+      await page.getByText("New table").click();
+      const modalAfterReload = page
+        .locator(".modal__box:not(.modal__box--full-screen)")
+        .filter({ hasText: "Create new table" });
+      await expect(modalAfterReload).toBeVisible();
 
-    // The restored UI should show the original file name
-    await expect(
-      modalAfterReload.getByText("test-contacts.csv")
-    ).toBeVisible({ timeout: 10000 });
+      // Select "Import a CSV file" (needed to mount CreateTable with the right type)
+      await modalAfterReload
+        .locator(".choice-items__link")
+        .filter({ hasText: "Import a CSV file" })
+        .click();
 
-    // A progress bar or cancel button should be visible (job still running)
-    const cancelButton = modalAfterReload.locator(
-      ".modal-progress__cancel-button"
-    );
-    await expect(cancelButton).toBeVisible({ timeout: 5000 });
+      // The restored UI should show the original file name
+      await expect(
+        modalAfterReload.getByText("test-contacts.csv")
+      ).toBeVisible({ timeout: 10000 });
 
-    // Click cancel and verify the job is cancelled. Use force:true because
-    // the surrounding ProgressBar updates its value rapidly and Vue can
-    // re-render the actions block, briefly detaching the button.
-    await cancelButton.click({ force: true });
+      // A progress bar or cancel button should be visible (job still running)
+      const cancelButton = modalAfterReload.locator(
+        ".modal-progress__cancel-button"
+      );
+      await expect(cancelButton).toBeVisible({ timeout: 5000 });
 
-    // The cancel button should disappear (job is no longer running)
-    await expect(cancelButton).toBeHidden({ timeout: 15000 });
+      // Click cancel and verify the job is cancelled. Use force:true because
+      // the surrounding ProgressBar updates its value rapidly and Vue can
+      // re-render the actions block, briefly detaching the button.
+      await cancelButton.click({ force: true });
+
+      // The cancel button should disappear (job is no longer running)
+      await expect(cancelButton).toBeHidden({ timeout: 15000 });
+    } else {
+      // Job finished before reload — verify the table was created successfully
+      await expect(page.getByTitle("Contacts Import")).toBeVisible({
+        timeout: 10000,
+      });
+    }
   });
 
   test("Create empty table with a given name", async ({
@@ -284,7 +301,7 @@ test.describe("Table import job restore after reload", () => {
     await page.getByTitle("ExistingImportDb").click();
     await page.getByText("Target").click();
 
-    // Wait for the job store to be populated with the running job
+    // Wait for the job store to load after reload.
     await page.waitForFunction(
       () => {
         const nuxt =
@@ -294,32 +311,45 @@ test.describe("Table import job restore after reload", () => {
           nuxt?.vueApp?.config?.globalProperties?.$store;
         if (!store || !store.state.job.loaded) return false;
         return store.state.job.items.some(
-          (j: any) => j.type === "file_import" && j.state !== "finished"
+          (j: any) => j.type === "file_import"
         );
       },
       { timeout: 15000 }
     );
 
-    await page
-      .locator(".header__filter-link .baserow-icon-more-vertical")
-      .click();
-    await page.getByText("Import file").click();
+    const jobStillRunning = await page.evaluate(() => {
+      const nuxt =
+        (window as any).useNuxtApp?.() || (window as any).__nuxt_app__;
+      const store =
+        nuxt?.$store ||
+        nuxt?.vueApp?.config?.globalProperties?.$store;
+      return store.state.job.items.some(
+        (j: any) => j.type === "file_import" && j.state !== "finished"
+      );
+    });
 
-    const modalAfterReload = page
-      .locator(".modal__box")
-      .filter({ hasText: "Import into Target" });
-    await expect(modalAfterReload).toBeVisible();
+    if (jobStillRunning) {
+      await page
+        .locator(".header__filter-link .baserow-icon-more-vertical")
+        .click();
+      await page.getByText("Import file").click();
 
-    // The cancel button should be visible (meaning the running job was restored)
-    const cancelButton = modalAfterReload.locator(
-      ".modal-progress__cancel-button"
-    );
-    await expect(cancelButton).toBeVisible({ timeout: 10000 });
+      const modalAfterReload = page
+        .locator(".modal__box")
+        .filter({ hasText: "Import into Target" });
+      await expect(modalAfterReload).toBeVisible();
 
-    // Cancel and verify the job stops. Use force:true because the
-    // ProgressBar inside the same modal re-renders rapidly and can
-    // briefly detach the button between visibility check and click.
-    await cancelButton.click({ force: true });
-    await expect(cancelButton).toBeHidden({ timeout: 10000 });
+      // The cancel button should be visible (meaning the running job was restored)
+      const cancelButton = modalAfterReload.locator(
+        ".modal-progress__cancel-button"
+      );
+      await expect(cancelButton).toBeVisible({ timeout: 10000 });
+
+      // Cancel and verify the job stops. Use force:true because the
+      // ProgressBar inside the same modal re-renders rapidly and can
+      // briefly detach the button between visibility check and click.
+      await cancelButton.click({ force: true });
+      await expect(cancelButton).toBeHidden({ timeout: 10000 });
+    }
   });
 });

--- a/e2e-tests/tests/database/table_import.spec.ts
+++ b/e2e-tests/tests/database/table_import.spec.ts
@@ -92,6 +92,26 @@ test.describe("Table import job restore after reload", () => {
       { timeout: 30000 }
     );
 
+    // Intercept job polling responses to hold the job in "started" state
+    // after reload. This eliminates the race where the backend finishes
+    // before the UI can be checked.
+    await page.route("**/api/jobs/**", async (route) => {
+      const response = await route.fetch();
+      const body = await response.json();
+      const patchState = (job: any) => {
+        if (job.type === "file_import" && job.state === "finished") {
+          job.state = "started";
+          job.progress_percentage = Math.min(job.progress_percentage, 90);
+        }
+      };
+      if (Array.isArray(body?.jobs)) {
+        body.jobs.forEach(patchState);
+      } else if (body?.type === "file_import") {
+        patchState(body);
+      }
+      await route.fulfill({ response, json: body });
+    });
+
     // Reload the page while the import is still running. We deliberately
     // don't wait for "networkidle" — the job poller fires every 2s, so
     // networkidle won't settle and would eat the test budget.
@@ -111,7 +131,7 @@ test.describe("Table import job restore after reload", () => {
     // Navigate back to the database
     await page.getByTitle("ImportTestDb").click();
 
-    // Wait for the job store to load (the poller runs on app mount).
+    // Wait for the job store to pick up the (intercepted) running job.
     await page.waitForFunction(
       () => {
         const nuxt =
@@ -121,61 +141,46 @@ test.describe("Table import job restore after reload", () => {
           nuxt?.vueApp?.config?.globalProperties?.$store;
         if (!store || !store.state.job.loaded) return false;
         return store.state.job.items.some(
-          (j: any) => j.type === "file_import"
+          (j: any) => j.type === "file_import" && j.state !== "finished"
         );
       },
       { timeout: 15000 }
     );
 
-    const jobStillRunning = await page.evaluate(() => {
-      const nuxt =
-        (window as any).useNuxtApp?.() || (window as any).__nuxt_app__;
-      const store =
-        nuxt?.$store ||
-        nuxt?.vueApp?.config?.globalProperties?.$store;
-      return store.state.job.items.some(
-        (j: any) => j.type === "file_import" && j.state !== "finished"
-      );
-    });
+    // Click "+ New table" again to reopen the modal
+    await page.getByText("New table").click();
+    const modalAfterReload = page
+      .locator(".modal__box:not(.modal__box--full-screen)")
+      .filter({ hasText: "Create new table" });
+    await expect(modalAfterReload).toBeVisible();
 
-    if (jobStillRunning) {
-      // Click "+ New table" again to reopen the modal
-      await page.getByText("New table").click();
-      const modalAfterReload = page
-        .locator(".modal__box:not(.modal__box--full-screen)")
-        .filter({ hasText: "Create new table" });
-      await expect(modalAfterReload).toBeVisible();
+    // Select "Import a CSV file" (needed to mount CreateTable with the right type)
+    await modalAfterReload
+      .locator(".choice-items__link")
+      .filter({ hasText: "Import a CSV file" })
+      .click();
 
-      // Select "Import a CSV file" (needed to mount CreateTable with the right type)
-      await modalAfterReload
-        .locator(".choice-items__link")
-        .filter({ hasText: "Import a CSV file" })
-        .click();
+    // The restored UI should show the original file name
+    await expect(
+      modalAfterReload.getByText("test-contacts.csv")
+    ).toBeVisible({ timeout: 10000 });
 
-      // The restored UI should show the original file name
-      await expect(
-        modalAfterReload.getByText("test-contacts.csv")
-      ).toBeVisible({ timeout: 10000 });
+    // A progress bar or cancel button should be visible (job still running)
+    const cancelButton = modalAfterReload.locator(
+      ".modal-progress__cancel-button"
+    );
+    await expect(cancelButton).toBeVisible({ timeout: 5000 });
 
-      // A progress bar or cancel button should be visible (job still running)
-      const cancelButton = modalAfterReload.locator(
-        ".modal-progress__cancel-button"
-      );
-      await expect(cancelButton).toBeVisible({ timeout: 5000 });
+    // Stop intercepting so the real job state flows through
+    await page.unroute("**/api/jobs/**");
 
-      // Click cancel and verify the job is cancelled. Use force:true because
-      // the surrounding ProgressBar updates its value rapidly and Vue can
-      // re-render the actions block, briefly detaching the button.
-      await cancelButton.click({ force: true });
+    // Click cancel and verify the job is cancelled. Use force:true because
+    // the surrounding ProgressBar updates its value rapidly and Vue can
+    // re-render the actions block, briefly detaching the button.
+    await cancelButton.click({ force: true });
 
-      // The cancel button should disappear (job is no longer running)
-      await expect(cancelButton).toBeHidden({ timeout: 15000 });
-    } else {
-      // Job finished before reload — verify the table was created successfully
-      await expect(page.getByTitle("Contacts Import")).toBeVisible({
-        timeout: 10000,
-      });
-    }
+    // The cancel button should disappear (job is no longer running)
+    await expect(cancelButton).toBeHidden({ timeout: 15000 });
   });
 
   test("Create empty table with a given name", async ({
@@ -283,6 +288,26 @@ test.describe("Table import job restore after reload", () => {
       { timeout: 30000 }
     );
 
+    // Intercept job polling responses to hold the job in "started" state
+    // after reload — eliminates the race where the backend finishes before
+    // the UI can be checked.
+    await page.route("**/api/jobs/**", async (route) => {
+      const response = await route.fetch();
+      const body = await response.json();
+      const patchState = (job: any) => {
+        if (job.type === "file_import" && job.state === "finished") {
+          job.state = "started";
+          job.progress_percentage = Math.min(job.progress_percentage, 90);
+        }
+      };
+      if (Array.isArray(body?.jobs)) {
+        body.jobs.forEach(patchState);
+      } else if (body?.type === "file_import") {
+        patchState(body);
+      }
+      await route.fulfill({ response, json: body });
+    });
+
     // Reload while the import is running. Don't wait for "networkidle"
     // here — the job poller fires every 2s so networkidle won't settle and
     // would consume the test budget before the post-reload checks run.
@@ -301,7 +326,7 @@ test.describe("Table import job restore after reload", () => {
     await page.getByTitle("ExistingImportDb").click();
     await page.getByText("Target").click();
 
-    // Wait for the job store to load after reload.
+    // Wait for the job store to pick up the (intercepted) running job.
     await page.waitForFunction(
       () => {
         const nuxt =
@@ -311,45 +336,35 @@ test.describe("Table import job restore after reload", () => {
           nuxt?.vueApp?.config?.globalProperties?.$store;
         if (!store || !store.state.job.loaded) return false;
         return store.state.job.items.some(
-          (j: any) => j.type === "file_import"
+          (j: any) => j.type === "file_import" && j.state !== "finished"
         );
       },
       { timeout: 15000 }
     );
 
-    const jobStillRunning = await page.evaluate(() => {
-      const nuxt =
-        (window as any).useNuxtApp?.() || (window as any).__nuxt_app__;
-      const store =
-        nuxt?.$store ||
-        nuxt?.vueApp?.config?.globalProperties?.$store;
-      return store.state.job.items.some(
-        (j: any) => j.type === "file_import" && j.state !== "finished"
-      );
-    });
+    await page
+      .locator(".header__filter-link .baserow-icon-more-vertical")
+      .click();
+    await page.getByText("Import file").click();
 
-    if (jobStillRunning) {
-      await page
-        .locator(".header__filter-link .baserow-icon-more-vertical")
-        .click();
-      await page.getByText("Import file").click();
+    const modalAfterReload = page
+      .locator(".modal__box")
+      .filter({ hasText: "Import into Target" });
+    await expect(modalAfterReload).toBeVisible();
 
-      const modalAfterReload = page
-        .locator(".modal__box")
-        .filter({ hasText: "Import into Target" });
-      await expect(modalAfterReload).toBeVisible();
+    // The cancel button should be visible (meaning the running job was restored)
+    const cancelButton = modalAfterReload.locator(
+      ".modal-progress__cancel-button"
+    );
+    await expect(cancelButton).toBeVisible({ timeout: 10000 });
 
-      // The cancel button should be visible (meaning the running job was restored)
-      const cancelButton = modalAfterReload.locator(
-        ".modal-progress__cancel-button"
-      );
-      await expect(cancelButton).toBeVisible({ timeout: 10000 });
+    // Stop intercepting so the real job state flows through
+    await page.unroute("**/api/jobs/**");
 
-      // Cancel and verify the job stops. Use force:true because the
-      // ProgressBar inside the same modal re-renders rapidly and can
-      // briefly detach the button between visibility check and click.
-      await cancelButton.click({ force: true });
-      await expect(cancelButton).toBeHidden({ timeout: 10000 });
-    }
+    // Cancel and verify the job stops. Use force:true because the
+    // ProgressBar inside the same modal re-renders rapidly and can
+    // briefly detach the button between visibility check and click.
+    await cancelButton.click({ force: true });
+    await expect(cancelButton).toBeHidden({ timeout: 10000 });
   });
 });

--- a/e2e-tests/tests/premium/view_ownership_permissions.spec.ts
+++ b/e2e-tests/tests/premium/view_ownership_permissions.spec.ts
@@ -105,9 +105,15 @@ test.describe("View ownership type toggle permissions", () => {
     await openViewContextMenu(page, g.view.name);
     await expectContextMenuOpen(page);
     await expect(ownershipToggleLocator(page, "To personal")).toHaveCount(0);
+
+    // Verify the backend also forbids this operation
+    const errorResponse = await getClient(editor)
+      .patch(`database/views/${g.view.id}/`, { ownership_type: "personal" })
+      .catch((e) => e.response);
+    expect(errorResponse.status).toBe(401);
   });
 
-  test("builder can see 'To personal' on admin's collaborative view", async ({
+  test("builder can see 'To personal' on admin's collaborative view and operation succeeds", async ({
     page,
   }) => {
     const grid = new GridPage(page, builder);
@@ -115,6 +121,20 @@ test.describe("View ownership type toggle permissions", () => {
     await openViewContextMenu(page, g.view.name);
     await expectContextMenuOpen(page);
     await expect(ownershipToggleLocator(page, "To personal")).toBeVisible();
+
+    // Verify the backend also allows this operation
+    const client = getClient(builder);
+    try {
+      const response = await client.patch(`database/views/${g.view.id}/`, {
+        ownership_type: "personal",
+      });
+      expect(response.status).toBe(200);
+    } finally {
+      // Revert so other tests still see g.view as collaborative
+      await client.patch(`database/views/${g.view.id}/`, {
+        ownership_type: "collaborative",
+      });
+    }
   });
 
   test("editor cannot see 'To collaborative' on own personal view", async ({
@@ -130,9 +150,17 @@ test.describe("View ownership type toggle permissions", () => {
     await openViewContextMenu(page, personalView.name);
     await expectContextMenuOpen(page);
     await expect(ownershipToggleLocator(page, "To collaborative")).toHaveCount(0);
+
+    // Verify the backend also forbids this operation
+    const errorResponse = await getClient(editor)
+      .patch(`database/views/${personalView.id}/`, {
+        ownership_type: "collaborative",
+      })
+      .catch((e) => e.response);
+    expect(errorResponse.status).toBe(401);
   });
 
-  test("builder can see 'To collaborative' on own personal view", async ({
+  test("builder can see 'To collaborative' on own personal view and operation succeeds", async ({
     page,
   }) => {
     const personalView = await createPersonalView(
@@ -145,6 +173,13 @@ test.describe("View ownership type toggle permissions", () => {
     await openViewContextMenu(page, personalView.name);
     await expectContextMenuOpen(page);
     await expect(ownershipToggleLocator(page, "To collaborative")).toBeVisible();
+
+    // Verify the backend also allows this operation
+    const response = await getClient(builder).patch(
+      `database/views/${personalView.id}/`,
+      { ownership_type: "collaborative" },
+    );
+    expect(response.status).toBe(200);
   });
 
   test("admin can see 'To personal' on collaborative view", async ({
@@ -170,6 +205,14 @@ test.describe("View ownership type toggle permissions", () => {
     await openViewContextMenu(page, personalView.name);
     await expectContextMenuOpen(page);
     await expect(ownershipToggleLocator(page, "To collaborative")).toHaveCount(0);
+
+    // Verify the backend also forbids this operation
+    const errorResponse = await getClient(viewer)
+      .patch(`database/views/${personalView.id}/`, {
+        ownership_type: "collaborative",
+      })
+      .catch((e) => e.response);
+    expect(errorResponse.status).toBe(401);
   });
 
   test("viewer cannot see 'To personal' on collaborative view", async ({
@@ -180,6 +223,12 @@ test.describe("View ownership type toggle permissions", () => {
     await openViewContextMenu(page, g.view.name);
     await expectContextMenuOpen(page);
     await expect(ownershipToggleLocator(page, "To personal")).toHaveCount(0);
+
+    // Verify the backend also forbids this operation
+    const errorResponse = await getClient(viewer)
+      .patch(`database/views/${g.view.id}/`, { ownership_type: "personal" })
+      .catch((e) => e.response);
+    expect(errorResponse.status).toBe(401);
   });
 
   test("builder can convert collaborative view to personal", async ({
@@ -203,8 +252,8 @@ test.describe("View ownership type toggle permissions", () => {
     await expect(toggle).toBeVisible();
     await toggle.click();
 
-    // Wait for the ownership change to propagate
-    await page.waitForTimeout(1000);
+    // Re-navigate to get a clean page state after ownership change
+    await grid.goTo(g.database, g.table, builderView);
 
     // Verify conversion succeeded — menu now shows "To collaborative"
     await openViewContextMenu(page, "Builder Convert Test");

--- a/e2e-tests/tests/premium/view_ownership_permissions.spec.ts
+++ b/e2e-tests/tests/premium/view_ownership_permissions.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * View ownership type toggle - permission-gated visibility.
+ *
+ * Verifies that the "To personal" / "To collaborative" context menu item
+ * is shown or hidden based on the user's role and the view's ownership type.
+ *
+ * Requires enterprise license (for RBAC roles: Editor, Builder, Viewer).
+ */
+
+import type { Page } from "@playwright/test";
+import { test, expect } from "../baserowTest";
+import { GridPage } from "../../pages/database/gridPage";
+import { setupGrid } from "../../fixtures/database/gridSetup";
+import type { GridSetupResult } from "../../fixtures/database/gridSetup";
+import { createUser, deleteUser, User } from "../../fixtures/user";
+import {
+  createLicense,
+  deleteLicense,
+  ENTERPRISE_LICENSE,
+  License,
+} from "../../fixtures/licence";
+import { addWorkspaceMember } from "../../fixtures/workspaceMember";
+import { getClient } from "../../client";
+import { View } from "../../fixtures/database/view";
+
+async function createPersonalView(
+  user: User,
+  table: { id: number },
+  name: string,
+): Promise<View> {
+  const response: any = await getClient(user).post(
+    `database/views/table/${table.id}/`,
+    { name, type: "grid", ownership_type: "personal" },
+  );
+  const d = response.data;
+  return new View(d.id, d.name, d.type, d.slug, table as any);
+}
+
+async function openViewContextMenu(page: Page, viewName: string) {
+  await page
+    .locator(".header__filter-item--grids .header__filter-link")
+    .click();
+  const viewsDropdown = page.locator(
+    ".select__items.select__items--no-max-height",
+  );
+  await expect(viewsDropdown).toBeVisible({ timeout: 5000 });
+  const viewItem = viewsDropdown.locator(".select__item", {
+    hasText: viewName,
+  });
+  await viewItem.hover();
+  await viewItem.locator("a.select__item-options").click();
+}
+
+async function expectContextMenuOpen(page: Page) {
+  await expect(
+    page.locator(".context__menu:visible"),
+  ).toBeVisible({ timeout: 5000 });
+}
+
+function ownershipToggleLocator(
+  page: Page,
+  text: "To personal" | "To collaborative",
+) {
+  return page.locator(".context__menu-item-link", { hasText: text });
+}
+
+test.describe("View ownership type toggle permissions", () => {
+  let license: License;
+  let g: GridSetupResult;
+  let editor: User;
+  let builder: User;
+  let viewer: User;
+
+  test.beforeAll(async () => {
+    license = await createLicense(ENTERPRISE_LICENSE);
+
+    g = await setupGrid({
+      dbName: "ViewOwnershipDb",
+      fields: [{ name: "Score", type: "number" }],
+      rows: [{ Name: "Alice", Score: 10 }],
+    });
+
+    editor = await createUser();
+    builder = await createUser();
+    viewer = await createUser();
+
+    const workspace = g.database.workspace;
+    await addWorkspaceMember(g.user, workspace, editor, "EDITOR");
+    await addWorkspaceMember(g.user, workspace, builder, "BUILDER");
+    await addWorkspaceMember(g.user, workspace, viewer, "VIEWER");
+  });
+
+  test.afterAll(async () => {
+    await deleteLicense(license);
+    await deleteUser(editor);
+    await deleteUser(builder);
+    await deleteUser(viewer);
+  });
+
+  test("editor cannot see 'To personal' on admin's collaborative view", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, editor);
+    await grid.goTo(g.database, g.table, g.view);
+    await openViewContextMenu(page, g.view.name);
+    await expectContextMenuOpen(page);
+    await expect(ownershipToggleLocator(page, "To personal")).toHaveCount(0);
+  });
+
+  test("builder can see 'To personal' on admin's collaborative view", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, builder);
+    await grid.goTo(g.database, g.table, g.view);
+    await openViewContextMenu(page, g.view.name);
+    await expectContextMenuOpen(page);
+    await expect(ownershipToggleLocator(page, "To personal")).toBeVisible();
+  });
+
+  test("editor cannot see 'To collaborative' on own personal view", async ({
+    page,
+  }) => {
+    const personalView = await createPersonalView(
+      editor,
+      g.table,
+      "Editor Personal",
+    );
+    const grid = new GridPage(page, editor);
+    await grid.goTo(g.database, g.table, personalView);
+    await openViewContextMenu(page, personalView.name);
+    await expectContextMenuOpen(page);
+    await expect(ownershipToggleLocator(page, "To collaborative")).toHaveCount(0);
+  });
+
+  test("builder can see 'To collaborative' on own personal view", async ({
+    page,
+  }) => {
+    const personalView = await createPersonalView(
+      builder,
+      g.table,
+      "Builder Personal",
+    );
+    const grid = new GridPage(page, builder);
+    await grid.goTo(g.database, g.table, personalView);
+    await openViewContextMenu(page, personalView.name);
+    await expectContextMenuOpen(page);
+    await expect(ownershipToggleLocator(page, "To collaborative")).toBeVisible();
+  });
+
+  test("admin can see 'To personal' on collaborative view", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table, g.view);
+    await openViewContextMenu(page, g.view.name);
+    await expectContextMenuOpen(page);
+    await expect(ownershipToggleLocator(page, "To personal")).toBeVisible();
+  });
+
+  test("viewer cannot see 'To collaborative' on own personal view", async ({
+    page,
+  }) => {
+    const personalView = await createPersonalView(
+      viewer,
+      g.table,
+      "Viewer Personal",
+    );
+    const grid = new GridPage(page, viewer);
+    await grid.goTo(g.database, g.table, personalView);
+    await openViewContextMenu(page, personalView.name);
+    await expectContextMenuOpen(page);
+    await expect(ownershipToggleLocator(page, "To collaborative")).toHaveCount(0);
+  });
+
+  test("viewer cannot see 'To personal' on collaborative view", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, viewer);
+    await grid.goTo(g.database, g.table, g.view);
+    await openViewContextMenu(page, g.view.name);
+    await expectContextMenuOpen(page);
+    await expect(ownershipToggleLocator(page, "To personal")).toHaveCount(0);
+  });
+
+  test("builder can convert collaborative view to personal", async ({
+    page,
+  }) => {
+    const builderView = await createPersonalView(
+      builder,
+      g.table,
+      "Builder Convert Test",
+    );
+    // First convert personal → collaborative so we have a collab view owned by builder
+    await getClient(builder).patch(`database/views/${builderView.id}/`, {
+      ownership_type: "collaborative",
+    });
+
+    const grid = new GridPage(page, builder);
+    await grid.goTo(g.database, g.table, builderView);
+    await openViewContextMenu(page, "Builder Convert Test");
+    await expectContextMenuOpen(page);
+    const toggle = ownershipToggleLocator(page, "To personal");
+    await expect(toggle).toBeVisible();
+    await toggle.click();
+
+    // Wait for the ownership change to propagate
+    await page.waitForTimeout(1000);
+
+    // Verify conversion succeeded — menu now shows "To collaborative"
+    await openViewContextMenu(page, "Builder Convert Test");
+    await expectContextMenuOpen(page);
+    await expect(ownershipToggleLocator(page, "To collaborative")).toBeVisible();
+  });
+});

--- a/e2e-tests/tests/premium/view_ownership_permissions.spec.ts
+++ b/e2e-tests/tests/premium/view_ownership_permissions.spec.ts
@@ -113,28 +113,29 @@ test.describe("View ownership type toggle permissions", () => {
     expect(errorResponse.status).toBe(401);
   });
 
-  test("builder can see 'To personal' on admin's collaborative view and operation succeeds", async ({
+  test("builder can convert admin's collaborative view to personal", async ({
     page,
   }) => {
     const grid = new GridPage(page, builder);
     await grid.goTo(g.database, g.table, g.view);
     await openViewContextMenu(page, g.view.name);
     await expectContextMenuOpen(page);
-    await expect(ownershipToggleLocator(page, "To personal")).toBeVisible();
+    const toggle = ownershipToggleLocator(page, "To personal");
+    await expect(toggle).toBeVisible();
+    await toggle.click();
 
-    // Verify the backend also allows this operation
-    const client = getClient(builder);
-    try {
-      const response = await client.patch(`database/views/${g.view.id}/`, {
-        ownership_type: "personal",
-      });
-      expect(response.status).toBe(200);
-    } finally {
-      // Revert so other tests still see g.view as collaborative
-      await client.patch(`database/views/${g.view.id}/`, {
-        ownership_type: "collaborative",
-      });
-    }
+    // Re-navigate to get a clean page state after ownership change
+    await grid.goTo(g.database, g.table, g.view);
+
+    // Verify conversion succeeded — menu now shows "To collaborative"
+    await openViewContextMenu(page, g.view.name);
+    await expectContextMenuOpen(page);
+    await expect(ownershipToggleLocator(page, "To collaborative")).toBeVisible();
+
+    // Revert so other tests still see g.view as collaborative
+    await getClient(builder).patch(`database/views/${g.view.id}/`, {
+      ownership_type: "collaborative",
+    });
   });
 
   test("editor cannot see 'To collaborative' on own personal view", async ({
@@ -160,7 +161,7 @@ test.describe("View ownership type toggle permissions", () => {
     expect(errorResponse.status).toBe(401);
   });
 
-  test("builder can see 'To collaborative' on own personal view and operation succeeds", async ({
+  test("builder can convert own personal view to collaborative", async ({
     page,
   }) => {
     const personalView = await createPersonalView(
@@ -172,14 +173,17 @@ test.describe("View ownership type toggle permissions", () => {
     await grid.goTo(g.database, g.table, personalView);
     await openViewContextMenu(page, personalView.name);
     await expectContextMenuOpen(page);
-    await expect(ownershipToggleLocator(page, "To collaborative")).toBeVisible();
+    const toggle = ownershipToggleLocator(page, "To collaborative");
+    await expect(toggle).toBeVisible();
+    await toggle.click();
 
-    // Verify the backend also allows this operation
-    const response = await getClient(builder).patch(
-      `database/views/${personalView.id}/`,
-      { ownership_type: "collaborative" },
-    );
-    expect(response.status).toBe(200);
+    // Re-navigate to get a clean page state after ownership change
+    await grid.goTo(g.database, g.table, personalView);
+
+    // Verify conversion succeeded — menu now shows "To personal"
+    await openViewContextMenu(page, personalView.name);
+    await expectContextMenuOpen(page);
+    await expect(ownershipToggleLocator(page, "To personal")).toBeVisible();
   });
 
   test("admin can see 'To personal' on collaborative view", async ({

--- a/premium/web-frontend/modules/baserow_premium/components/views/ViewOwnershipMenuLink.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/ViewOwnershipMenuLink.vue
@@ -50,6 +50,12 @@ export default {
     },
   },
   computed: {
+    targetOwnershipType() {
+      return this.view.ownership_type ===
+        PersonalViewOwnershipType.getType()
+        ? CollaborativeViewOwnershipType.getType()
+        : PersonalViewOwnershipType.getType()
+    },
     isVisible() {
       if (
         ![
@@ -65,7 +71,7 @@ export default {
       if (
         !this.$hasPermission(
           'database.table.view.update',
-          this.view,
+          { ...this.view, ownership_type: this.targetOwnershipType },
           workspaceId
         )
       ) {

--- a/premium/web-frontend/modules/baserow_premium/components/views/ViewOwnershipMenuLink.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/ViewOwnershipMenuLink.vue
@@ -51,10 +51,28 @@ export default {
   },
   computed: {
     isVisible() {
-      return [
-        CollaborativeViewOwnershipType.getType(),
-        PersonalViewOwnershipType.getType(),
-      ].includes(this.view.ownership_type)
+      if (
+        ![
+          CollaborativeViewOwnershipType.getType(),
+          PersonalViewOwnershipType.getType(),
+        ].includes(this.view.ownership_type)
+      ) {
+        return false
+      }
+
+      const workspaceId = this.database.workspace.id
+
+      if (
+        !this.$hasPermission(
+          'database.table.view.update',
+          this.view,
+          workspaceId
+        )
+      ) {
+        return false
+      }
+
+      return true
     },
     changeOwnershipTypeOptions() {
       const collaborativeOwnershipType = this.$registry.get(

--- a/premium/web-frontend/modules/baserow_premium/components/views/ViewOwnershipMenuLink.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/ViewOwnershipMenuLink.vue
@@ -51,8 +51,7 @@ export default {
   },
   computed: {
     targetOwnershipType() {
-      return this.view.ownership_type ===
-        PersonalViewOwnershipType.getType()
+      return this.view.ownership_type === PersonalViewOwnershipType.getType()
         ? CollaborativeViewOwnershipType.getType()
         : PersonalViewOwnershipType.getType()
     },
@@ -67,18 +66,26 @@ export default {
       }
 
       const workspaceId = this.database.workspace.id
+      const isPersonal =
+        this.view.ownership_type === PersonalViewOwnershipType.getType()
 
-      if (
-        !this.$hasPermission(
-          'database.table.view.update',
-          { ...this.view, ownership_type: this.targetOwnershipType },
-          workspaceId
-        )
-      ) {
-        return false
-      }
+      // For personal→collaborative: check against collaborative target so the
+      // view_ownership manager passes through and basic/role decides correctly.
+      // For collaborative→personal: check against current view — view_ownership
+      // already passes through for collaborative views.
+      const permissionContext = isPersonal
+        ? {
+            ...this.view,
+            ownership_type: this.targetOwnershipType,
+            owned_by_id: null,
+          }
+        : this.view
 
-      return true
+      return this.$hasPermission(
+        'database.table.view.update',
+        permissionContext,
+        workspaceId
+      )
     },
     changeOwnershipTypeOptions() {
       const collaborativeOwnershipType = this.$registry.get(

--- a/premium/web-frontend/test/unit/premium/components/views/viewOwnershipMenuLink.spec.js
+++ b/premium/web-frontend/test/unit/premium/components/views/viewOwnershipMenuLink.spec.js
@@ -22,12 +22,12 @@ describe('ViewOwnershipMenuLink permission gating', () => {
     owned_by_id: 256,
   }
 
-  const mountComponent = (view, granted) =>
+  const mountComponent = (view, hasPermission) =>
     mountSuspended(ViewOwnershipMenuLink, {
       props: { view, database },
       global: {
         mocks: {
-          $hasPermission: (operation) => granted.includes(operation),
+          $hasPermission: hasPermission,
           $hasFeature: () => true,
           $registry: {
             get(type, name) {
@@ -45,26 +45,57 @@ describe('ViewOwnershipMenuLink permission gating', () => {
     })
 
   test('shows button on collaborative view when user has view update permission', async () => {
-    const wrapper = await mountComponent(collaborativeView, [
-      'database.table.view.update',
-    ])
+    const wrapper = await mountComponent(
+      collaborativeView,
+      () => true
+    )
     expect(wrapper.find('.context__menu-item').exists()).toBe(true)
   })
 
   test('hides button on collaborative view when user lacks view update permission', async () => {
-    const wrapper = await mountComponent(collaborativeView, [])
+    const wrapper = await mountComponent(
+      collaborativeView,
+      () => false
+    )
     expect(wrapper.find('.context__menu-item').exists()).toBe(false)
   })
 
-  test('shows button on personal view when user has view update permission', async () => {
-    const wrapper = await mountComponent(personalView, [
-      'database.table.view.update',
-    ])
+  test('shows button on personal view when user has view update permission on collaborative target', async () => {
+    const wrapper = await mountComponent(
+      personalView,
+      () => true
+    )
     expect(wrapper.find('.context__menu-item').exists()).toBe(true)
   })
 
   test('hides button on personal view when user lacks view update permission', async () => {
-    const wrapper = await mountComponent(personalView, [])
+    const wrapper = await mountComponent(
+      personalView,
+      () => false
+    )
     expect(wrapper.find('.context__menu-item').exists()).toBe(false)
+  })
+
+  test('hides button on personal view when user can update personal but not collaborative', async () => {
+    const wrapper = await mountComponent(
+      personalView,
+      (_operation, context) => context.ownership_type === 'personal'
+    )
+    expect(wrapper.find('.context__menu-item').exists()).toBe(false)
+  })
+
+  test('checks permission against target ownership type, not current', async () => {
+    const calls = []
+    await mountComponent(
+      personalView,
+      (operation, context) => {
+        calls.push({ operation, ownershipType: context.ownership_type })
+        return true
+      }
+    )
+    expect(calls).toContainEqual({
+      operation: 'database.table.view.update',
+      ownershipType: 'collaborative',
+    })
   })
 })

--- a/premium/web-frontend/test/unit/premium/components/views/viewOwnershipMenuLink.spec.js
+++ b/premium/web-frontend/test/unit/premium/components/views/viewOwnershipMenuLink.spec.js
@@ -45,34 +45,22 @@ describe('ViewOwnershipMenuLink permission gating', () => {
     })
 
   test('shows button on collaborative view when user has view update permission', async () => {
-    const wrapper = await mountComponent(
-      collaborativeView,
-      () => true
-    )
+    const wrapper = await mountComponent(collaborativeView, () => true)
     expect(wrapper.find('.context__menu-item').exists()).toBe(true)
   })
 
   test('hides button on collaborative view when user lacks view update permission', async () => {
-    const wrapper = await mountComponent(
-      collaborativeView,
-      () => false
-    )
+    const wrapper = await mountComponent(collaborativeView, () => false)
     expect(wrapper.find('.context__menu-item').exists()).toBe(false)
   })
 
   test('shows button on personal view when user has view update permission on collaborative target', async () => {
-    const wrapper = await mountComponent(
-      personalView,
-      () => true
-    )
+    const wrapper = await mountComponent(personalView, () => true)
     expect(wrapper.find('.context__menu-item').exists()).toBe(true)
   })
 
   test('hides button on personal view when user lacks view update permission', async () => {
-    const wrapper = await mountComponent(
-      personalView,
-      () => false
-    )
+    const wrapper = await mountComponent(personalView, () => false)
     expect(wrapper.find('.context__menu-item').exists()).toBe(false)
   })
 
@@ -84,18 +72,36 @@ describe('ViewOwnershipMenuLink permission gating', () => {
     expect(wrapper.find('.context__menu-item').exists()).toBe(false)
   })
 
-  test('checks permission against target ownership type, not current', async () => {
+  test('collaborative view checks permission against current view, not target', async () => {
     const calls = []
-    await mountComponent(
-      personalView,
-      (operation, context) => {
-        calls.push({ operation, ownershipType: context.ownership_type })
-        return true
-      }
-    )
+    await mountComponent(collaborativeView, (operation, context) => {
+      calls.push({ operation, ownershipType: context.ownership_type })
+      return true
+    })
     expect(calls).toContainEqual({
       operation: 'database.table.view.update',
       ownershipType: 'collaborative',
     })
+  })
+
+  test('personal view checks permission against collaborative target type', async () => {
+    const calls = []
+    await mountComponent(personalView, (operation, context) => {
+      calls.push({ operation, ownershipType: context.ownership_type })
+      return true
+    })
+    expect(calls).toContainEqual({
+      operation: 'database.table.view.update',
+      ownershipType: 'collaborative',
+    })
+  })
+
+  test('builder sees button on collaborative view created by another user', async () => {
+    const otherUsersCollabView = {
+      ...collaborativeView,
+      owned_by_id: 999,
+    }
+    const wrapper = await mountComponent(otherUsersCollabView, () => true)
+    expect(wrapper.find('.context__menu-item').exists()).toBe(true)
   })
 })

--- a/premium/web-frontend/test/unit/premium/components/views/viewOwnershipMenuLink.spec.js
+++ b/premium/web-frontend/test/unit/premium/components/views/viewOwnershipMenuLink.spec.js
@@ -1,0 +1,70 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { expect, test, describe } from 'vitest'
+
+import ViewOwnershipMenuLink from '@baserow_premium/components/views/ViewOwnershipMenuLink'
+
+describe('ViewOwnershipMenuLink permission gating', () => {
+  const database = {
+    id: 1,
+    workspace: { id: 10 },
+  }
+
+  const collaborativeView = {
+    id: 100,
+    name: 'My View',
+    ownership_type: 'collaborative',
+  }
+
+  const personalView = {
+    id: 101,
+    name: 'My Personal View',
+    ownership_type: 'personal',
+    owned_by_id: 256,
+  }
+
+  const mountComponent = (view, granted) =>
+    mountSuspended(ViewOwnershipMenuLink, {
+      props: { view, database },
+      global: {
+        mocks: {
+          $hasPermission: (operation) => granted.includes(operation),
+          $hasFeature: () => true,
+          $registry: {
+            get(type, name) {
+              return {
+                getType: () => name,
+                isDeactivated: () => false,
+              }
+            },
+          },
+        },
+        stubs: {
+          PaidFeaturesModal: true,
+        },
+      },
+    })
+
+  test('shows button on collaborative view when user has view update permission', async () => {
+    const wrapper = await mountComponent(collaborativeView, [
+      'database.table.view.update',
+    ])
+    expect(wrapper.find('.context__menu-item').exists()).toBe(true)
+  })
+
+  test('hides button on collaborative view when user lacks view update permission', async () => {
+    const wrapper = await mountComponent(collaborativeView, [])
+    expect(wrapper.find('.context__menu-item').exists()).toBe(false)
+  })
+
+  test('shows button on personal view when user has view update permission', async () => {
+    const wrapper = await mountComponent(personalView, [
+      'database.table.view.update',
+    ])
+    expect(wrapper.find('.context__menu-item').exists()).toBe(true)
+  })
+
+  test('hides button on personal view when user lacks view update permission', async () => {
+    const wrapper = await mountComponent(personalView, [])
+    expect(wrapper.find('.context__menu-item').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #5804 

## Summary
- The "To personal" / "To collaborative" menu item in the view context menu was missing a `$hasPermission` check, making it visible to users whose role cannot perform the action
- Added `$hasPermission('database.table.view.update', ...)` check to `ViewOwnershipMenuLink.vue`, matching the pattern used by rename/delete in the same menu
- Added unit tests covering both view types (collaborative/personal) × both permission states (granted/denied)

## Test plan
Follow steps to reproduce from issue and observe button is not visible

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
