### PR TITLE
fix: return 400 instead of 500 for CSV field values with unquoted newlines

### DIFF
--- a/backend/src/baserow/api/admin/views.py
+++ b/backend/src/baserow/api/admin/views.py
@@ -70,7 +70,20 @@ class APIListingView(
         if not ids_param:
             return queryset
 
-        record_ids = split_comma_separated_string(ids_param)
+        try:
+            record_ids = split_comma_separated_string(ids_param)
+        except ValueError:
+            raise QueryParameterValidationException(
+                {
+                    "ids": [
+                        {
+                            "code": "invalid",
+                            "error": "The provided ids parameter is not a valid "
+                            "comma separated string.",
+                        }
+                    ]
+                }
+            )
 
         invalid_id = next(
             (record for record in record_ids if not record.isdigit()), None

--- a/backend/src/baserow/api/serializers.py
+++ b/backend/src/baserow/api/serializers.py
@@ -125,7 +125,10 @@ class CommaSeparatedIntegerValuesField(serializers.Field):
         return ",".join(value)
 
     def to_internal_value(self, data):
-        record_ids = split_comma_separated_string(data)
+        try:
+            record_ids = split_comma_separated_string(data)
+        except ValueError as e:
+            raise serializers.ValidationError(str(e), code="invalid") from e
         if not all([record.isdigit() for record in record_ids]):
             raise serializers.ValidationError("The provided record ids are not valid.")
 

--- a/backend/src/baserow/contrib/database/api/fields/serializers.py
+++ b/backend/src/baserow/contrib/database/api/fields/serializers.py
@@ -338,7 +338,10 @@ class FileFieldRequestSerializer(serializers.ListField):
             return []
 
         if isinstance(data, str):
-            data = split_comma_separated_string(data)
+            try:
+                data = split_comma_separated_string(data)
+            except ValueError as e:
+                raise serializers.ValidationError(str(e), code="invalid") from e
 
         if any([not isinstance(i, type(data[0])) for i in data]):
             raise serializers.ValidationError(
@@ -412,7 +415,10 @@ class LinkRowRequestSerializer(serializers.ListField):
                 )
 
         elif isinstance(data, str):
-            data = split_comma_separated_string(data)
+            try:
+                data = split_comma_separated_string(data)
+            except ValueError as e:
+                raise serializers.ValidationError(str(e), code="invalid") from e
 
         elif isinstance(data, int):
             data = [data]
@@ -537,7 +543,10 @@ class ListOrStringField(serializers.ListField):
 
     def to_internal_value(self, data):
         if isinstance(data, str):
-            data = split_comma_separated_string(data)
+            try:
+                data = split_comma_separated_string(data)
+            except ValueError as e:
+                raise serializers.ValidationError(str(e), code="invalid") from e
 
         return super().to_internal_value(data)
 

--- a/backend/src/baserow/contrib/database/api/utils.py
+++ b/backend/src/baserow/contrib/database/api/utils.py
@@ -6,6 +6,7 @@ from django.db.models import QuerySet
 
 from rest_framework import serializers
 
+from baserow.api.exceptions import QueryParameterValidationException
 from baserow.config.settings.utils import str_to_bool
 from baserow.contrib.database.api.rows.exceptions import InvalidJoinParameterException
 from baserow.contrib.database.fields.exceptions import (
@@ -85,8 +86,18 @@ def get_include_exclude_fields(
         queryset = Field.objects.filter(table=table)
 
     if user_field_names:
-        includes = extract_field_names_from_string(include)
-        excludes = extract_field_names_from_string(exclude)
+        try:
+            includes = extract_field_names_from_string(include)
+        except ValueError:
+            raise QueryParameterValidationException(
+                {"include": [{"error": "Invalid comma-separated field names."}]}
+            )
+        try:
+            excludes = extract_field_names_from_string(exclude)
+        except ValueError:
+            raise QueryParameterValidationException(
+                {"exclude": [{"error": "Invalid comma-separated field names."}]}
+            )
         filter_type = "name__in"
     else:
         includes = extract_field_ids_from_string(include)
@@ -118,10 +129,7 @@ def extract_field_names_from_string(value):
     if not value:
         return []
 
-    try:
-        return split_comma_separated_string(value)
-    except ValueError:
-        return []
+    return split_comma_separated_string(value)
 
 
 def extract_field_ids_from_list(

--- a/backend/src/baserow/contrib/database/api/utils.py
+++ b/backend/src/baserow/contrib/database/api/utils.py
@@ -118,7 +118,10 @@ def extract_field_names_from_string(value):
     if not value:
         return []
 
-    return split_comma_separated_string(value)
+    try:
+        return split_comma_separated_string(value)
+    except ValueError:
+        return []
 
 
 def extract_field_ids_from_list(

--- a/backend/src/baserow/contrib/database/api/views/grid/utils.py
+++ b/backend/src/baserow/contrib/database/api/views/grid/utils.py
@@ -83,7 +83,11 @@ def parse_adhoc_view_group_bys(
 
     field_objects = model._field_objects
     group_bys = []
-    for raw_entry in split_comma_separated_string(raw_group_by):
+    try:
+        raw_entries = split_comma_separated_string(raw_group_by)
+    except ValueError:
+        raise OrderByFieldNotFound(raw_group_by)
+    for raw_entry in raw_entries:
         field_id = get_field_id_from_field_key(raw_entry, strict=False)
         if (
             field_id is None

--- a/backend/src/baserow/contrib/database/api/views/grid/views.py
+++ b/backend/src/baserow/contrib/database/api/views/grid/views.py
@@ -1221,10 +1221,6 @@ class PublicGridViewRowsView(APIView):
             response.data.update(**public_view_field_options)
 
         if group_by_metadata and group_by:
-            try:
-                group_by_field_strings = split_comma_separated_string(group_by)
-            except ValueError:
-                group_by_field_strings = []
             group_by_fields = [
                 # We can safely do this without having to check whether the
                 # `group_by` input is valid because this has already been validated
@@ -1232,7 +1228,7 @@ class PublicGridViewRowsView(APIView):
                 model._field_objects[get_field_id_from_field_key(field_string, False)][
                     "field"
                 ]
-                for field_string in group_by_field_strings
+                for field_string in split_comma_separated_string(group_by)
             ]
             serialized_group_by_metadata = serialize_group_by_fields_metadata(
                 queryset, group_by_fields, page

--- a/backend/src/baserow/contrib/database/api/views/grid/views.py
+++ b/backend/src/baserow/contrib/database/api/views/grid/views.py
@@ -1221,6 +1221,10 @@ class PublicGridViewRowsView(APIView):
             response.data.update(**public_view_field_options)
 
         if group_by_metadata and group_by:
+            try:
+                group_by_field_strings = split_comma_separated_string(group_by)
+            except ValueError:
+                group_by_field_strings = []
             group_by_fields = [
                 # We can safely do this without having to check whether the
                 # `group_by` input is valid because this has already been validated
@@ -1228,7 +1232,7 @@ class PublicGridViewRowsView(APIView):
                 model._field_objects[get_field_id_from_field_key(field_string, False)][
                     "field"
                 ]
-                for field_string in split_comma_separated_string(group_by)
+                for field_string in group_by_field_strings
             ]
             serialized_group_by_metadata = serialize_group_by_fields_metadata(
                 queryset, group_by_fields, page

--- a/backend/src/baserow/contrib/database/table/models.py
+++ b/backend/src/baserow/contrib/database/table/models.py
@@ -264,7 +264,10 @@ class TableModelQuerySet(MultiFieldPrefetchQuerysetMixin, BaserowCTEQuerySet):
         :rtype: QuerySet
         """
 
-        order_by_fields = split_comma_separated_string(order_string)
+        try:
+            order_by_fields = split_comma_separated_string(order_string)
+        except ValueError:
+            raise OrderByFieldNotFound(order_string)
 
         if user_field_names:
             field_object_dict = {

--- a/backend/src/baserow/core/formula/validator.py
+++ b/backend/src/baserow/core/formula/validator.py
@@ -204,10 +204,10 @@ def ensure_array(value: Any, allow_empty: bool = True) -> List[Any]:
     if isinstance(value, str):
         try:
             return [item.strip() for item in split_comma_separated_string(value)]
-        except ValueError:
+        except ValueError as e:
             raise ValidationError(
                 "The provided value is not a valid comma separated string."
-            )
+            ) from e
 
     return [value]
 

--- a/backend/src/baserow/core/formula/validator.py
+++ b/backend/src/baserow/core/formula/validator.py
@@ -202,7 +202,12 @@ def ensure_array(value: Any, allow_empty: bool = True) -> List[Any]:
         return value
 
     if isinstance(value, str):
-        return [item.strip() for item in split_comma_separated_string(value)]
+        try:
+            return [item.strip() for item in split_comma_separated_string(value)]
+        except ValueError:
+            raise ValidationError(
+                "The provided value is not a valid comma separated string."
+            )
 
     return [value]
 

--- a/backend/src/baserow/core/utils.py
+++ b/backend/src/baserow/core/utils.py
@@ -516,15 +516,20 @@ def split_comma_separated_string(comma_separated_string: str) -> List[str]:
 
     :param comma_separated_string: The string to split
     :return: A list of split items from the provided string.
+    :raises ValueError: If the string cannot be parsed as valid CSV (e.g. unquoted
+        newlines).
     """
 
     # Use python's csv handler as it knows how to handle quoted csv values etc.
     # csv.reader returns an iterator, we use next to get the first split row back.
-    return next(
-        csv.reader(
-            [comma_separated_string], delimiter=",", quotechar='"', escapechar="\\"
+    try:
+        return next(
+            csv.reader(
+                [comma_separated_string], delimiter=",", quotechar='"', escapechar="\\"
+            )
         )
-    )
+    except csv.Error as e:
+        raise ValueError(f"Could not split comma separated string: {e}") from e
 
 
 def list_to_comma_separated_string(value_list: List[str]) -> str:

--- a/backend/tests/baserow/api/admin/groups/test_workspaces_admin_views.py
+++ b/backend/tests/baserow/api/admin/groups/test_workspaces_admin_views.py
@@ -375,3 +375,12 @@ def test_admin_list_workspaces_as_options_filter_by_invalid_ids(
             "error": "'-2' is not a valid ID. Only positive integers are accepted.",
         }
     ]
+
+    # Newline in ids should return 400, not 500.
+    response = api_client.get(
+        reverse("api:admin:workspaces:options") + "?ids=1%0A2",
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {admin_token}",
+    )
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_QUERY_PARAMETER_VALIDATION"

--- a/backend/tests/baserow/api/test_csv_serializer_validation.py
+++ b/backend/tests/baserow/api/test_csv_serializer_validation.py
@@ -1,0 +1,12 @@
+import pytest
+from rest_framework import serializers
+
+from baserow.api.serializers import CommaSeparatedIntegerValuesField
+
+MALFORMED_CSV = '[\n  {\n    "name": ""\n  }\n]'
+
+
+def test_comma_separated_integer_field_newline_returns_validation_error():
+    field = CommaSeparatedIntegerValuesField()
+    with pytest.raises(serializers.ValidationError):
+        field.to_internal_value(MALFORMED_CSV)

--- a/backend/tests/baserow/contrib/database/api/fields/test_csv_field_validation.py
+++ b/backend/tests/baserow/contrib/database/api/fields/test_csv_field_validation.py
@@ -1,0 +1,28 @@
+import pytest
+from rest_framework import serializers
+
+from baserow.contrib.database.api.fields.serializers import (
+    FileFieldRequestSerializer,
+    LinkRowRequestSerializer,
+    ListOrStringField,
+)
+
+MALFORMED_CSV = '[\n  {\n    "name": ""\n  }\n]'
+
+
+def test_file_field_request_serializer_newline_returns_validation_error():
+    field = FileFieldRequestSerializer()
+    with pytest.raises(serializers.ValidationError):
+        field.to_internal_value(MALFORMED_CSV)
+
+
+def test_link_row_request_serializer_newline_returns_validation_error():
+    field = LinkRowRequestSerializer()
+    with pytest.raises(serializers.ValidationError):
+        field.to_internal_value(MALFORMED_CSV)
+
+
+def test_list_or_string_field_newline_returns_validation_error():
+    field = ListOrStringField()
+    with pytest.raises(serializers.ValidationError):
+        field.to_internal_value(MALFORMED_CSV)

--- a/backend/tests/baserow/contrib/database/api/rows/test_csv_newline_validation.py
+++ b/backend/tests/baserow/contrib/database/api/rows/test_csv_newline_validation.py
@@ -1,0 +1,35 @@
+from django.shortcuts import reverse
+
+import pytest
+from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_list_rows_order_by_with_newline_returns_400(api_client, data_fixture):
+    user, jwt_token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    data_fixture.create_text_field(table=table, name="Name")
+
+    url = reverse("api:database:rows:list", kwargs={"table_id": table.id})
+    response = api_client.get(
+        f"{url}?order_by=field_1%0Afield_2",
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {jwt_token}",
+    )
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_ORDER_BY_FIELD_NOT_FOUND"
+
+
+@pytest.mark.django_db
+def test_list_rows_include_with_newline_ignored(api_client, data_fixture):
+    user, jwt_token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    data_fixture.create_text_field(table=table, name="Name")
+
+    url = reverse("api:database:rows:list", kwargs={"table_id": table.id})
+    response = api_client.get(
+        f"{url}?user_field_names=true&include=a%0Ab",
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {jwt_token}",
+    )
+    assert response.status_code == HTTP_200_OK

--- a/backend/tests/baserow/contrib/database/api/rows/test_csv_newline_validation.py
+++ b/backend/tests/baserow/contrib/database/api/rows/test_csv_newline_validation.py
@@ -1,7 +1,7 @@
 from django.shortcuts import reverse
 
 import pytest
-from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
+from rest_framework.status import HTTP_400_BAD_REQUEST
 
 
 @pytest.mark.django_db
@@ -21,15 +21,19 @@ def test_list_rows_order_by_with_newline_returns_400(api_client, data_fixture):
 
 
 @pytest.mark.django_db
-def test_list_rows_include_with_newline_ignored(api_client, data_fixture):
+@pytest.mark.parametrize("param", ["include", "exclude"])
+def test_list_rows_include_exclude_with_newline_returns_400(
+    param, api_client, data_fixture
+):
     user, jwt_token = data_fixture.create_user_and_token()
     table = data_fixture.create_database_table(user=user)
     data_fixture.create_text_field(table=table, name="Name")
 
     url = reverse("api:database:rows:list", kwargs={"table_id": table.id})
     response = api_client.get(
-        f"{url}?user_field_names=true&include=a%0Ab",
+        f"{url}?user_field_names=true&{param}=a%0Ab",
         format="json",
         HTTP_AUTHORIZATION=f"JWT {jwt_token}",
     )
-    assert response.status_code == HTTP_200_OK
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_QUERY_PARAMETER_VALIDATION"

--- a/backend/tests/baserow/core/test_core_utils.py
+++ b/backend/tests/baserow/core/test_core_utils.py
@@ -137,6 +137,11 @@ def test_split_comma_separated_string():
     assert split_comma_separated_string('A,\\"B,C\\,D') == ["A", '"B', "C,D"]
 
 
+def test_split_comma_separated_string_with_unquoted_newline_raises_value_error():
+    with pytest.raises(ValueError):
+        split_comma_separated_string('[\n  {\n    "name": ""\n  }\n]')
+
+
 def test_remove_invalid_surrogate_characters():
     assert remove_invalid_surrogate_characters(b"test\uD83Dtest") == "testtest"
 

--- a/backend/tests/baserow/core/test_core_validators.py
+++ b/backend/tests/baserow/core/test_core_validators.py
@@ -2,6 +2,7 @@ from django.core.exceptions import ValidationError
 
 import pytest
 
+from baserow.core.formula.validator import ensure_array
 from baserow.core.user.password_validation import MaximumLengthValidator
 
 very_long_password = (
@@ -38,3 +39,8 @@ def test_max_length_validator_help_text():
         MaximumLengthValidator(max_length=1).get_help_text()
         == expected_help_text_singular
     )
+
+
+def test_ensure_array_with_unquoted_newline_raises_validation_error():
+    with pytest.raises(ValidationError):
+        ensure_array('[\n  {\n    "name": ""\n  }\n]')

--- a/changelog/entries/unreleased/bug/5823_raise_a_400_validation_error_instead_of_an_unhandled_500_whe.json
+++ b/changelog/entries/unreleased/bug/5823_raise_a_400_validation_error_instead_of_an_unhandled_500_whe.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Raise a 400 validation error instead of an unhandled 500 when comma-separated field values contain unquoted newlines.",
+    "issue_origin": "github",
+    "issue_number": 5823,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-03"
+}


### PR DESCRIPTION
Fixes an unhandled `csv.Error` in `split_comma_separated_string` that caused 500 responses instead of 400 validation errors when API clients sent string values containing unquoted newlines to comma-separated field inputs.

**Root cause:** `csv.reader` raises `csv.Error` on unquoted newlines, which does not inherit from `ValueError` and escapes DRF's validation layer.

**Fix:**
- Wrap `csv.reader` in `split_comma_separated_string` with `try/except csv.Error`, re-raise as `ValueError`
- Catch `ValueError` at each user-facing call site and translate to the appropriate domain error:
  - Serializers (`FileFieldRequestSerializer`, `LinkRowRequestSerializer`, `ListOrStringField`, `CommaSeparatedIntegerValuesField`): → `serializers.ValidationError`
  - Admin views (`?ids=` param): → `QueryParameterValidationException`
  - Grid group-by utils: → `OrderByFieldNotFound`
  - Table model `order_by_fields_string`: → `OrderByFieldNotFound`
  - Formula validator `ensure_array`: → `django.core.exceptions.ValidationError`

**Sentry:** Fixes BASEROW-SAAS-BACKEND-RM, BASEROW-SAAS-BACKEND-5G, BASEROW-SAAS-BACKEND-W1, BASEROW-SAAS-BACKEND-1AS

### How to test this PR

1. Create a table with a file field.
2. `POST /api/database/rows/table/{table_id}/` with body:
   ```json
   {"field_<id>": "[\n  {\n    \"name\": \"\"\n  }\n]"}
   ```
3. Confirm response is `400` with a validation error, not `500`.
4. `GET /api/database/rows/table/{table_id}/?order_by=field_1%0Afield_2` — confirm `400` `ERROR_ORDER_BY_FIELD_NOT_FOUND`, not `500`.
5. Run tests: `just b test tests/baserow/core/test_core_utils.py tests/baserow/core/test_core_validators.py tests/baserow/contrib/database/api/fields/test_csv_field_validation.py tests/baserow/api/test_csv_serializer_validation.py`

Closes #5823 

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
