### PR TITLE
feat: arrange widgets on a responsive grid

### DIFF
--- a/backend/src/baserow/contrib/dashboard/api/widgets/errors.py
+++ b/backend/src/baserow/contrib/dashboard/api/widgets/errors.py
@@ -17,3 +17,9 @@ ERROR_WIDGET_IMPROPERLY_CONFIGURED = (
     HTTP_400_BAD_REQUEST,
     "The requested configuration is not allowed.",
 )
+
+ERROR_WIDGET_LAYOUT_INVALID = (
+    "ERROR_WIDGET_LAYOUT_INVALID",
+    HTTP_400_BAD_REQUEST,
+    "The requested widget layout is not valid for this dashboard.",
+)

--- a/backend/src/baserow/contrib/dashboard/api/widgets/serializers.py
+++ b/backend/src/baserow/contrib/dashboard/api/widgets/serializers.py
@@ -8,16 +8,32 @@ from baserow.contrib.dashboard.widgets.models import Widget
 from baserow.contrib.dashboard.widgets.registries import widget_type_registry
 
 
+class WidgetGridLayoutSerializer(serializers.Serializer):
+    default_width = serializers.IntegerField(min_value=1)
+    default_height = serializers.IntegerField(min_value=1)
+    min_width = serializers.IntegerField(min_value=1)
+    min_height = serializers.IntegerField(min_value=1)
+    max_width = serializers.IntegerField(min_value=1)
+    max_height = serializers.IntegerField(min_value=1)
+
+
 class WidgetSerializer(serializers.ModelSerializer):
     """
     Basic widget serializer mostly for returned values.
     """
 
     type = serializers.SerializerMethodField(help_text="The type of the widget.")
+    grid_layout = serializers.SerializerMethodField(
+        help_text="The size constraints for this widget type."
+    )
 
     @extend_schema_field(OpenApiTypes.STR)
     def get_type(self, instance):
         return widget_type_registry.get_by_model(instance.specific_class).type
+
+    @extend_schema_field(WidgetGridLayoutSerializer)
+    def get_grid_layout(self, instance):
+        return instance.get_type().get_grid_layout().as_dict()
 
     class Meta:
         model = Widget
@@ -28,6 +44,11 @@ class WidgetSerializer(serializers.ModelSerializer):
             "dashboard_id",
             "type",
             "order",
+            "grid_x",
+            "grid_y",
+            "grid_width",
+            "grid_height",
+            "grid_layout",
         )
         extra_kwargs = {
             "id": {"read_only": True},
@@ -36,6 +57,11 @@ class WidgetSerializer(serializers.ModelSerializer):
             "dashboard_id": {"read_only": True},
             "type": {"read_only": True},
             "order": {"read_only": True, "help_text": "Lowest first."},
+            "grid_x": {"read_only": True},
+            "grid_y": {"read_only": True},
+            "grid_width": {"read_only": True},
+            "grid_height": {"read_only": True},
+            "grid_layout": {"read_only": True},
         }
 
 
@@ -79,3 +105,19 @@ class UpdateWidgetSerializer(serializers.ModelSerializer):
             "title": {"required": False, "allow_blank": False},
             "description": {"required": False, "allow_blank": True},
         }
+
+
+class WidgetLayoutItemSerializer(serializers.Serializer):
+    id = serializers.IntegerField(min_value=1)
+    grid_x = serializers.IntegerField(min_value=0)
+    grid_y = serializers.IntegerField(min_value=0)
+    grid_width = serializers.IntegerField(min_value=1)
+    grid_height = serializers.IntegerField(min_value=1)
+
+
+class UpdateWidgetLayoutSerializer(serializers.Serializer):
+    widgets = WidgetLayoutItemSerializer(many=True)
+
+
+class DeleteWidgetWithLayoutSerializer(UpdateWidgetLayoutSerializer):
+    widget_id = serializers.IntegerField(min_value=1)

--- a/backend/src/baserow/contrib/dashboard/api/widgets/urls.py
+++ b/backend/src/baserow/contrib/dashboard/api/widgets/urls.py
@@ -1,11 +1,26 @@
 from django.urls import re_path
 
-from baserow.contrib.dashboard.api.widgets.views import WidgetsView, WidgetView
+from baserow.contrib.dashboard.api.widgets.views import (
+    WidgetLayoutDeleteView,
+    WidgetLayoutView,
+    WidgetsView,
+    WidgetView,
+)
 
 app_name = "baserow.contrib.database.api.widgets"
 
 
 urlpatterns = [
+    re_path(
+        r"(?P<dashboard_id>[0-9]+)/widgets/layout/$",
+        WidgetLayoutView.as_view(),
+        name="layout",
+    ),
+    re_path(
+        r"(?P<dashboard_id>[0-9]+)/widgets/layout/delete/$",
+        WidgetLayoutDeleteView.as_view(),
+        name="layout-delete",
+    ),
     re_path(
         r"(?P<dashboard_id>[0-9]+)/widgets/$",
         WidgetsView.as_view(),

--- a/backend/src/baserow/contrib/dashboard/api/widgets/views.py
+++ b/backend/src/baserow/contrib/dashboard/api/widgets/views.py
@@ -8,7 +8,11 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from baserow.api.decorators import map_exceptions, validate_body_custom_fields
+from baserow.api.decorators import (
+    map_exceptions,
+    validate_body,
+    validate_body_custom_fields,
+)
 from baserow.api.schemas import (
     CLIENT_SESSION_ID_SCHEMA_PARAMETER,
     CLIENT_UNDO_REDO_ACTION_GROUP_ID_SCHEMA_PARAMETER,
@@ -24,11 +28,14 @@ from baserow.contrib.dashboard.exceptions import DashboardDoesNotExist
 from baserow.contrib.dashboard.widgets.actions import (
     CreateWidgetActionType,
     DeleteWidgetActionType,
+    DeleteWidgetWithLayoutActionType,
     UpdateWidgetActionType,
+    UpdateWidgetLayoutActionType,
 )
 from baserow.contrib.dashboard.widgets.exceptions import (
     WidgetDoesNotExist,
     WidgetImproperlyConfigured,
+    WidgetLayoutInvalid,
     WidgetTypeDoesNotExist,
 )
 from baserow.contrib.dashboard.widgets.registries import widget_type_registry
@@ -37,13 +44,23 @@ from baserow.contrib.dashboard.widgets.service import WidgetService
 from .errors import (
     ERROR_WIDGET_DOES_NOT_EXIST,
     ERROR_WIDGET_IMPROPERLY_CONFIGURED,
+    ERROR_WIDGET_LAYOUT_INVALID,
     ERROR_WIDGET_TYPE_DOES_NOT_EXIST,
 )
 from .serializers import (
     CreateWidgetSerializer,
+    DeleteWidgetWithLayoutSerializer,
+    UpdateWidgetLayoutSerializer,
     UpdateWidgetSerializer,
     WidgetSerializer,
 )
+
+
+def serialize_widgets(widgets):
+    return [
+        widget_type_registry.get_serializer(widget, WidgetSerializer).data
+        for widget in widgets
+    ]
 
 
 class WidgetsView(APIView):
@@ -85,11 +102,7 @@ class WidgetsView(APIView):
         """
 
         widgets = WidgetService().get_widgets(request.user, dashboard_id)
-        data = [
-            widget_type_registry.get_serializer(widget, WidgetSerializer).data
-            for widget in widgets
-        ]
-        return Response(data)
+        return Response(serialize_widgets(widgets))
 
     @extend_schema(
         parameters=[
@@ -247,3 +260,101 @@ class WidgetView(APIView):
 
         DeleteWidgetActionType.do(request.user, widget_id)
         return Response(status=204)
+
+
+class WidgetLayoutView(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="dashboard_id",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.INT,
+                description="The id of the dashboard whose widget layout is updated.",
+            ),
+            CLIENT_SESSION_ID_SCHEMA_PARAMETER,
+            CLIENT_UNDO_REDO_ACTION_GROUP_ID_SCHEMA_PARAMETER,
+        ],
+        tags=["Dashboard widgets"],
+        operation_id="update_dashboard_widget_layout",
+        description="Atomically updates the complete layout of a dashboard's widgets.",
+        request=UpdateWidgetLayoutSerializer,
+        responses={
+            200: DiscriminatorCustomFieldsMappingSerializer(
+                widget_type_registry, WidgetSerializer, many=True
+            ),
+            400: get_error_schema(
+                ["ERROR_REQUEST_BODY_VALIDATION", "ERROR_WIDGET_LAYOUT_INVALID"]
+            ),
+            401: get_error_schema(["ERROR_PERMISSION_DENIED"]),
+            404: get_error_schema(["ERROR_DASHBOARD_DOES_NOT_EXIST"]),
+        },
+    )
+    @transaction.atomic
+    @map_exceptions(
+        {
+            DashboardDoesNotExist: ERROR_DASHBOARD_DOES_NOT_EXIST,
+            WidgetLayoutInvalid: ERROR_WIDGET_LAYOUT_INVALID,
+        }
+    )
+    @validate_body(UpdateWidgetLayoutSerializer)
+    def patch(self, request, data: Dict, dashboard_id: int):
+        widgets = UpdateWidgetLayoutActionType.do(
+            request.user,
+            dashboard_id,
+            data["widgets"],
+        )
+        return Response(serialize_widgets(widgets))
+
+
+class WidgetLayoutDeleteView(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="dashboard_id",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.INT,
+                description="The id of the dashboard whose widget is deleted.",
+            ),
+            CLIENT_SESSION_ID_SCHEMA_PARAMETER,
+            CLIENT_UNDO_REDO_ACTION_GROUP_ID_SCHEMA_PARAMETER,
+        ],
+        tags=["Dashboard widgets"],
+        operation_id="delete_dashboard_widget_with_layout",
+        description=(
+            "Atomically deletes a widget and persists the complete resulting layout."
+        ),
+        request=DeleteWidgetWithLayoutSerializer,
+        responses={
+            200: DiscriminatorCustomFieldsMappingSerializer(
+                widget_type_registry, WidgetSerializer, many=True
+            ),
+            400: get_error_schema(
+                ["ERROR_REQUEST_BODY_VALIDATION", "ERROR_WIDGET_LAYOUT_INVALID"]
+            ),
+            401: get_error_schema(["ERROR_PERMISSION_DENIED"]),
+            404: get_error_schema(
+                ["ERROR_DASHBOARD_DOES_NOT_EXIST", "ERROR_WIDGET_DOES_NOT_EXIST"]
+            ),
+        },
+    )
+    @transaction.atomic
+    @map_exceptions(
+        {
+            DashboardDoesNotExist: ERROR_DASHBOARD_DOES_NOT_EXIST,
+            WidgetDoesNotExist: ERROR_WIDGET_DOES_NOT_EXIST,
+            WidgetLayoutInvalid: ERROR_WIDGET_LAYOUT_INVALID,
+        }
+    )
+    @validate_body(DeleteWidgetWithLayoutSerializer)
+    def post(self, request, data: Dict, dashboard_id: int):
+        widgets = DeleteWidgetWithLayoutActionType.do(
+            request.user,
+            dashboard_id,
+            data["widget_id"],
+            data["widgets"],
+        )
+        return Response(serialize_widgets(widgets))

--- a/backend/src/baserow/contrib/dashboard/apps.py
+++ b/backend/src/baserow/contrib/dashboard/apps.py
@@ -40,6 +40,7 @@ class DashboardConfig(AppConfig):
             ListWidgetsOperationType,
             ReadWidgetOperationType,
             RestoreWidgetOperationType,
+            UpdateWidgetLayoutOperationType,
             UpdateWidgetOperationType,
         )
 
@@ -47,6 +48,7 @@ class DashboardConfig(AppConfig):
         operation_type_registry.register(ReadWidgetOperationType())
         operation_type_registry.register(CreateWidgetOperationType())
         operation_type_registry.register(UpdateWidgetOperationType())
+        operation_type_registry.register(UpdateWidgetLayoutOperationType())
         operation_type_registry.register(DeleteWidgetOperationType())
         operation_type_registry.register(RestoreWidgetOperationType())
 
@@ -101,7 +103,9 @@ class DashboardConfig(AppConfig):
         from baserow.contrib.dashboard.widgets.actions import (
             CreateWidgetActionType,
             DeleteWidgetActionType,
+            DeleteWidgetWithLayoutActionType,
             UpdateWidgetActionType,
+            UpdateWidgetLayoutActionType,
         )
 
         from .ws.receivers import (  # noqa: F401
@@ -109,11 +113,14 @@ class DashboardConfig(AppConfig):
             widget_created,
             widget_deleted,
             widget_updated,
+            widgets_layout_updated,
         )
 
         action_type_registry.register(CreateWidgetActionType())
         action_type_registry.register(UpdateWidgetActionType())
+        action_type_registry.register(UpdateWidgetLayoutActionType())
         action_type_registry.register(DeleteWidgetActionType())
+        action_type_registry.register(DeleteWidgetWithLayoutActionType())
         action_type_registry.register(UpdateDashboardDataSourceActionType())
 
         from baserow.core.search.registries import workspace_search_registry

--- a/backend/src/baserow/contrib/dashboard/migrations/0004_widget_grid_layout.py
+++ b/backend/src/baserow/contrib/dashboard/migrations/0004_widget_grid_layout.py
@@ -1,0 +1,78 @@
+from django.db import migrations, models
+
+
+BATCH_SIZE = 1_000
+
+
+def populate_widget_grid_layout(apps, schema_editor):
+    Widget = apps.get_model("dashboard", "Widget")
+
+    widgets_to_update = []
+    current_dashboard_id = None
+    next_grid_y = 0
+
+    for widget in (
+        Widget.objects.select_related("content_type")
+        .order_by("dashboard_id", "order", "id")
+        .iterator(chunk_size=BATCH_SIZE)
+    ):
+        if widget.dashboard_id != current_dashboard_id:
+            current_dashboard_id = widget.dashboard_id
+            next_grid_y = 0
+
+        grid_height = 4 if widget.content_type.model == "summarywidget" else 9
+        widget.grid_x = 0
+        widget.grid_y = next_grid_y
+        widget.grid_width = 6
+        widget.grid_height = grid_height
+        next_grid_y += grid_height
+        widgets_to_update.append(widget)
+
+        if len(widgets_to_update) == BATCH_SIZE:
+            Widget.objects.bulk_update(
+                widgets_to_update,
+                ["grid_x", "grid_y", "grid_width", "grid_height"],
+                batch_size=BATCH_SIZE,
+            )
+            widgets_to_update.clear()
+
+    if widgets_to_update:
+        Widget.objects.bulk_update(
+            widgets_to_update,
+            ["grid_x", "grid_y", "grid_width", "grid_height"],
+            batch_size=BATCH_SIZE,
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("dashboard", "0003_widget_dashboarddatasource_summarywidget"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="widget",
+            name="grid_x",
+            field=models.PositiveIntegerField(db_default=0, default=0),
+        ),
+        migrations.AddField(
+            model_name="widget",
+            name="grid_y",
+            field=models.PositiveIntegerField(db_default=0, default=0),
+        ),
+        migrations.AddField(
+            model_name="widget",
+            name="grid_width",
+            field=models.PositiveIntegerField(db_default=6, default=6),
+        ),
+        migrations.AddField(
+            model_name="widget",
+            name="grid_height",
+            field=models.PositiveIntegerField(db_default=9, default=9),
+        ),
+        migrations.RunPython(populate_widget_grid_layout, migrations.RunPython.noop),
+        migrations.AlterModelOptions(
+            name="widget",
+            options={"ordering": ("grid_y", "grid_x", "id")},
+        ),
+    ]

--- a/backend/src/baserow/contrib/dashboard/types.py
+++ b/backend/src/baserow/contrib/dashboard/types.py
@@ -9,6 +9,10 @@ class WidgetDict(TypedDict):
     title: str
     description: str
     order: str
+    grid_x: int
+    grid_y: int
+    grid_width: int
+    grid_height: int
     type: str
 
 

--- a/backend/src/baserow/contrib/dashboard/widgets/actions.py
+++ b/backend/src/baserow/contrib/dashboard/widgets/actions.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from django.contrib.auth.models import AbstractUser
 from django.utils.translation import gettext_lazy as _
@@ -148,6 +148,72 @@ class UpdateWidgetActionType(UndoableActionType):
         )
 
 
+class UpdateWidgetLayoutActionType(UndoableActionType):
+    type = "update_widget_layout"
+    description = ActionTypeDescription(
+        _("Update widget layout"),
+        _("Dashboard widget layout updated"),
+        DASHBOARD_ACTION_CONTEXT,
+    )
+    analytics_params = ["dashboard_id"]
+
+    @dataclass
+    class Params:
+        dashboard_id: int
+        dashboard_name: str
+        original_layout: list[dict[str, int]]
+        new_layout: list[dict[str, int]]
+
+    @classmethod
+    def do(
+        cls,
+        user: AbstractUser,
+        dashboard_id: int,
+        new_layout: list[dict[str, int]],
+    ) -> list[Widget]:
+        updated_layout = WidgetService().update_widget_layout(
+            user, dashboard_id, new_layout
+        )
+        cls.register_action(
+            user=user,
+            params=cls.Params(
+                updated_layout.dashboard.id,
+                updated_layout.dashboard.name,
+                updated_layout.original_layout,
+                updated_layout.new_layout,
+            ),
+            scope=cls.scope(updated_layout.dashboard.id),
+            workspace=updated_layout.dashboard.workspace,
+        )
+        return updated_layout.widgets
+
+    @classmethod
+    def scope(cls, dashboard_id):
+        return ApplicationActionScopeType.value(dashboard_id)
+
+    @classmethod
+    def undo(
+        cls,
+        user: AbstractUser,
+        params: Params,
+        action_to_undo: Action,
+    ):
+        WidgetService().update_widget_layout(
+            user, params.dashboard_id, params.original_layout
+        )
+
+    @classmethod
+    def redo(
+        cls,
+        user: AbstractUser,
+        params: Params,
+        action_to_redo: Action,
+    ):
+        WidgetService().update_widget_layout(
+            user, params.dashboard_id, params.new_layout
+        )
+
+
 class DeleteWidgetActionType(UndoableActionType):
     type = "delete_widget"
     description = ActionTypeDescription(
@@ -163,20 +229,28 @@ class DeleteWidgetActionType(UndoableActionType):
         dashboard_name: str
         widget_id: int
         widget_title: str
+        original_layout: list[dict[str, int]] = field(default_factory=list)
+        new_layout: list[dict[str, int]] = field(default_factory=list)
 
     @classmethod
     def do(cls, user: AbstractUser, widget_id: int) -> None:
-        widget = WidgetService().delete_widget(user, widget_id)
+        updated_layout = WidgetService().delete_widget_and_compact_layout(
+            user, widget_id
+        )
+        deleted_widget = updated_layout.deleted_widget
+        assert deleted_widget is not None
         cls.register_action(
             user=user,
             params=cls.Params(
-                widget.dashboard.id,
-                widget.dashboard.name,
-                widget.id,
-                widget.title,
+                updated_layout.dashboard.id,
+                updated_layout.dashboard.name,
+                deleted_widget.id,
+                deleted_widget.title,
+                updated_layout.original_layout,
+                updated_layout.new_layout,
             ),
-            scope=cls.scope(widget.dashboard.id),
-            workspace=widget.dashboard.workspace,
+            scope=cls.scope(updated_layout.dashboard.id),
+            workspace=updated_layout.dashboard.workspace,
         )
 
     @classmethod
@@ -195,6 +269,10 @@ class DeleteWidgetActionType(UndoableActionType):
             WidgetTrashableItemType.type,
             params.widget_id,
         )
+        if params.original_layout:
+            WidgetService().update_widget_layout(
+                user, params.dashboard_id, params.original_layout
+            )
 
     @classmethod
     def redo(
@@ -204,3 +282,84 @@ class DeleteWidgetActionType(UndoableActionType):
         action_to_redo: Action,
     ):
         WidgetService().delete_widget(user, params.widget_id)
+
+
+class DeleteWidgetWithLayoutActionType(UndoableActionType):
+    type = "delete_widget_with_layout"
+    description = ActionTypeDescription(
+        _("Delete widget"),
+        _('Widget "%(widget_title)s" (%(widget_id)s) deleted'),
+        DASHBOARD_ACTION_CONTEXT,
+    )
+    analytics_params = ["dashboard_id", "widget_id"]
+
+    @dataclass
+    class Params:
+        dashboard_id: int
+        dashboard_name: str
+        widget_id: int
+        widget_title: str
+        original_layout: list[dict[str, int]]
+        new_layout: list[dict[str, int]]
+
+    @classmethod
+    def do(
+        cls,
+        user: AbstractUser,
+        dashboard_id: int,
+        widget_id: int,
+        new_layout: list[dict[str, int]],
+    ) -> list[Widget]:
+        updated_layout = WidgetService().delete_widget_with_layout(
+            user, dashboard_id, widget_id, new_layout
+        )
+        deleted_widget = updated_layout.deleted_widget
+        assert deleted_widget is not None
+        cls.register_action(
+            user=user,
+            params=cls.Params(
+                updated_layout.dashboard.id,
+                updated_layout.dashboard.name,
+                deleted_widget.id,
+                deleted_widget.title,
+                updated_layout.original_layout,
+                updated_layout.new_layout,
+            ),
+            scope=cls.scope(updated_layout.dashboard.id),
+            workspace=updated_layout.dashboard.workspace,
+        )
+        return updated_layout.widgets
+
+    @classmethod
+    def scope(cls, dashboard_id):
+        return ApplicationActionScopeType.value(dashboard_id)
+
+    @classmethod
+    def undo(
+        cls,
+        user: AbstractUser,
+        params: Params,
+        action_to_undo: Action,
+    ):
+        TrashHandler.restore_item(
+            user,
+            WidgetTrashableItemType.type,
+            params.widget_id,
+        )
+        WidgetService().update_widget_layout(
+            user, params.dashboard_id, params.original_layout
+        )
+
+    @classmethod
+    def redo(
+        cls,
+        user: AbstractUser,
+        params: Params,
+        action_to_redo: Action,
+    ):
+        WidgetService().delete_widget_with_layout(
+            user,
+            params.dashboard_id,
+            params.widget_id,
+            params.new_layout,
+        )

--- a/backend/src/baserow/contrib/dashboard/widgets/exceptions.py
+++ b/backend/src/baserow/contrib/dashboard/widgets/exceptions.py
@@ -8,3 +8,7 @@ class WidgetTypeDoesNotExist(Exception):
 
 class WidgetImproperlyConfigured(Exception):
     """Raised when the widget settings is not allowed."""
+
+
+class WidgetLayoutInvalid(Exception):
+    """Raised when a dashboard widget layout is malformed or invalid."""

--- a/backend/src/baserow/contrib/dashboard/widgets/handler.py
+++ b/backend/src/baserow/contrib/dashboard/widgets/handler.py
@@ -108,6 +108,100 @@ class WidgetHandler:
 
         return widgets
 
+    def get_widgets_for_update(self, dashboard: Dashboard) -> list[Widget]:
+        """Returns all active dashboard widgets locked for a layout mutation."""
+
+        return list(
+            Widget.objects.select_related(
+                "dashboard", "dashboard__workspace", "content_type"
+            )
+            .filter(dashboard=dashboard)
+            .select_for_update(of=("self",))
+            .order_by("id")
+        )
+
+    @staticmethod
+    def get_widget_layout(widget: Widget) -> dict[str, int]:
+        return {
+            "id": widget.id,
+            "grid_x": widget.grid_x,
+            "grid_y": widget.grid_y,
+            "grid_width": widget.grid_width,
+            "grid_height": widget.grid_height,
+        }
+
+    @staticmethod
+    def _layouts_overlap(first: dict[str, int], second: dict[str, int]) -> bool:
+        return (
+            first["grid_x"] < second["grid_x"] + second["grid_width"]
+            and second["grid_x"] < first["grid_x"] + first["grid_width"]
+            and first["grid_y"] < second["grid_y"] + second["grid_height"]
+            and second["grid_y"] < first["grid_y"] + first["grid_height"]
+        )
+
+    def get_compacted_widget_layout(
+        self, widgets: Iterable[Widget]
+    ) -> list[dict[str, int]]:
+        """Returns a deterministic vertically compacted layout.
+
+        Widgets retain their horizontal position and dimensions. They are processed
+        top-to-bottom, then left-to-right, so a deletion produces the same result on
+        every client without relying on the browser grid implementation.
+        """
+
+        compacted_layout = []
+        for widget in sorted(
+            widgets,
+            key=lambda widget: (widget.grid_y, widget.grid_x, widget.id),
+        ):
+            layout = self.get_widget_layout(widget)
+            layout["grid_y"] = 0
+
+            while any(
+                self._layouts_overlap(layout, other) for other in compacted_layout
+            ):
+                layout["grid_y"] += 1
+
+            compacted_layout.append(layout)
+
+        return compacted_layout
+
+    def get_last_grid_y(self, dashboard: Dashboard) -> int:
+        """Returns the first free row after every active widget in a dashboard."""
+
+        return max(
+            (
+                grid_y + grid_height
+                for grid_y, grid_height in Widget.objects.filter(
+                    dashboard=dashboard
+                ).values_list("grid_y", "grid_height")
+            ),
+            default=0,
+        )
+
+    def place_restored_widget_at_bottom(self, widget: Widget) -> None:
+        """Places a restored widget after the active dashboard layout.
+
+        A widget can have been deleted while the remaining layout compacted. Restoring
+        it at its old coordinates could therefore overlap an active widget. Generic
+        trash restores preserve the current dashboard and append the widget instead;
+        undo actions subsequently restore their recorded complete layout.
+        """
+
+        grid_y = max(
+            (
+                other_grid_y + other_grid_height
+                for other_grid_y, other_grid_height in Widget.objects.filter(
+                    dashboard=widget.dashboard
+                )
+                .exclude(id=widget.id)
+                .values_list("grid_y", "grid_height")
+            ),
+            default=0,
+        )
+        widget.grid_y = grid_y
+        widget.save(update_fields=["grid_y", "updated_on"])
+
     def create_widget(
         self,
         widget_type: WidgetType,
@@ -125,12 +219,20 @@ class WidgetHandler:
 
         order = Widget.get_last_order(dashboard)
         allowed_values = extract_allowed(kwargs, widget_type.allowed_fields)
+        grid_layout = widget_type.get_grid_layout()
 
         allowed_values["dashboard"] = dashboard
         allowed_values = widget_type.prepare_value_for_db(allowed_values)
 
         model_class = cast(Widget, widget_type.model_class)
-        widget = model_class(order=order, **allowed_values)
+        widget = model_class(
+            order=order,
+            grid_x=0,
+            grid_y=self.get_last_grid_y(dashboard),
+            grid_width=grid_layout.default_width,
+            grid_height=grid_layout.default_height,
+            **allowed_values,
+        )
         widget._ensure_content_type_is_set()
         widget.full_clean()
         widget.save()
@@ -162,6 +264,29 @@ class WidgetHandler:
         new_widget_values = widget.get_type().export_prepared_values(instance=widget)
 
         return UpdatedWidget(widget, original_widget_values, new_widget_values)
+
+    def update_widget_layout(
+        self,
+        widgets: list[Widget],
+        layout_by_widget_id: dict[int, dict[str, int]],
+    ) -> None:
+        """Persists an already validated complete dashboard layout."""
+
+        for widget in widgets:
+            layout = layout_by_widget_id[widget.id]
+            widget.grid_x = layout["grid_x"]
+            widget.grid_y = layout["grid_y"]
+            widget.grid_width = layout["grid_width"]
+            widget.grid_height = layout["grid_height"]
+            widget.save(
+                update_fields=[
+                    "grid_x",
+                    "grid_y",
+                    "grid_width",
+                    "grid_height",
+                    "updated_on",
+                ]
+            )
 
     def delete_widget(self, widget: Widget):
         """
@@ -222,6 +347,22 @@ class WidgetHandler:
         """
 
         widget_type = widget_type_registry.get(serialized_widget["type"])
+        grid_fields = ("grid_x", "grid_y", "grid_width", "grid_height")
+
+        # Exports created before the grid layout was introduced do not carry
+        # geometry. Place those widgets one below another using the defaults of
+        # their type, instead of relying on the model defaults and overlapping
+        # every imported widget at (0, 0).
+        if not all(field in serialized_widget for field in grid_fields):
+            grid_layout = widget_type.get_grid_layout()
+            serialized_widget = {
+                **serialized_widget,
+                "grid_x": 0,
+                "grid_y": self.get_last_grid_y(dashboard),
+                "grid_width": grid_layout.default_width,
+                "grid_height": grid_layout.default_height,
+            }
+
         widget = widget_type.import_serialized(
             dashboard,
             serialized_widget,

--- a/backend/src/baserow/contrib/dashboard/widgets/models.py
+++ b/backend/src/baserow/contrib/dashboard/widgets/models.py
@@ -41,6 +41,10 @@ class Widget(
         editable=False,
         default=Decimal("1"),
     )
+    grid_x = models.PositiveIntegerField(default=0, db_default=0)
+    grid_y = models.PositiveIntegerField(default=0, db_default=0)
+    grid_width = models.PositiveIntegerField(default=6, db_default=6)
+    grid_height = models.PositiveIntegerField(default=9, db_default=9)
     content_type = models.ForeignKey(
         ContentType,
         verbose_name="content type",
@@ -49,7 +53,7 @@ class Widget(
     )
 
     class Meta:
-        ordering = ("order", "id")
+        ordering = ("grid_y", "grid_x", "id")
 
     @staticmethod
     def get_type_registry():

--- a/backend/src/baserow/contrib/dashboard/widgets/operations.py
+++ b/backend/src/baserow/contrib/dashboard/widgets/operations.py
@@ -19,6 +19,10 @@ class UpdateWidgetOperationType(WidgetOperationType):
     type = "dashboard.widget.update"
 
 
+class UpdateWidgetLayoutOperationType(DashboardOperationType):
+    type = "dashboard.update_widget_layout"
+
+
 class DeleteWidgetOperationType(WidgetOperationType):
     type = "dashboard.widget.delete"
 

--- a/backend/src/baserow/contrib/dashboard/widgets/registries.py
+++ b/backend/src/baserow/contrib/dashboard/widgets/registries.py
@@ -5,7 +5,7 @@ from django.db.models import QuerySet
 
 from baserow.contrib.dashboard.models import Dashboard
 from baserow.contrib.dashboard.types import WidgetDict
-from baserow.contrib.dashboard.widgets.types import UpdatedWidget
+from baserow.contrib.dashboard.widgets.types import UpdatedWidget, WidgetGridLayout
 from baserow.core.registry import (
     CustomFieldsInstanceMixin,
     CustomFieldsRegistryMixin,
@@ -35,6 +35,17 @@ class WidgetType(
     parent_property_name = "dashboard"
     id_mapping_name = DASHBOARD_WIDGETS
     allowed_fields = ["title", "description"]
+    grid_layout = WidgetGridLayout(
+        default_width=3,
+        default_height=9,
+        min_width=1,
+        min_height=4,
+        max_width=6,
+        max_height=16,
+    )
+
+    def get_grid_layout(self) -> WidgetGridLayout:
+        return self.grid_layout
 
     def enhance_queryset(self, queryset: QuerySet[Widget]) -> QuerySet[Widget]:
         """

--- a/backend/src/baserow/contrib/dashboard/widgets/service.py
+++ b/backend/src/baserow/contrib/dashboard/widgets/service.py
@@ -1,12 +1,17 @@
 from django.contrib.auth.models import AbstractUser
+from django.db import transaction
 
 from baserow.contrib.dashboard.handler import DashboardHandler
-from baserow.contrib.dashboard.widgets.exceptions import WidgetDoesNotExist
+from baserow.contrib.dashboard.widgets.exceptions import (
+    WidgetDoesNotExist,
+    WidgetLayoutInvalid,
+)
 from baserow.contrib.dashboard.widgets.operations import (
     CreateWidgetOperationType,
     DeleteWidgetOperationType,
     ListWidgetsOperationType,
     ReadWidgetOperationType,
+    UpdateWidgetLayoutOperationType,
     UpdateWidgetOperationType,
 )
 from baserow.contrib.dashboard.widgets.registries import widget_type_registry
@@ -15,8 +20,13 @@ from baserow.core.trash.handler import TrashHandler
 
 from .handler import WidgetHandler
 from .models import Widget
-from .signals import widget_created, widget_deleted, widget_updated
-from .types import UpdatedWidget
+from .signals import (
+    widget_created,
+    widget_deleted,
+    widget_updated,
+    widgets_layout_updated,
+)
+from .types import UpdatedWidget, UpdatedWidgetLayout
 
 
 class WidgetService:
@@ -162,6 +172,241 @@ class WidgetService:
         widget_updated.send(self, user=user, widget=updated_widget.widget)
         return updated_widget
 
+    def _validate_widget_layout(
+        self,
+        widgets: list[Widget],
+        layout: list[dict[str, int]],
+    ) -> dict[int, dict[str, int]]:
+        """Validates a full layout against widget identities and type constraints."""
+
+        if len(layout) != len(widgets):
+            raise WidgetLayoutInvalid("The layout must include every dashboard widget.")
+
+        layout_by_widget_id = {}
+        for item in layout:
+            try:
+                widget_id = item["id"]
+                grid_x = item["grid_x"]
+                grid_y = item["grid_y"]
+                grid_width = item["grid_width"]
+                grid_height = item["grid_height"]
+            except (KeyError, TypeError) as exc:
+                raise WidgetLayoutInvalid("The layout item is incomplete.") from exc
+
+            values = (widget_id, grid_x, grid_y, grid_width, grid_height)
+            if any(type(value) is not int for value in values):
+                raise WidgetLayoutInvalid("The layout values must be integers.")
+            if widget_id in layout_by_widget_id:
+                raise WidgetLayoutInvalid("A widget can only occur once in the layout.")
+            if grid_x < 0 or grid_y < 0 or grid_width < 1 or grid_height < 1:
+                raise WidgetLayoutInvalid(
+                    "The layout contains an invalid grid position."
+                )
+
+            layout_by_widget_id[widget_id] = {
+                "id": widget_id,
+                "grid_x": grid_x,
+                "grid_y": grid_y,
+                "grid_width": grid_width,
+                "grid_height": grid_height,
+            }
+
+        widget_ids = {widget.id for widget in widgets}
+        if set(layout_by_widget_id) != widget_ids:
+            raise WidgetLayoutInvalid(
+                "The layout widgets do not match the dashboard widgets."
+            )
+
+        normalized_layout = []
+        for widget in widgets:
+            item = layout_by_widget_id[widget.id]
+            constraints = widget.get_type().get_grid_layout()
+            if item["grid_x"] + item["grid_width"] > 6:
+                raise WidgetLayoutInvalid(
+                    "A widget cannot extend past the sixth column."
+                )
+            if not constraints.min_width <= item["grid_width"] <= constraints.max_width:
+                raise WidgetLayoutInvalid("The widget width is outside of its limits.")
+            if (
+                not constraints.min_height
+                <= item["grid_height"]
+                <= constraints.max_height
+            ):
+                raise WidgetLayoutInvalid("The widget height is outside of its limits.")
+            normalized_layout.append(item)
+
+        for index, item in enumerate(normalized_layout):
+            for other in normalized_layout[index + 1 :]:
+                overlaps_horizontally = (
+                    item["grid_x"] < other["grid_x"] + other["grid_width"]
+                    and other["grid_x"] < item["grid_x"] + item["grid_width"]
+                )
+                overlaps_vertically = (
+                    item["grid_y"] < other["grid_y"] + other["grid_height"]
+                    and other["grid_y"] < item["grid_y"] + item["grid_height"]
+                )
+                if overlaps_horizontally and overlaps_vertically:
+                    raise WidgetLayoutInvalid("Dashboard widgets cannot overlap.")
+
+        return layout_by_widget_id
+
+    @transaction.atomic
+    def update_widget_layout(
+        self,
+        user: AbstractUser,
+        dashboard_id: int,
+        layout: list[dict[str, int]],
+    ) -> UpdatedWidgetLayout:
+        """Atomically persists a complete dashboard widget layout."""
+
+        dashboard = self.dashboard_handler.get_dashboard(dashboard_id)
+        CoreHandler().check_permissions(
+            user,
+            UpdateWidgetLayoutOperationType.type,
+            workspace=dashboard.workspace,
+            context=dashboard,
+        )
+
+        widgets = self.handler.get_widgets_for_update(dashboard)
+        original_layout = [self.handler.get_widget_layout(widget) for widget in widgets]
+        layout_by_widget_id = self._validate_widget_layout(widgets, layout)
+        self.handler.update_widget_layout(widgets, layout_by_widget_id)
+
+        updated_widgets = list(self.handler.get_widgets(dashboard))
+        new_layout = [
+            layout_by_widget_id[widget.id]
+            for widget in sorted(widgets, key=lambda widget: widget.id)
+        ]
+        widgets_layout_updated.send(
+            self,
+            user=user,
+            dashboard=dashboard,
+            widgets=updated_widgets,
+        )
+        return UpdatedWidgetLayout(
+            dashboard,
+            updated_widgets,
+            original_layout,
+            new_layout,
+        )
+
+    @transaction.atomic
+    def delete_widget_with_layout(
+        self,
+        user: AbstractUser,
+        dashboard_id: int,
+        widget_id: int,
+        layout: list[dict[str, int]],
+    ) -> UpdatedWidgetLayout:
+        """Trashes one widget and atomically persists the resulting full layout."""
+
+        dashboard = self.dashboard_handler.get_dashboard(dashboard_id)
+        CoreHandler().check_permissions(
+            user,
+            UpdateWidgetLayoutOperationType.type,
+            workspace=dashboard.workspace,
+            context=dashboard,
+        )
+
+        widgets = self.handler.get_widgets_for_update(dashboard)
+        widgets_by_id = {widget.id: widget for widget in widgets}
+        widget = widgets_by_id.get(widget_id)
+        if widget is None:
+            raise WidgetDoesNotExist()
+
+        CoreHandler().check_permissions(
+            user,
+            DeleteWidgetOperationType.type,
+            workspace=dashboard.workspace,
+            context=widget,
+        )
+
+        original_layout = [self.handler.get_widget_layout(widget) for widget in widgets]
+        remaining_widgets = [widget for widget in widgets if widget.id != widget_id]
+        layout_by_widget_id = self._validate_widget_layout(remaining_widgets, layout)
+
+        TrashHandler.trash(user, dashboard.workspace, dashboard, widget)
+        self.handler.update_widget_layout(remaining_widgets, layout_by_widget_id)
+
+        updated_widgets = list(self.handler.get_widgets(dashboard))
+        new_layout = [
+            layout_by_widget_id[widget.id]
+            for widget in sorted(remaining_widgets, key=lambda widget: widget.id)
+        ]
+        widgets_layout_updated.send(
+            self,
+            user=user,
+            dashboard=dashboard,
+            widgets=updated_widgets,
+        )
+        return UpdatedWidgetLayout(
+            dashboard,
+            updated_widgets,
+            original_layout,
+            new_layout,
+            widget,
+        )
+
+    @transaction.atomic
+    def delete_widget_and_compact_layout(
+        self, user: AbstractUser, widget_id: int
+    ) -> UpdatedWidgetLayout:
+        """Trashes a widget and compacts the remaining widgets vertically.
+
+        This keeps the legacy single-widget deletion endpoint compatible with the
+        persisted grid. The automatic compaction is a consequence of deleting the
+        widget, so it intentionally requires the delete permission rather than the
+        dashboard-wide layout permission used by client-supplied layouts.
+        """
+
+        deleted_widget = self.handler.get_widget(widget_id)
+        widget_id = deleted_widget.id
+
+        if TrashHandler.item_has_a_trashed_parent(deleted_widget):
+            raise WidgetDoesNotExist()
+
+        dashboard = deleted_widget.dashboard
+        CoreHandler().check_permissions(
+            user,
+            DeleteWidgetOperationType.type,
+            workspace=dashboard.workspace,
+            context=deleted_widget,
+        )
+
+        widgets = self.handler.get_widgets_for_update(dashboard)
+        widgets_by_id = {widget.id: widget for widget in widgets}
+        widget = widgets_by_id.get(widget_id)
+        if widget is None:
+            raise WidgetDoesNotExist()
+
+        original_layout = [self.handler.get_widget_layout(widget) for widget in widgets]
+        remaining_widgets = [widget for widget in widgets if widget.id != widget_id]
+        compacted_layout = self.handler.get_compacted_widget_layout(remaining_widgets)
+        layout_by_widget_id = {layout["id"]: layout for layout in compacted_layout}
+
+        TrashHandler.trash(user, dashboard.workspace, dashboard, widget)
+        self.handler.update_widget_layout(remaining_widgets, layout_by_widget_id)
+
+        updated_widgets = list(self.handler.get_widgets(dashboard))
+        new_layout = [
+            layout_by_widget_id[widget.id]
+            for widget in sorted(remaining_widgets, key=lambda widget: widget.id)
+        ]
+        widget_deleted.send(self, user=user, widget=deleted_widget)
+        widgets_layout_updated.send(
+            self,
+            user=user,
+            dashboard=dashboard,
+            widgets=updated_widgets,
+        )
+        return UpdatedWidgetLayout(
+            dashboard,
+            updated_widgets,
+            original_layout,
+            new_layout,
+            deleted_widget,
+        )
+
     def delete_widget(self, user: AbstractUser, widget_id: int) -> Widget:
         """
         Deletes the widget based on the provided widget id if the
@@ -172,20 +417,7 @@ class WidgetService:
             correct permission.
         """
 
-        widget = self.handler.get_widget(widget_id)
-
-        if TrashHandler.item_has_a_trashed_parent(widget):
-            raise WidgetDoesNotExist()
-
-        CoreHandler().check_permissions(
-            user,
-            DeleteWidgetOperationType.type,
-            workspace=widget.dashboard.workspace,
-            context=widget,
-        )
-
-        TrashHandler.trash(user, widget.dashboard.workspace, widget.dashboard, widget)
-
-        widget_deleted.send(self, user=user, widget=widget)
-
-        return widget
+        updated_layout = self.delete_widget_and_compact_layout(user, widget_id)
+        deleted_widget = updated_layout.deleted_widget
+        assert deleted_widget is not None
+        return deleted_widget

--- a/backend/src/baserow/contrib/dashboard/widgets/signals.py
+++ b/backend/src/baserow/contrib/dashboard/widgets/signals.py
@@ -3,3 +3,4 @@ from django.dispatch import Signal
 widget_created = Signal()
 widget_updated = Signal()
 widget_deleted = Signal()
+widgets_layout_updated = Signal()

--- a/backend/src/baserow/contrib/dashboard/widgets/trash_types.py
+++ b/backend/src/baserow/contrib/dashboard/widgets/trash_types.py
@@ -27,6 +27,7 @@ class WidgetTrashableItemType(TrashableItemType):
         widget_type = widget_type_registry.get_by_model(trashed_item.specific)
         widget_type.before_restore(trashed_item.specific)
         super().restore(trashed_item, trash_entry)
+        WidgetHandler().place_restored_widget_at_bottom(trashed_item)
         widget_created.send(self, widget=trashed_item)
 
     def permanently_delete_item(

--- a/backend/src/baserow/contrib/dashboard/widgets/types.py
+++ b/backend/src/baserow/contrib/dashboard/widgets/types.py
@@ -1,9 +1,34 @@
 from dataclasses import dataclass
-from typing import NewType
+from typing import TYPE_CHECKING, NewType
 
 from .models import Widget
 
+if TYPE_CHECKING:
+    from baserow.contrib.dashboard.models import Dashboard
+
 WidgetForUpdate = NewType("WidgetForUpdate", Widget)
+
+
+@dataclass(frozen=True)
+class WidgetGridLayout:
+    """The grid constraints and default size for a dashboard widget type."""
+
+    default_width: int
+    default_height: int
+    min_width: int
+    min_height: int
+    max_width: int
+    max_height: int
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "default_width": self.default_width,
+            "default_height": self.default_height,
+            "min_width": self.min_width,
+            "min_height": self.min_height,
+            "max_width": self.max_width,
+            "max_height": self.max_height,
+        }
 
 
 @dataclass
@@ -11,3 +36,12 @@ class UpdatedWidget:
     widget: Widget
     original_values: dict[str, any]
     new_values: dict[str, any]
+
+
+@dataclass
+class UpdatedWidgetLayout:
+    dashboard: "Dashboard"
+    widgets: list[Widget]
+    original_layout: list[dict[str, int]]
+    new_layout: list[dict[str, int]]
+    deleted_widget: Widget | None = None

--- a/backend/src/baserow/contrib/dashboard/widgets/widget_types.py
+++ b/backend/src/baserow/contrib/dashboard/widgets/widget_types.py
@@ -13,11 +13,20 @@ from baserow.core.services.registries import service_type_registry
 
 from .models import SummaryWidget
 from .registries import WidgetType
+from .types import WidgetGridLayout
 
 
 class SummaryWidgetType(WidgetType):
     type = "summary"
     model_class = SummaryWidget
+    grid_layout = WidgetGridLayout(
+        default_width=2,
+        default_height=4,
+        min_width=1,
+        min_height=4,
+        max_width=6,
+        max_height=6,
+    )
     serializer_field_names = ["data_source_id"]
     serializer_field_overrides = {
         "data_source_id": serializers.PrimaryKeyRelatedField(

--- a/backend/src/baserow/contrib/dashboard/ws/receivers.py
+++ b/backend/src/baserow/contrib/dashboard/ws/receivers.py
@@ -92,6 +92,37 @@ def widget_deleted(
     transaction.on_commit(send_ws_message)
 
 
+@receiver(widget_signals.widgets_layout_updated)
+def widgets_layout_updated(
+    sender,
+    dashboard,
+    widgets,
+    user=None,
+    **kwargs,
+):
+    """Broadcast a complete widget set after an atomic grid-layout mutation."""
+
+    def send_ws_message():
+        page_type = page_registry.get("dashboard")
+        payload = {
+            "type": "widgets_layout_updated",
+            "dashboard_id": dashboard.id,
+            "widgets": [
+                widget_type_registry.get_serializer(widget, WidgetSerializer).data
+                for widget in widgets
+            ],
+        }
+        page_type.broadcast(
+            payload,
+            dashboard_id=dashboard.id,
+            ignore_web_socket_id=getattr(user, "web_socket_id", None)
+            if user is not None
+            else None,
+        )
+
+    transaction.on_commit(send_ws_message)
+
+
 @receiver(data_source_signals.dashboard_data_source_updated)
 def dashboard_data_source_updated(sender, user, data_source, **kwargs):
     def send_ws_message():

--- a/backend/tests/baserow/contrib/dashboard/api/widgets/test_widget_views.py
+++ b/backend/tests/baserow/contrib/dashboard/api/widgets/test_widget_views.py
@@ -10,7 +10,17 @@ from rest_framework.status import (
 )
 
 from baserow.contrib.dashboard.widgets.models import Widget
+from baserow.contrib.dashboard.widgets.service import WidgetService
 from baserow.test_utils.helpers import AnyInt
+
+SUMMARY_GRID_LAYOUT = {
+    "default_width": 2,
+    "default_height": 4,
+    "min_width": 1,
+    "min_height": 4,
+    "max_width": 6,
+    "max_height": 6,
+}
 
 
 @pytest.mark.django_db
@@ -58,6 +68,11 @@ def test_get_widgets(api_client, data_fixture):
             "dashboard_id": dashboard.id,
             "data_source_id": data_source.id,
             "order": "1.00000000000000000000",
+            "grid_x": 0,
+            "grid_y": 0,
+            "grid_width": 6,
+            "grid_height": 9,
+            "grid_layout": SUMMARY_GRID_LAYOUT,
             "type": "summary",
         },
         {
@@ -67,6 +82,11 @@ def test_get_widgets(api_client, data_fixture):
             "dashboard_id": dashboard.id,
             "data_source_id": data_source_2.id,
             "order": "1.00000000000000000000",
+            "grid_x": 0,
+            "grid_y": 0,
+            "grid_width": 6,
+            "grid_height": 9,
+            "grid_layout": SUMMARY_GRID_LAYOUT,
             "type": "summary",
         },
     ]
@@ -132,6 +152,11 @@ def test_create_widget(api_client, data_fixture):
         "data_source_id": AnyInt(),
         "dashboard_id": dashboard.id,
         "order": "1.00000000000000000000",
+        "grid_x": 0,
+        "grid_y": 0,
+        "grid_width": 2,
+        "grid_height": 4,
+        "grid_layout": SUMMARY_GRID_LAYOUT,
         "type": "summary",
     }
 
@@ -290,6 +315,11 @@ def test_update_widget(api_client, data_fixture):
         "dashboard_id": widget.dashboard.id,
         "data_source_id": data_source.id,
         "order": "1.00000000000000000000",
+        "grid_x": 0,
+        "grid_y": 0,
+        "grid_width": 6,
+        "grid_height": 9,
+        "grid_layout": SUMMARY_GRID_LAYOUT,
         "type": "summary",
     }
     widget.refresh_from_db()
@@ -462,3 +492,132 @@ def test_delete_widget_not_found(api_client, data_fixture):
 
     assert response.status_code == HTTP_404_NOT_FOUND
     assert response.json()["error"] == "ERROR_WIDGET_DOES_NOT_EXIST"
+
+
+@pytest.mark.django_db
+def test_update_widget_layout(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    dashboard = data_fixture.create_dashboard_application(user=user)
+    first_widget = WidgetService().create_widget(
+        user, "summary", dashboard.id, title="First"
+    )
+    second_widget = WidgetService().create_widget(
+        user, "summary", dashboard.id, title="Second"
+    )
+
+    url = reverse("api:dashboard:widgets:layout", kwargs={"dashboard_id": dashboard.id})
+    response = api_client.patch(
+        url,
+        {
+            "widgets": [
+                {
+                    "id": first_widget.id,
+                    "grid_x": 0,
+                    "grid_y": 0,
+                    "grid_width": 2,
+                    "grid_height": 4,
+                },
+                {
+                    "id": second_widget.id,
+                    "grid_x": 2,
+                    "grid_y": 0,
+                    "grid_width": 2,
+                    "grid_height": 4,
+                },
+            ]
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_200_OK, response.json()
+    assert {
+        widget["id"]: (widget["grid_x"], widget["grid_y"]) for widget in response.json()
+    } == {
+        first_widget.id: (0, 0),
+        second_widget.id: (2, 0),
+    }
+
+    first_widget.refresh_from_db()
+    second_widget.refresh_from_db()
+    assert (first_widget.grid_x, first_widget.grid_y) == (0, 0)
+    assert (second_widget.grid_x, second_widget.grid_y) == (2, 0)
+
+
+@pytest.mark.django_db
+def test_update_widget_layout_rejects_collisions(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    dashboard = data_fixture.create_dashboard_application(user=user)
+    first_widget = WidgetService().create_widget(
+        user, "summary", dashboard.id, title="First"
+    )
+    second_widget = WidgetService().create_widget(
+        user, "summary", dashboard.id, title="Second"
+    )
+
+    url = reverse("api:dashboard:widgets:layout", kwargs={"dashboard_id": dashboard.id})
+    response = api_client.patch(
+        url,
+        {
+            "widgets": [
+                {
+                    "id": first_widget.id,
+                    "grid_x": 0,
+                    "grid_y": 0,
+                    "grid_width": 2,
+                    "grid_height": 4,
+                },
+                {
+                    "id": second_widget.id,
+                    "grid_x": 0,
+                    "grid_y": 0,
+                    "grid_width": 2,
+                    "grid_height": 4,
+                },
+            ]
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_WIDGET_LAYOUT_INVALID"
+
+
+@pytest.mark.django_db
+def test_delete_widget_with_layout(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    dashboard = data_fixture.create_dashboard_application(user=user)
+    first_widget = WidgetService().create_widget(
+        user, "summary", dashboard.id, title="First"
+    )
+    second_widget = WidgetService().create_widget(
+        user, "summary", dashboard.id, title="Second"
+    )
+
+    url = reverse(
+        "api:dashboard:widgets:layout-delete", kwargs={"dashboard_id": dashboard.id}
+    )
+    response = api_client.post(
+        url,
+        {
+            "widget_id": first_widget.id,
+            "widgets": [
+                {
+                    "id": second_widget.id,
+                    "grid_x": 0,
+                    "grid_y": 0,
+                    "grid_width": 2,
+                    "grid_height": 4,
+                }
+            ],
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_200_OK, response.json()
+    assert [widget["id"] for widget in response.json()] == [second_widget.id]
+    assert not Widget.objects.filter(id=first_widget.id).exists()
+    second_widget.refresh_from_db()
+    assert (second_widget.grid_x, second_widget.grid_y) == (0, 0)

--- a/backend/tests/baserow/contrib/dashboard/test_dashboard_application_types.py
+++ b/backend/tests/baserow/contrib/dashboard/test_dashboard_application_types.py
@@ -153,6 +153,10 @@ def test_dashboard_export_serialized_with_widgets(data_fixture):
                 "order": "1.00000000000000000000",
                 "title": "Widget 1",
                 "type": "summary",
+                "grid_x": 0,
+                "grid_y": 0,
+                "grid_width": 2,
+                "grid_height": 4,
             },
             {
                 "data_source_id": dashboard_widget_2.data_source.id,
@@ -161,6 +165,10 @@ def test_dashboard_export_serialized_with_widgets(data_fixture):
                 "order": "2.00000000000000000000",
                 "title": "Widget 2",
                 "type": "summary",
+                "grid_x": 0,
+                "grid_y": 4,
+                "grid_width": 2,
+                "grid_height": 4,
             },
         ],
     }
@@ -350,6 +358,8 @@ def test_dashboard_import_serialized_with_widgets(data_fixture):
     assert widget1.description == "Description 1"
     assert widget1.order == Decimal("1.0")
     assert widget1.data_source.id == ds1.id
+    assert (widget1.grid_x, widget1.grid_y) == (0, 0)
+    assert (widget1.grid_width, widget1.grid_height) == (2, 4)
 
     widget2 = widgets[1].specific
     assert widget1.content_type == ContentType.objects.get_for_model(SummaryWidget)
@@ -357,6 +367,8 @@ def test_dashboard_import_serialized_with_widgets(data_fixture):
     assert widget2.description == "Description 2"
     assert widget2.order == Decimal("2.0")
     assert widget2.data_source.id == ds2.id
+    assert (widget2.grid_x, widget2.grid_y) == (0, 4)
+    assert (widget2.grid_width, widget2.grid_height) == (2, 4)
 
     assert progress.progress == 100
 

--- a/backend/tests/baserow/contrib/dashboard/test_dashboard_trash_types.py
+++ b/backend/tests/baserow/contrib/dashboard/test_dashboard_trash_types.py
@@ -29,6 +29,32 @@ def test_restore_widget(data_fixture):
 
 
 @pytest.mark.django_db
+def test_restore_widget_after_compacted_delete_is_placed_after_active_layout(
+    data_fixture,
+):
+    user = data_fixture.create_user()
+    dashboard = data_fixture.create_dashboard_application(user=user)
+    widget = data_fixture.create_summary_widget(dashboard=dashboard)
+    widget_2 = data_fixture.create_summary_widget(dashboard=dashboard)
+    widget.grid_width = 6
+    widget.grid_height = 4
+    widget.save(update_fields=["grid_width", "grid_height"])
+    widget_2.grid_width = 6
+    widget_2.grid_height = 4
+    widget_2.save(update_fields=["grid_width", "grid_height"])
+
+    WidgetService().delete_widget(user, widget.id)
+    widget_2.refresh_from_db()
+    assert widget_2.grid_y == 0
+
+    TrashHandler.restore_item(user, WidgetTrashableItemType.type, widget.id)
+
+    widget.refresh_from_db()
+    assert (widget.grid_x, widget.grid_y) == (0, 4)
+    assert (widget_2.grid_x, widget_2.grid_y) == (0, 0)
+
+
+@pytest.mark.django_db
 def test_delete_widget_permanently_removes_data_source(data_fixture):
     user = data_fixture.create_user()
     dashboard = data_fixture.create_dashboard_application(user=user)

--- a/backend/tests/baserow/contrib/dashboard/widgets/test_dashboard_widgets_action_types.py
+++ b/backend/tests/baserow/contrib/dashboard/widgets/test_dashboard_widgets_action_types.py
@@ -5,7 +5,9 @@ import pytest
 from baserow.contrib.dashboard.widgets.actions import (
     CreateWidgetActionType,
     DeleteWidgetActionType,
+    DeleteWidgetWithLayoutActionType,
     UpdateWidgetActionType,
+    UpdateWidgetLayoutActionType,
 )
 from baserow.contrib.dashboard.widgets.models import SummaryWidget
 from baserow.contrib.dashboard.widgets.service import WidgetService
@@ -134,14 +136,26 @@ def test_can_undo_redo_delete_widget(data_fixture):
         title="Widget title",
         description="Widget description",
     )
+    second_widget = WidgetService().create_widget(
+        user,
+        "summary",
+        dashboard.id,
+        title="Second widget",
+    )
+    widget.grid_width = 6
+    widget.save(update_fields=["grid_width"])
+    second_widget.grid_width = 6
+    second_widget.save(update_fields=["grid_width"])
     dashboard_widgets = WidgetService().get_widgets(user, dashboard.id)
-    assert len(dashboard_widgets) == 1
+    assert len(dashboard_widgets) == 2
 
     # do
     action_type_registry.get_by_type(DeleteWidgetActionType).do(user, widget.id)
 
     dashboard_widgets = WidgetService().get_widgets(user, dashboard.id)
-    assert len(dashboard_widgets) == 0
+    assert len(dashboard_widgets) == 1
+    second_widget.refresh_from_db()
+    assert (second_widget.grid_x, second_widget.grid_y) == (0, 0)
 
     # undo
     ActionHandler.undo(
@@ -151,11 +165,17 @@ def test_can_undo_redo_delete_widget(data_fixture):
     )
 
     dashboard_widgets = WidgetService().get_widgets(user, dashboard.id)
-    assert len(dashboard_widgets) == 1
-    widget = dashboard_widgets[0]
-    assert widget.title == "Widget title"
-    assert widget.description == "Widget description"
-    assert widget.content_type == ContentType.objects.get_for_model(SummaryWidget)
+    assert len(dashboard_widgets) == 2
+    restored_widget = next(item for item in dashboard_widgets if item.id == widget.id)
+    assert restored_widget.title == "Widget title"
+    assert restored_widget.description == "Widget description"
+    assert restored_widget.content_type == ContentType.objects.get_for_model(
+        SummaryWidget
+    )
+    restored_widget.refresh_from_db()
+    second_widget.refresh_from_db()
+    assert (restored_widget.grid_x, restored_widget.grid_y) == (0, 0)
+    assert (second_widget.grid_x, second_widget.grid_y) == (0, 4)
 
     # redo
     actions_redone = ActionHandler.redo(
@@ -166,4 +186,113 @@ def test_can_undo_redo_delete_widget(data_fixture):
     assert_undo_redo_actions_are_valid(actions_redone, [DeleteWidgetActionType])
 
     dashboard_widgets = WidgetService().get_widgets(user, dashboard.id)
-    assert len(dashboard_widgets) == 0
+    assert len(dashboard_widgets) == 1
+    second_widget.refresh_from_db()
+    assert (second_widget.grid_x, second_widget.grid_y) == (0, 0)
+
+
+@pytest.mark.django_db
+@pytest.mark.undo_redo
+def test_can_undo_redo_update_widget_layout(data_fixture):
+    session_id = "session-id"
+    user = data_fixture.create_user(session_id=session_id)
+    workspace = data_fixture.create_workspace(user=user)
+    dashboard = data_fixture.create_dashboard_application(
+        workspace=workspace, user=user
+    )
+    first_widget = WidgetService().create_widget(
+        user, "summary", dashboard.id, title="First"
+    )
+    second_widget = WidgetService().create_widget(
+        user, "summary", dashboard.id, title="Second"
+    )
+    new_layout = [
+        {
+            "id": first_widget.id,
+            "grid_x": 0,
+            "grid_y": 0,
+            "grid_width": 2,
+            "grid_height": 4,
+        },
+        {
+            "id": second_widget.id,
+            "grid_x": 2,
+            "grid_y": 0,
+            "grid_width": 2,
+            "grid_height": 4,
+        },
+    ]
+
+    action_type_registry.get_by_type(UpdateWidgetLayoutActionType).do(
+        user, dashboard.id, new_layout
+    )
+    second_widget.refresh_from_db()
+    assert (second_widget.grid_x, second_widget.grid_y) == (2, 0)
+
+    ActionHandler.undo(
+        user,
+        [ApplicationActionScopeType.value(application_id=dashboard.id)],
+        session_id,
+    )
+    second_widget.refresh_from_db()
+    assert (second_widget.grid_x, second_widget.grid_y) == (0, 4)
+
+    actions_redone = ActionHandler.redo(
+        user,
+        [ApplicationActionScopeType.value(application_id=dashboard.id)],
+        session_id,
+    )
+    assert_undo_redo_actions_are_valid(actions_redone, [UpdateWidgetLayoutActionType])
+    second_widget.refresh_from_db()
+    assert (second_widget.grid_x, second_widget.grid_y) == (2, 0)
+
+
+@pytest.mark.django_db
+@pytest.mark.undo_redo
+def test_can_undo_redo_delete_widget_with_layout(data_fixture):
+    session_id = "session-id"
+    user = data_fixture.create_user(session_id=session_id)
+    workspace = data_fixture.create_workspace(user=user)
+    dashboard = data_fixture.create_dashboard_application(
+        workspace=workspace, user=user
+    )
+    first_widget = WidgetService().create_widget(
+        user, "summary", dashboard.id, title="First"
+    )
+    second_widget = WidgetService().create_widget(
+        user, "summary", dashboard.id, title="Second"
+    )
+    compacted_layout = [
+        {
+            "id": second_widget.id,
+            "grid_x": 0,
+            "grid_y": 0,
+            "grid_width": 2,
+            "grid_height": 4,
+        }
+    ]
+
+    action_type_registry.get_by_type(DeleteWidgetWithLayoutActionType).do(
+        user, dashboard.id, first_widget.id, compacted_layout
+    )
+    assert len(WidgetService().get_widgets(user, dashboard.id)) == 1
+
+    ActionHandler.undo(
+        user,
+        [ApplicationActionScopeType.value(application_id=dashboard.id)],
+        session_id,
+    )
+    widgets = list(WidgetService().get_widgets(user, dashboard.id))
+    assert {widget.id for widget in widgets} == {first_widget.id, second_widget.id}
+    second_widget.refresh_from_db()
+    assert (second_widget.grid_x, second_widget.grid_y) == (0, 4)
+
+    actions_redone = ActionHandler.redo(
+        user,
+        [ApplicationActionScopeType.value(application_id=dashboard.id)],
+        session_id,
+    )
+    assert_undo_redo_actions_are_valid(
+        actions_redone, [DeleteWidgetWithLayoutActionType]
+    )
+    assert len(WidgetService().get_widgets(user, dashboard.id)) == 1

--- a/backend/tests/baserow/contrib/dashboard/widgets/test_dashboard_widgets_handler.py
+++ b/backend/tests/baserow/contrib/dashboard/widgets/test_dashboard_widgets_handler.py
@@ -196,6 +196,8 @@ def test_create_widget(data_fixture):
     assert widget.title == "New widget title"
     assert widget.description == "My desc"
     assert widget.content_type == ContentType.objects.get_for_model(SummaryWidget)
+    assert (widget.grid_x, widget.grid_y) == (0, 0)
+    assert (widget.grid_width, widget.grid_height) == (2, 4)
     assert Widget.objects.count() == 1
 
 
@@ -226,3 +228,56 @@ def test_delete_widget(data_fixture):
     assert Widget.objects.count() == 0
 
     assert DashboardDataSource.objects.filter(id=data_source_id).count() == 0
+
+
+@pytest.mark.django_db
+def test_get_compacted_widget_layout_preserves_columns_and_fills_vertical_gaps(
+    data_fixture,
+):
+    dashboard = data_fixture.create_dashboard_application()
+    first_widget = data_fixture.create_summary_widget(dashboard=dashboard)
+    second_widget = data_fixture.create_summary_widget(dashboard=dashboard)
+    third_widget = data_fixture.create_summary_widget(dashboard=dashboard)
+
+    first_widget.grid_x = 0
+    first_widget.grid_y = 0
+    first_widget.grid_width = 2
+    first_widget.grid_height = 4
+    second_widget.grid_x = 2
+    second_widget.grid_y = 4
+    second_widget.grid_width = 4
+    second_widget.grid_height = 4
+    third_widget.grid_x = 0
+    third_widget.grid_y = 8
+    third_widget.grid_width = 2
+    third_widget.grid_height = 4
+    for widget in (first_widget, second_widget, third_widget):
+        widget.save(update_fields=["grid_x", "grid_y", "grid_width", "grid_height"])
+
+    layout = WidgetHandler().get_compacted_widget_layout(
+        [first_widget, second_widget, third_widget]
+    )
+
+    assert layout == [
+        {
+            "id": first_widget.id,
+            "grid_x": 0,
+            "grid_y": 0,
+            "grid_width": 2,
+            "grid_height": 4,
+        },
+        {
+            "id": second_widget.id,
+            "grid_x": 2,
+            "grid_y": 0,
+            "grid_width": 4,
+            "grid_height": 4,
+        },
+        {
+            "id": third_widget.id,
+            "grid_x": 0,
+            "grid_y": 4,
+            "grid_width": 2,
+            "grid_height": 4,
+        },
+    ]

--- a/backend/tests/baserow/contrib/dashboard/widgets/test_dashboard_widgets_service.py
+++ b/backend/tests/baserow/contrib/dashboard/widgets/test_dashboard_widgets_service.py
@@ -275,6 +275,22 @@ def test_delete_widget(data_fixture):
 
 
 @pytest.mark.django_db
+def test_delete_widget_compacts_legacy_widget_layout(data_fixture):
+    user = data_fixture.create_user()
+    dashboard = data_fixture.create_dashboard_application(user=user)
+    remaining_widget = data_fixture.create_summary_widget(dashboard=dashboard)
+    deleted_widget = data_fixture.create_summary_widget(dashboard=dashboard)
+    Widget.objects.filter(id=remaining_widget.id).update(grid_height=9)
+    Widget.objects.filter(id=deleted_widget.id).update(grid_y=12, grid_height=9)
+
+    WidgetService().delete_widget(user, deleted_widget.id)
+
+    remaining_widget.refresh_from_db()
+    assert remaining_widget.grid_y == 0
+    assert remaining_widget.grid_height == 9
+
+
+@pytest.mark.django_db
 def test_delete_widget_permission_denied(data_fixture):
     user_without_perms = data_fixture.create_user()
     dashboard = data_fixture.create_dashboard_application()

--- a/backend/tests/baserow/contrib/dashboard/ws/test_dashboard_receivers.py
+++ b/backend/tests/baserow/contrib/dashboard/ws/test_dashboard_receivers.py
@@ -12,6 +12,7 @@ from baserow.contrib.dashboard.widgets.signals import (
     widget_created,
     widget_deleted,
     widget_updated,
+    widgets_layout_updated,
 )
 from baserow.core.services.registries import service_type_registry
 
@@ -72,6 +73,35 @@ def test_widget_deleted_ws_receiver(mock_broadcast_to_channel_group, data_fixtur
     assert args[0][1]["type"] == "widget_deleted"
     assert args[0][1]["dashboard_id"] == dashboard.id
     assert args[0][1]["widget"]["id"] == widget.id
+    assert args[0][2] == "test_websocket_id"
+
+
+@pytest.mark.django_db(transaction=True)
+@patch("baserow.ws.registries.broadcast_to_channel_group")
+def test_widgets_layout_updated_ws_receiver(
+    mock_broadcast_to_channel_group, data_fixture
+):
+    user = data_fixture.create_user(web_socket_id="test_websocket_id")
+    dashboard = data_fixture.create_dashboard_application()
+    first_widget = data_fixture.create_summary_widget(dashboard=dashboard)
+    second_widget = data_fixture.create_summary_widget(dashboard=dashboard)
+
+    widgets_layout_updated.send(
+        None,
+        user=user,
+        dashboard=dashboard,
+        widgets=[first_widget, second_widget],
+    )
+
+    mock_broadcast_to_channel_group.delay.assert_called_once()
+    args = mock_broadcast_to_channel_group.delay.call_args
+    assert args[0][0] == f"dashboard-{dashboard.id}"
+    assert args[0][1]["type"] == "widgets_layout_updated"
+    assert args[0][1]["dashboard_id"] == dashboard.id
+    assert [widget["id"] for widget in args[0][1]["widgets"]] == [
+        first_widget.id,
+        second_widget.id,
+    ]
     assert args[0][2] == "test_websocket_id"
 
 

--- a/changelog/entries/unreleased/feature/3306_allow_dashboard_widgets_to_be_arranged_and_resized_on_a_grid.json
+++ b/changelog/entries/unreleased/feature/3306_allow_dashboard_widgets_to_be_arranged_and_resized_on_a_grid.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Allow dashboard widgets to be arranged and resized on a grid",
+    "issue_origin": "github",
+    "issue_number": 3306,
+    "domain": "dashboard",
+    "bullet_points": [],
+    "created_at": "2026-08-04"
+}

--- a/e2e-tests/fixtures/dashboard/dashboard.ts
+++ b/e2e-tests/fixtures/dashboard/dashboard.ts
@@ -1,0 +1,55 @@
+import { getClient } from "../../client";
+import { Workspace } from "../workspace";
+
+export type DashboardWidget = {
+  id: number;
+  grid_x: number;
+  grid_y: number;
+  grid_width: number;
+  grid_height: number;
+};
+
+export class Dashboard {
+  constructor(
+    public id: number,
+    public name: string,
+    public workspace: Workspace,
+  ) {}
+}
+
+export async function createDashboard(
+  dashboardName: string,
+  workspace: Workspace,
+): Promise<Dashboard> {
+  const response: any = await getClient(workspace.user).post(
+    `applications/workspace/${workspace.id}/`,
+    {
+      name: dashboardName,
+      type: "dashboard",
+    },
+  );
+  return new Dashboard(response.data.id, response.data.name, workspace);
+}
+
+export async function createSummaryWidget(
+  dashboard: Dashboard,
+  title: string,
+): Promise<DashboardWidget> {
+  const response: any = await getClient(dashboard.workspace.user).post(
+    `dashboard/${dashboard.id}/widgets/`,
+    {
+      title,
+      type: "summary",
+    },
+  );
+  return response.data;
+}
+
+export async function getDashboardWidgets(
+  dashboard: Dashboard,
+): Promise<DashboardWidget[]> {
+  const response: any = await getClient(dashboard.workspace.user).get(
+    `dashboard/${dashboard.id}/widgets/`,
+  );
+  return response.data;
+}

--- a/e2e-tests/tests/dashboard/dashboardWidgetGrid.spec.ts
+++ b/e2e-tests/tests/dashboard/dashboardWidgetGrid.spec.ts
@@ -1,0 +1,266 @@
+import type { Locator, Page } from '@playwright/test'
+
+import {
+  createDashboard,
+  createSummaryWidget,
+  Dashboard,
+  getDashboardWidgets,
+} from '../../fixtures/dashboard/dashboard'
+import { baserowConfig } from '../../playwright.config'
+import { expect, test } from '../baserowTest'
+
+type GridCoordinates = {
+  grid_x: number
+  grid_y: number
+  grid_width: number
+  grid_height: number
+}
+
+async function goToDashboard(page: Page, dashboard: Dashboard) {
+  await page.goto(
+    `${baserowConfig.PUBLIC_WEB_FRONTEND_URL}/dashboard/${dashboard.id}`,
+    { waitUntil: 'networkidle' }
+  )
+  await expect(page.getByText('Edit mode', { exact: true })).toBeVisible()
+}
+
+async function enterEditMode(page: Page) {
+  await page.getByText('Edit mode', { exact: true }).click()
+  await expect(page.getByRole('button', { name: 'Done editing' })).toBeVisible()
+}
+
+async function dragBy(
+  page: Page,
+  source: Locator,
+  deltaX: number,
+  deltaY: number
+) {
+  const box = await source.boundingBox()
+  if (!box) {
+    throw new Error('Could not measure the dashboard widget drag handle')
+  }
+
+  const x = box.x + box.width / 2
+  const y = box.y + box.height / 2
+  await page.mouse.move(x, y)
+  await page.mouse.down()
+  await page.mouse.move(x + deltaX, y + deltaY, { steps: 12 })
+  await page.mouse.up()
+}
+
+async function expectWidgetLayout(
+  dashboard: Dashboard,
+  widgetId: number,
+  expected: Partial<GridCoordinates>
+) {
+  await expect
+    .poll(async () => {
+      const widgets = await getDashboardWidgets(dashboard)
+      return widgets.find((widget) => widget.id === widgetId)
+    })
+    .toMatchObject(expected)
+}
+
+test.describe('Dashboard widget grid', () => {
+  test.use({ viewport: { width: 1440, height: 1000 } })
+
+  test('keeps widget context menus available in edit mode', async ({
+    page,
+    workspacePage,
+  }) => {
+    const dashboard = await createDashboard(
+      'Dashboard widget context menu',
+      workspacePage.workspace
+    )
+    const widget = await createSummaryWidget(dashboard, 'Context widget')
+
+    await goToDashboard(page, dashboard)
+    await expect(
+      page.getByTestId(`dashboard-widget-grid-item-${widget.id}`)
+    ).toBeVisible()
+    await enterEditMode(page)
+
+    const contextButton = page.getByTestId(
+      `dashboard-widget-context-${widget.id}`
+    )
+    await expect(contextButton).toBeVisible()
+    await contextButton.click()
+    await expect(page.getByText('Delete', { exact: true })).toBeVisible()
+  })
+
+  test('finishes loading widgets after reloading a dashboard', async ({
+    page,
+    workspacePage,
+  }) => {
+    const dashboard = await createDashboard(
+      'Dashboard widget reload',
+      workspacePage.workspace
+    )
+    const widget = await createSummaryWidget(dashboard, 'Reload widget')
+
+    await goToDashboard(page, dashboard)
+    await expect(
+      page.getByTestId(`dashboard-widget-grid-item-${widget.id}`)
+    ).toBeVisible()
+
+    await page.reload({ waitUntil: 'networkidle' })
+
+    const loadingIndicator = page
+      .getByTestId(`dashboard-widget-grid-item-${widget.id}`)
+      .locator('.dashboard-summary-widget__loading')
+    await expect(loadingIndicator).toHaveCount(0, { timeout: 10_000 })
+  })
+
+  test('snaps widgets to invisible grid tracks while resizing', async ({
+    page,
+    workspacePage,
+  }) => {
+    const dashboard = await createDashboard(
+      'Dashboard widget grid snap',
+      workspacePage.workspace
+    )
+    const widget = await createSummaryWidget(dashboard, 'Guide widget')
+
+    await goToDashboard(page, dashboard)
+    await enterEditMode(page)
+
+    const grid = page.getByTestId('dashboard-widget-grid')
+    const layoutBox = await grid.locator('.vgl-layout').boundingBox()
+    const resizer = page
+      .getByTestId(`dashboard-widget-grid-item-${widget.id}`)
+      .locator('.vgl-item__resizer')
+    const resizerBox = await resizer.boundingBox()
+    if (!layoutBox || !resizerBox) {
+      throw new Error('Could not measure the dashboard widget grid resizer')
+    }
+
+    const gridGap = 16
+    const columnWidth = (layoutBox.width - 7 * gridGap) / 6
+    const x = resizerBox.x + resizerBox.width / 2
+    const y = resizerBox.y + resizerBox.height / 2
+
+    await page.mouse.move(x, y)
+    await page.mouse.down()
+    try {
+      await page.mouse.move(x + columnWidth + gridGap, y, { steps: 12 })
+      await expect(grid).toHaveClass(/dashboard-widget-grid--interacting/)
+
+      const alignment = await page.evaluate(
+        ({ widgetId, gridGap }) => {
+          const grid = document.querySelector('.dashboard-widget-grid')
+          const layout = grid?.querySelector('.vgl-layout')
+          const widget = document.querySelector(
+            `[data-testid="dashboard-widget-grid-item-${widgetId}"]`
+          )
+          if (!grid || !layout || !widget) {
+            throw new Error('Could not inspect the dashboard widget grid')
+          }
+
+          const gridRect = grid.getBoundingClientRect()
+          const layoutRect = layout.getBoundingClientRect()
+          const widgetRect = widget.getBoundingClientRect()
+          const columns = Number.parseFloat(
+            getComputedStyle(grid).getPropertyValue(
+              '--dashboard-widget-grid-columns'
+            )
+          )
+          const step = (layoutRect.width - gridGap) / columns
+          const x = Math.round(
+            (widgetRect.left - layoutRect.left - gridGap) / step
+          )
+          const width = Math.round((widgetRect.width + gridGap) / step)
+
+          return {
+            width,
+            // A widget spans its internal gutters and ends at the last track
+            // boundary, immediately before the following real gutter.
+            leftDelta: Math.abs(widgetRect.left - gridRect.left - x * step),
+            rightDelta: Math.abs(
+              widgetRect.right - gridRect.left - ((x + width) * step - gridGap)
+            ),
+          }
+        },
+        { widgetId: widget.id, gridGap }
+      )
+
+      expect(alignment.width).toBe(3)
+      expect(alignment.leftDelta).toBeLessThanOrEqual(1)
+      expect(alignment.rightDelta).toBeLessThanOrEqual(1)
+    } finally {
+      await page.mouse.up()
+    }
+  })
+
+  test('persists drag and horizontal/vertical resize, then broadcasts the layout', async ({
+    page,
+    workspacePage,
+  }) => {
+    const dashboard = await createDashboard(
+      'Dashboard widget grid',
+      workspacePage.workspace
+    )
+    const firstWidget = await createSummaryWidget(dashboard, 'First widget')
+    const secondWidget = await createSummaryWidget(dashboard, 'Second widget')
+    await createSummaryWidget(dashboard, 'Third widget')
+
+    await goToDashboard(page, dashboard)
+
+    const observerPage = await page.context().newPage()
+    await goToDashboard(observerPage, dashboard)
+
+    await enterEditMode(page)
+
+    const grid = page.getByTestId('dashboard-widget-grid')
+    const layoutBox = await grid.locator('.vgl-layout').boundingBox()
+    if (!layoutBox) {
+      throw new Error('Could not measure the dashboard widget grid')
+    }
+
+    const columnWidth = (layoutBox.width - 7 * 16) / 6
+    const rowHeightWithMargin = 24 + 16
+
+    await dragBy(
+      page,
+      page.getByTestId(`dashboard-widget-drag-handle-${secondWidget.id}`),
+      2 * (columnWidth + 16),
+      -4 * rowHeightWithMargin
+    )
+    await expectWidgetLayout(dashboard, secondWidget.id, {
+      grid_x: 2,
+      grid_y: 0,
+    })
+
+    const resizer = page
+      .getByTestId(`dashboard-widget-grid-item-${secondWidget.id}`)
+      .locator('.vgl-item__resizer')
+    await dragBy(page, resizer, 2 * (columnWidth + 16), 2 * rowHeightWithMargin)
+    await expectWidgetLayout(dashboard, secondWidget.id, {
+      grid_x: 2,
+      grid_y: 0,
+      grid_width: 4,
+      grid_height: 6,
+    })
+
+    await page.reload({ waitUntil: 'networkidle' })
+    await expectWidgetLayout(dashboard, secondWidget.id, {
+      grid_x: 2,
+      grid_y: 0,
+      grid_width: 4,
+      grid_height: 6,
+    })
+
+    await expect
+      .poll(async () => {
+        const box = await observerPage
+          .getByTestId(`dashboard-widget-grid-item-${secondWidget.id}`)
+          .boundingBox()
+        const firstBox = await observerPage
+          .getByTestId(`dashboard-widget-grid-item-${firstWidget.id}`)
+          .boundingBox()
+        return box && firstBox ? Math.round(box.x - firstBox.x) : null
+      })
+      .toBeGreaterThan(0)
+
+    await observerPage.close()
+  })
+})

--- a/enterprise/backend/src/baserow_enterprise/role/default_roles.py
+++ b/enterprise/backend/src/baserow_enterprise/role/default_roles.py
@@ -88,6 +88,7 @@ from baserow.contrib.dashboard.widgets.operations import (
     ListWidgetsOperationType,
     ReadWidgetOperationType,
     RestoreWidgetOperationType,
+    UpdateWidgetLayoutOperationType,
     UpdateWidgetOperationType,
 )
 from baserow.contrib.database.airtable.operations import (
@@ -574,6 +575,8 @@ default_roles[BUILDER_ROLE_UID].extend(
         GetIncludingPublicValuesOperationType,
         CreateWidgetOperationType,
         UpdateWidgetOperationType,
+        # A layout mutation can reposition every widget after a collision.
+        UpdateWidgetLayoutOperationType,
         DeleteWidgetOperationType,
         RestoreWidgetOperationType,
         CreateDashboardDataSourceOperationType,

--- a/premium/backend/src/baserow_premium/dashboard/widgets/widget_types.py
+++ b/premium/backend/src/baserow_premium/dashboard/widgets/widget_types.py
@@ -11,7 +11,7 @@ from baserow.contrib.dashboard.types import WidgetDict
 from baserow.contrib.dashboard.widgets.exceptions import WidgetImproperlyConfigured
 from baserow.contrib.dashboard.widgets.models import Widget
 from baserow.contrib.dashboard.widgets.registries import WidgetType
-from baserow.contrib.dashboard.widgets.types import UpdatedWidget
+from baserow.contrib.dashboard.widgets.types import UpdatedWidget, WidgetGridLayout
 from baserow.core.services.registries import service_type_registry
 from baserow_premium.api.dashboard.widgets.serializers import (
     ChartSeriesConfigSerializer,
@@ -34,6 +34,14 @@ from baserow_premium.license.handler import LicenseHandler
 class ChartWidgetType(WidgetType):
     type = "chart"
     model_class = ChartWidget
+    grid_layout = WidgetGridLayout(
+        default_width=3,
+        default_height=9,
+        min_width=3,
+        min_height=8,
+        max_width=6,
+        max_height=16,
+    )
     serializer_field_names = [
         "data_source_id",
         "series_config",
@@ -245,6 +253,14 @@ class ChartWidgetType(WidgetType):
 class PieChartWidgetType(WidgetType):
     type = "pie_chart"
     model_class = PieChartWidget
+    grid_layout = WidgetGridLayout(
+        default_width=3,
+        default_height=9,
+        min_width=3,
+        min_height=8,
+        max_width=6,
+        max_height=16,
+    )
     serializer_field_names = [
         "data_source_id",
         "series_config",

--- a/premium/backend/tests/baserow_premium_tests/api/dashboard/test_chart_widget_type_views.py
+++ b/premium/backend/tests/baserow_premium_tests/api/dashboard/test_chart_widget_type_views.py
@@ -11,6 +11,25 @@ from baserow_premium.integrations.local_baserow.models import (
     LocalBaserowTableServiceAggregationSeries,
 )
 
+CHART_GRID_LAYOUT = {
+    "default_width": 3,
+    "default_height": 9,
+    "min_width": 3,
+    "min_height": 8,
+    "max_width": 6,
+    "max_height": 16,
+}
+
+
+def chart_grid_fields(width=3, height=9):
+    return {
+        "grid_x": 0,
+        "grid_y": 0,
+        "grid_width": width,
+        "grid_height": height,
+        "grid_layout": CHART_GRID_LAYOUT,
+    }
+
 
 @pytest.mark.django_db
 @override_settings(DEBUG=True)
@@ -42,6 +61,7 @@ def test_create_chart_widget(api_client, premium_data_fixture):
         "dashboard_id": dashboard.id,
         "order": "1.00000000000000000000",
         "type": "chart",
+        **chart_grid_fields(),
         "series_config": [],
         "default_series_chart_type": "BAR",
     }
@@ -78,6 +98,7 @@ def test_create_chart_widget_default_line(api_client, premium_data_fixture):
         "dashboard_id": dashboard.id,
         "order": "1.00000000000000000000",
         "type": "chart",
+        **chart_grid_fields(),
         "series_config": [],
         "default_series_chart_type": "LINE",
     }
@@ -133,6 +154,7 @@ def test_get_widgets_with_chart_widget(api_client, premium_data_fixture):
             "data_source_id": data_source.id,
             "order": "1.00000000000000000000",
             "type": "chart",
+            **chart_grid_fields(width=6),
             "series_config": [
                 {
                     "series_id": series_1.id,
@@ -302,6 +324,7 @@ def test_update_widget_preserve_chart_config(api_client, premium_data_fixture):
         "data_source_id": data_source.id,
         "order": "1.00000000000000000000",
         "type": "chart",
+        **chart_grid_fields(width=6),
         "series_config": [
             {
                 "series_id": series_1.id,

--- a/premium/backend/tests/baserow_premium_tests/api/dashboard/test_pie_chart_widget_type_views.py
+++ b/premium/backend/tests/baserow_premium_tests/api/dashboard/test_pie_chart_widget_type_views.py
@@ -11,6 +11,25 @@ from baserow_premium.integrations.local_baserow.models import (
     LocalBaserowTableServiceAggregationSeries,
 )
 
+PIE_CHART_GRID_LAYOUT = {
+    "default_width": 3,
+    "default_height": 9,
+    "min_width": 3,
+    "min_height": 8,
+    "max_width": 6,
+    "max_height": 16,
+}
+
+
+def pie_chart_grid_fields(width=3, height=9):
+    return {
+        "grid_x": 0,
+        "grid_y": 0,
+        "grid_width": width,
+        "grid_height": height,
+        "grid_layout": PIE_CHART_GRID_LAYOUT,
+    }
+
 
 @pytest.mark.django_db
 @override_settings(DEBUG=True)
@@ -42,6 +61,7 @@ def test_create_pie_chart_widget(api_client, premium_data_fixture):
         "dashboard_id": dashboard.id,
         "order": "1.00000000000000000000",
         "type": "pie_chart",
+        **pie_chart_grid_fields(),
         "series_config": [],
         "default_series_chart_type": "PIE",
     }
@@ -78,6 +98,7 @@ def test_create_pie_chart_widget_default_pie(api_client, premium_data_fixture):
         "dashboard_id": dashboard.id,
         "order": "1.00000000000000000000",
         "type": "pie_chart",
+        **pie_chart_grid_fields(),
         "series_config": [],
         "default_series_chart_type": "PIE",
     }
@@ -133,6 +154,7 @@ def test_get_widgets_with_pie_chart_widget(api_client, premium_data_fixture):
             "data_source_id": data_source.id,
             "order": "1.00000000000000000000",
             "type": "pie_chart",
+            **pie_chart_grid_fields(width=6),
             "series_config": [
                 {
                     "series_id": series_1.id,
@@ -302,6 +324,7 @@ def test_update_pie_widget_preserve_chart_config(api_client, premium_data_fixtur
         "data_source_id": data_source.id,
         "order": "1.00000000000000000000",
         "type": "pie_chart",
+        **pie_chart_grid_fields(width=6),
         "series_config": [
             {
                 "series_id": series_1.id,

--- a/premium/backend/tests/baserow_premium_tests/dashboard/test_dashboard_application_types_charts.py
+++ b/premium/backend/tests/baserow_premium_tests/dashboard/test_dashboard_application_types_charts.py
@@ -131,6 +131,10 @@ def test_dashboard_export_serialized_with_chart_widget(premium_data_fixture):
                 "order": "1.00000000000000000000",
                 "title": "Widget 1",
                 "type": "chart",
+                "grid_x": 0,
+                "grid_y": 0,
+                "grid_width": 3,
+                "grid_height": 9,
                 "series_config": [],
                 "default_series_chart_type": "BAR",
             },
@@ -275,6 +279,10 @@ def test_dashboard_import_serialized_with_widgets(premium_data_fixture):
     assert widget1.description == "Description 1"
     assert widget1.order == Decimal("1.0")
     assert widget1.data_source.id == ds1.id
+    assert widget1.grid_x == 0
+    assert widget1.grid_y == 0
+    assert widget1.grid_width == 3
+    assert widget1.grid_height == 9
 
     assert progress.progress == 100
 
@@ -380,6 +388,10 @@ def test_dashboard_export_serialized_with_chart_widget_config(premium_data_fixtu
                 "order": "1.00000000000000000000",
                 "title": "Widget 1",
                 "type": "chart",
+                "grid_x": 0,
+                "grid_y": 0,
+                "grid_width": 3,
+                "grid_height": 9,
                 "series_config": [
                     {"series_chart_type": "BAR", "series_id": series_1.id},
                     {"series_chart_type": "LINE", "series_id": series_2.id},
@@ -515,6 +527,10 @@ def test_dashboard_import_serialized_with_widget_config(premium_data_fixture):
     assert widget1.description == "Description 1"
     assert widget1.order == Decimal("1.0")
     assert widget1.data_source.id == ds1.id
+    assert widget1.grid_x == 0
+    assert widget1.grid_y == 0
+    assert widget1.grid_width == 3
+    assert widget1.grid_height == 9
 
     series_configs = ChartSeriesConfig.objects.filter(widget=widget1)
     assert series_configs.count() == 2
@@ -603,6 +619,10 @@ def test_dashboard_export_serialized_with_default_chart_type(premium_data_fixtur
                 "order": "1.00000000000000000000",
                 "title": "Widget 1",
                 "type": "chart",
+                "grid_x": 0,
+                "grid_y": 0,
+                "grid_width": 3,
+                "grid_height": 9,
                 "series_config": [],
                 "default_series_chart_type": "LINE",
             },

--- a/premium/backend/tests/baserow_premium_tests/dashboard/test_pie_chart_widget_type.py
+++ b/premium/backend/tests/baserow_premium_tests/dashboard/test_pie_chart_widget_type.py
@@ -184,6 +184,10 @@ def test_dashboard_export_serialized_with_pie_chart_widget_config(premium_data_f
                 "order": "1.00000000000000000000",
                 "title": "Pie chart",
                 "type": "pie_chart",
+                "grid_x": 0,
+                "grid_y": 0,
+                "grid_width": 3,
+                "grid_height": 9,
                 "series_config": [
                     {"series_chart_type": "PIE", "series_id": series_1.id},
                     {"series_chart_type": "DOUGHNUT", "series_id": series_2.id},
@@ -319,6 +323,10 @@ def test_dashboard_import_serialized_with_pie_chart_widget_config(premium_data_f
     assert widget1.description == "Description 1"
     assert widget1.order == Decimal("1.0")
     assert widget1.data_source.id == ds1.id
+    assert widget1.grid_x == 0
+    assert widget1.grid_y == 0
+    assert widget1.grid_width == 3
+    assert widget1.grid_height == 9
 
     series_configs = PieChartSeriesConfig.objects.filter(widget=widget1)
     assert series_configs.count() == 2

--- a/premium/web-frontend/modules/baserow_premium/assets/scss/components/chart.scss
+++ b/premium/web-frontend/modules/baserow_premium/assets/scss/components/chart.scss
@@ -1,8 +1,13 @@
 .chart {
-  max-height: 320px;
+  flex: 1 1 auto;
+  width: 100% !important;
+  height: 100% !important;
+  min-height: 0;
+  max-height: none;
 }
 
 .chart__no-data {
+  flex: 1 1 auto;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/premium/web-frontend/modules/baserow_premium/assets/scss/components/dashboard_chart_widget.scss
+++ b/premium/web-frontend/modules/baserow_premium/assets/scss/components/dashboard_chart_widget.scss
@@ -1,9 +1,14 @@
 .dashboard-chart-widget {
-  // nothing
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
 }
 
 .dashboard-chart-widget__content {
-  height: 280px;
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .dashboard-chart-widget__loading {

--- a/web-frontend/modules/core/assets/scss/components/dashboard/dashboard_summary_widget.scss
+++ b/web-frontend/modules/core/assets/scss/components/dashboard/dashboard_summary_widget.scss
@@ -1,8 +1,13 @@
 .dashboard-summary-widget {
-  // nothing
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
 }
 
 .dashboard-summary-widget__summary {
+  flex: 1 1 auto;
+  min-height: 0;
   color: $palette-neutral-1200;
   font-size: 40px;
   font-weight: 600;

--- a/web-frontend/modules/core/assets/scss/components/dashboard/dashboard_widget.scss
+++ b/web-frontend/modules/core/assets/scss/components/dashboard/dashboard_widget.scss
@@ -1,18 +1,24 @@
 .dashboard-widget {
   border: 1px solid $palette-neutral-200;
+  background-color: $white;
   box-shadow: 0 1px 2px 0 rgba(7, 8, 16, 0.1);
   position: relative;
-
-  &:not(:first-child) {
-    margin-top: 24px;
-  }
+  display: flex;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
 
   @include rounded($rounded-md);
 }
 
+.dashboard-widget > .dashboard-summary-widget,
+.dashboard-widget > .dashboard-chart-widget {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 .dashboard-widget--selected {
-  outline: 1.5px solid #4e5cfe;
-  outline-offset: 8px;
+  border: 1.5px solid #4e5cfe;
 }
 
 .dashboard-widget--selectable {
@@ -53,4 +59,115 @@
   cursor: default;
   padding: 4px 8px;
   z-index: 1;
+}
+
+.dashboard-widget__drag-handle {
+  position: absolute;
+  top: 13px;
+  left: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  color: $palette-neutral-700;
+  cursor: grab;
+  z-index: 2;
+
+  &:active {
+    cursor: grabbing;
+  }
+}
+
+.dashboard-widget-grid {
+  --dashboard-widget-grid-columns: 6;
+  --dashboard-widget-grid-gap: 16px;
+  --dashboard-widget-grid-row-height: 24px;
+  --grid-gap: var(--dashboard-widget-grid-gap);
+
+  position: relative;
+  width: 100%;
+
+  .vgl-layout {
+    --vgl-placeholder-bg: #4e5cfe;
+    --vgl-placeholder-opacity: 12%;
+    --vgl-placeholder-z-index: 3;
+    --vgl-item-resizing-z-index: 4;
+    --vgl-item-resizing-opacity: 92%;
+    --vgl-item-dragging-z-index: 4;
+    --vgl-item-dragging-opacity: 100%;
+    --vgl-resizer-size: 14px;
+    --vgl-resizer-border-color: #4e5cfe;
+    --vgl-resizer-border-width: 2px;
+
+    position: relative;
+    box-sizing: border-box;
+    width: calc(100% + var(--grid-gap) + var(--grid-gap));
+    top: calc(0px - var(--grid-gap));
+    left: calc(0px - var(--grid-gap));
+    margin-bottom: calc(0px - var(--grid-gap));
+    transition: height 200ms ease;
+  }
+
+  .vgl-item {
+    position: absolute;
+    box-sizing: border-box;
+    transition: 200ms ease;
+    transition-property: left, top, right;
+
+    &--placeholder {
+      z-index: var(--vgl-placeholder-z-index);
+      user-select: none;
+      background-color: var(--vgl-placeholder-bg);
+      opacity: var(--vgl-placeholder-opacity);
+      transition-duration: 100ms;
+    }
+
+    &--no-touch {
+      touch-action: none;
+    }
+
+    &--transform {
+      right: auto;
+      left: 0;
+      transition-property: transform;
+    }
+
+    &--transform.vgl-item--rtl {
+      right: 0;
+      left: auto;
+    }
+
+    &--resizing {
+      z-index: var(--vgl-item-resizing-z-index);
+      user-select: none;
+      opacity: var(--vgl-item-resizing-opacity);
+    }
+
+    &--dragging {
+      z-index: var(--vgl-item-dragging-z-index);
+      user-select: none;
+      opacity: var(--vgl-item-dragging-opacity);
+      transition: none;
+    }
+
+    &__resizer {
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      box-sizing: border-box;
+      width: var(--vgl-resizer-size);
+      height: var(--vgl-resizer-size);
+      cursor: se-resize;
+
+      &::before {
+        position: absolute;
+        inset: 0 3px 3px 0;
+        content: '';
+        border: 0 solid var(--vgl-resizer-border-color);
+        border-right-width: var(--vgl-resizer-border-width);
+        border-bottom-width: var(--vgl-resizer-border-width);
+      }
+    }
+  }
 }

--- a/web-frontend/modules/core/assets/scss/components/dashboard/widget.scss
+++ b/web-frontend/modules/core/assets/scss/components/dashboard/widget.scss
@@ -18,6 +18,10 @@
   }
 }
 
+.dashboard-widget--layout-editable .widget__header--edit-mode {
+  padding-left: 48px;
+}
+
 .widget__header-main {
   display: flex;
   flex-direction: column;

--- a/web-frontend/modules/dashboard/components/DashboardWidgetGrid.client.vue
+++ b/web-frontend/modules/dashboard/components/DashboardWidgetGrid.client.vue
@@ -1,0 +1,230 @@
+<template>
+  <div
+    class="dashboard-widget-grid"
+    data-testid="dashboard-widget-grid"
+    :style="{
+      '--dashboard-widget-grid-columns': columns,
+      '--dashboard-widget-grid-gap': `${gridGap}px`,
+      '--dashboard-widget-grid-row-height': `${gridRowHeight}px`,
+    }"
+    :class="{
+      'dashboard-widget-grid--interacting': isInteracting,
+    }"
+  >
+    <GridLayout
+      v-if="layout.length > 0"
+      v-model:layout="layout"
+      :col-num="columns"
+      :row-height="gridRowHeight"
+      :margin="[gridGap, gridGap]"
+      :vertical-compact="true"
+      :is-draggable="canManipulateLayout"
+      :is-resizable="canManipulateLayout"
+      :use-style-cursor="false"
+    >
+      <GridItem
+        v-for="layoutItem in layout"
+        :key="layoutItem.i"
+        v-bind="
+          getWidgetGridItemConstraints(
+            getWidget(layoutItem),
+            columns,
+            layoutItem
+          )
+        "
+        :i="layoutItem.i"
+        :x="layoutItem.x"
+        :y="layoutItem.y"
+        :w="layoutItem.w"
+        :h="layoutItem.h"
+        :is-draggable="canManipulateLayout"
+        :is-resizable="canManipulateLayout"
+        :data-testid="`dashboard-widget-grid-item-${layoutItem.i}`"
+        drag-allow-from=".dashboard-widget__drag-handle"
+        @move="startInteraction"
+        @resize="startInteraction"
+        @moved="persistLayout"
+        @resized="persistLayout"
+      >
+        <DashboardWidget
+          v-if="getWidget(layoutItem)"
+          :widget="getWidget(layoutItem)"
+          :dashboard="dashboard"
+          :store-prefix="storePrefix"
+          :data-testid="`dashboard-widget-${layoutItem.i}`"
+          :is-layout-editable="canManipulateLayout"
+          @delete-widget="deleteWidget"
+        />
+      </GridItem>
+    </GridLayout>
+  </div>
+</template>
+
+<script>
+import { GridItem, GridLayout } from 'grid-layout-plus'
+
+import DashboardWidget from '@baserow/modules/dashboard/components/widget/DashboardWidget'
+import {
+  createWidgetGridLayout,
+  getDashboardGridColumns,
+  getWidgetGridItemConstraints,
+  toWidgetLayoutPayload,
+} from '@baserow/modules/dashboard/utils/widgetGridLayout'
+import { notifyIf } from '@baserow/modules/core/utils/error'
+
+const GRID_GAP = 16
+const GRID_ROW_HEIGHT = 24
+
+export default {
+  name: 'DashboardWidgetGrid',
+  components: { DashboardWidget, GridItem, GridLayout },
+  props: {
+    dashboard: {
+      type: Object,
+      required: true,
+    },
+    storePrefix: {
+      type: String,
+      required: false,
+      default: '',
+    },
+  },
+  data() {
+    return {
+      isInteracting: false,
+      isPersisting: false,
+      layout: [],
+      gridGap: GRID_GAP,
+      gridRowHeight: GRID_ROW_HEIGHT,
+      viewportWidth: 0,
+    }
+  },
+  computed: {
+    widgets() {
+      return this.$store.getters[
+        `${this.storePrefix}dashboardApplication/getWidgets`
+      ]
+    },
+    widgetsById() {
+      return Object.fromEntries(
+        this.widgets.map((widget) => [String(widget.id), widget])
+      )
+    },
+    columns() {
+      return getDashboardGridColumns(this.viewportWidth)
+    },
+    isEditMode() {
+      return this.$store.getters[
+        `${this.storePrefix}dashboardApplication/isEditMode`
+      ]
+    },
+    canUpdateLayout() {
+      return this.$hasPermission(
+        'dashboard.update_widget_layout',
+        this.dashboard,
+        this.dashboard.workspace.id
+      )
+    },
+    canManipulateLayout() {
+      return (
+        this.columns === 6 &&
+        this.isEditMode &&
+        this.canUpdateLayout &&
+        !this.isPersisting
+      )
+    },
+  },
+  watch: {
+    columns() {
+      // A viewport breakpoint can interrupt an active pointer operation.
+      this.isInteracting = false
+      this.syncLayoutFromWidgets()
+    },
+    widgets: {
+      handler() {
+        if (!this.isInteracting && !this.isPersisting) {
+          this.syncLayoutFromWidgets()
+        }
+      },
+      deep: true,
+    },
+  },
+  mounted() {
+    this.updateViewportWidth()
+    window.addEventListener('resize', this.updateViewportWidth)
+    this.syncLayoutFromWidgets()
+  },
+  beforeUnmount() {
+    window.removeEventListener('resize', this.updateViewportWidth)
+  },
+  methods: {
+    getWidgetGridItemConstraints,
+    updateViewportWidth() {
+      this.viewportWidth = window.innerWidth
+    },
+    getWidget(layoutItem) {
+      return this.widgetsById[String(layoutItem.i)]
+    },
+    syncLayoutFromWidgets() {
+      this.layout = createWidgetGridLayout(this.widgets, this.columns)
+    },
+    startInteraction() {
+      if (this.canManipulateLayout) {
+        this.isInteracting = true
+      }
+    },
+    async persistLayout() {
+      if (!this.isInteracting || !this.canManipulateLayout) {
+        return
+      }
+
+      // GridItem emits its end event just before GridLayout applies the final
+      // position and compacts every affected item.
+      await this.$nextTick()
+      this.isPersisting = true
+      try {
+        await this.$store.dispatch(
+          `${this.storePrefix}dashboardApplication/updateWidgetLayout`,
+          {
+            dashboardId: this.dashboard.id,
+            layout: toWidgetLayoutPayload(this.layout),
+          }
+        )
+      } catch (error) {
+        notifyIf(error, 'dashboard')
+      } finally {
+        this.isPersisting = false
+        this.isInteracting = false
+        this.syncLayoutFromWidgets()
+      }
+    },
+    async deleteWidget(widgetId) {
+      if (!this.canUpdateLayout || this.isPersisting) {
+        return
+      }
+
+      const previousLayout = this.layout.map((item) => ({ ...item }))
+      this.isPersisting = true
+      this.layout = this.layout.filter((item) => Number(item.i) !== widgetId)
+
+      await this.$nextTick()
+      try {
+        await this.$store.dispatch(
+          `${this.storePrefix}dashboardApplication/deleteWidgetWithLayout`,
+          {
+            dashboardId: this.dashboard.id,
+            widgetId,
+            layout: toWidgetLayoutPayload(this.layout),
+          }
+        )
+      } catch (error) {
+        this.layout = previousLayout
+        notifyIf(error, 'dashboard')
+      } finally {
+        this.isPersisting = false
+        this.syncLayoutFromWidgets()
+      }
+    },
+  },
+}
+</script>

--- a/web-frontend/modules/dashboard/components/WidgetBoard.vue
+++ b/web-frontend/modules/dashboard/components/WidgetBoard.vue
@@ -1,21 +1,15 @@
 <template>
-  <div>
-    <DashboardWidget
-      v-for="widget in widgets"
-      :key="widget.id"
-      :widget="widget"
-      :dashboard="dashboard"
-      :store-prefix="storePrefix"
-    />
-  </div>
+  <ClientOnly fallback-tag="div">
+    <DashboardWidgetGrid :dashboard="dashboard" :store-prefix="storePrefix" />
+  </ClientOnly>
 </template>
 
 <script>
-import DashboardWidget from '@baserow/modules/dashboard/components/widget/DashboardWidget'
+import DashboardWidgetGrid from '@baserow/modules/dashboard/components/DashboardWidgetGrid.client'
 
 export default {
   name: 'WidgetBoard',
-  components: { DashboardWidget },
+  components: { DashboardWidgetGrid },
   props: {
     dashboard: {
       type: Object,
@@ -25,18 +19,6 @@ export default {
       type: String,
       required: false,
       default: '',
-    },
-  },
-  computed: {
-    isEditMode() {
-      return this.$store.getters[
-        `${this.storePrefix}dashboardApplication/isEditMode`
-      ]
-    },
-    widgets() {
-      return this.$store.getters[
-        `${this.storePrefix}dashboardApplication/getWidgets`
-      ]
     },
   },
 }

--- a/web-frontend/modules/dashboard/components/widget/DashboardWidget.vue
+++ b/web-frontend/modules/dashboard/components/widget/DashboardWidget.vue
@@ -4,9 +4,19 @@
     :class="{
       'dashboard-widget--selected': isSelected,
       'dashboard-widget--selectable': isSelectable,
+      'dashboard-widget--layout-editable': isLayoutEditable,
     }"
     @click="selectWidgetIfAllowed(widget.id)"
   >
+    <span
+      v-if="isLayoutEditable"
+      class="dashboard-widget__drag-handle"
+      :data-testid="`dashboard-widget-drag-handle-${widget.id}`"
+      :aria-label="$t('widget.dragWidget')"
+      :title="$t('widget.dragWidget')"
+    >
+      <i class="iconoir-drag" aria-hidden="true"></i>
+    </span>
     <div v-if="isSelected && isEditMode" class="dashboard-widget__name">
       {{ widgetType.name }}
     </div>
@@ -17,6 +27,7 @@
       :store-prefix="storePrefix"
       :loading="isLoading"
       :edit-mode="isEditMode"
+      @delete-widget="$emit('delete-widget', $event)"
     />
   </div>
 </template>
@@ -38,7 +49,13 @@ export default {
       required: false,
       default: '',
     },
+    isLayoutEditable: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
+  emits: ['delete-widget'],
   computed: {
     isSelected() {
       return this.selectedWidgetId === this.widget.id && this.isEditMode

--- a/web-frontend/modules/dashboard/components/widget/SummaryWidget.vue
+++ b/web-frontend/modules/dashboard/components/widget/SummaryWidget.vue
@@ -5,31 +5,30 @@
       'dashboard-summary-widget--with-header-description': widget.description,
     }"
   >
-    <template v-if="!loading">
-      <div class="widget__header widget__header--no-border">
-        <div class="widget__header-main">
-          <div class="widget__header-title-wrapper">
-            <div class="widget__header-title">{{ widget.title }}</div>
+    <div
+      class="widget__header widget__header--no-border"
+      :class="{ 'widget__header--edit-mode': isEditMode }"
+    >
+      <div class="widget__header-main">
+        <div class="widget__header-title-wrapper">
+          <div class="widget__header-title">{{ widget.title }}</div>
 
-            <Badge
-              v-if="dataSourceMisconfigured"
-              color="red"
-              indicator
-              rounded
-              >{{ $t('widget.fixConfiguration') }}</Badge
-            >
-          </div>
-          <div v-if="widget.description" class="widget__header-description">
-            {{ widget.description }}
-          </div>
+          <Badge v-if="dataSourceMisconfigured" color="red" indicator rounded>{{
+            $t('widget.fixConfiguration')
+          }}</Badge>
         </div>
-        <WidgetContextMenu
-          v-if="isEditMode"
-          :widget="widget"
-          :dashboard="dashboard"
-          @delete-widget="$emit('delete-widget', $event)"
-        ></WidgetContextMenu>
+        <div v-if="widget.description" class="widget__header-description">
+          {{ widget.description }}
+        </div>
       </div>
+      <WidgetContextMenu
+        v-if="isEditMode"
+        :widget="widget"
+        :dashboard="dashboard"
+        @delete-widget="$emit('delete-widget', $event)"
+      ></WidgetContextMenu>
+    </div>
+    <template v-if="!loading">
       <div
         class="widget__content dashboard-summary-widget__summary"
         :class="{

--- a/web-frontend/modules/dashboard/components/widget/WidgetContext.vue
+++ b/web-frontend/modules/dashboard/components/widget/WidgetContext.vue
@@ -4,7 +4,6 @@
       <li v-if="canBeDeleted" class="context__menu-item">
         <a
           class="context__menu-item-link context__menu-item-link--delete"
-          :class="{ 'context__menu-item-link--loading': isDeleteInProgress }"
           @click="deleteWidget()"
         >
           <i class="context__menu-item-icon iconoir-bin"></i>
@@ -17,7 +16,6 @@
 
 <script>
 import context from '@baserow/modules/core/mixins/context'
-import { notifyIf } from '@baserow/modules/core/utils/error'
 
 export default {
   name: 'WidgetContext',
@@ -32,32 +30,26 @@ export default {
       required: true,
     },
   },
-  data() {
-    return {
-      isDeleteInProgress: false,
-    }
-  },
+  emits: ['delete-widget'],
   computed: {
     canBeDeleted() {
-      return this.$hasPermission(
-        'dashboard.widget.delete',
-        this.widget,
-        this.dashboard.workspace.id
+      return (
+        this.$hasPermission(
+          'dashboard.widget.delete',
+          this.widget,
+          this.dashboard.workspace.id
+        ) &&
+        this.$hasPermission(
+          'dashboard.update_widget_layout',
+          this.dashboard,
+          this.dashboard.workspace.id
+        )
       )
     },
   },
   methods: {
-    async deleteWidget() {
-      this.isDeleteInProgress = true
-      try {
-        await this.$store.dispatch(
-          'dashboardApplication/deleteWidget',
-          this.widget.id
-        )
-      } catch (error) {
-        notifyIf(error, 'dashboard')
-      }
-      this.isDeleteInProgress = false
+    deleteWidget() {
+      this.$emit('delete-widget', this.widget.id)
       if (this.$refs.context) {
         this.hide()
       }

--- a/web-frontend/modules/dashboard/components/widget/WidgetContextMenu.vue
+++ b/web-frontend/modules/dashboard/components/widget/WidgetContextMenu.vue
@@ -1,6 +1,7 @@
 <template>
   <div ref="contextButton" class="widget__header-context-menu">
     <ButtonIcon
+      :data-testid="`dashboard-widget-context-${widget.id}`"
       icon="iconoir-more-vert"
       type="secondary"
       size="regular"

--- a/web-frontend/modules/dashboard/locales/en.json
+++ b/web-frontend/modules/dashboard/locales/en.json
@@ -17,7 +17,8 @@
     "title": "Add new widget"
   },
   "widget": {
-    "fixConfiguration": "Fix configuration"
+    "fixConfiguration": "Fix configuration",
+    "dragWidget": "Drag widget"
   },
   "summaryWidget": {
     "name": "Summary"

--- a/web-frontend/modules/dashboard/realtime.js
+++ b/web-frontend/modules/dashboard/realtime.js
@@ -20,6 +20,16 @@ export const registerRealtimeEvents = (realtime) => {
       store.dispatch('dashboardApplication/handleWidgetDeleted', data.widget.id)
     }
   })
+  realtime.registerEvent('widgets_layout_updated', ({ store }, data) => {
+    if (
+      data.dashboard_id === store.getters['dashboardApplication/getDashboardId']
+    ) {
+      store.dispatch(
+        'dashboardApplication/handleWidgetsLayoutUpdated',
+        data.widgets
+      )
+    }
+  })
   realtime.registerEvent('data_source_updated', ({ store }, data) => {
     if (
       data.dashboard_id === store.getters['dashboardApplication/getDashboardId']

--- a/web-frontend/modules/dashboard/services/widget.js
+++ b/web-frontend/modules/dashboard/services/widget.js
@@ -11,6 +11,17 @@ export default (client) => {
     update(widgetId, values = {}) {
       return client.patch(`/dashboard/widgets/${widgetId}/`, values)
     },
+    updateLayout(dashboardId, widgets) {
+      return client.patch(`/dashboard/${dashboardId}/widgets/layout/`, {
+        widgets,
+      })
+    },
+    deleteWithLayout(dashboardId, widgetId, widgets) {
+      return client.post(`/dashboard/${dashboardId}/widgets/layout/delete/`, {
+        widget_id: widgetId,
+        widgets,
+      })
+    },
     delete(widgetId) {
       return client.delete(`/dashboard/widgets/${widgetId}/`)
     },

--- a/web-frontend/modules/dashboard/store/dashboardApplication.js
+++ b/web-frontend/modules/dashboard/store/dashboardApplication.js
@@ -37,7 +37,20 @@ export const mutations = {
     state.editMode = !state.editMode
   },
   ADD_WIDGET(state, widget) {
-    state.widgets.push(widget)
+    const existingWidget = state.widgets.find(
+      (existingWidget) => existingWidget.id === widget.id
+    )
+    if (existingWidget) {
+      Object.assign(existingWidget, widget)
+    } else {
+      state.widgets.push(widget)
+    }
+  },
+  SET_WIDGETS(state, widgets) {
+    state.widgets = widgets
+    if (!widgets.some((widget) => widget.id === state.selectedWidgetId)) {
+      state.selectedWidgetId = null
+    }
   },
   ADD_DATA_SOURCE(state, dataSource) {
     state.dataSources.push(dataSource)
@@ -65,6 +78,10 @@ export const mutations = {
   },
   UPDATE_WIDGET(state, { widgetId, values }) {
     const widget = state.widgets.find((widget) => widget.id === widgetId)
+    if (!widget) {
+      state.widgets.push(values)
+      return
+    }
     // In Vue 3, direct assignment works thanks to Proxy-based reactivity
     if (Array.isArray(values.series_config)) {
       widget.series_config = [...values.series_config]
@@ -73,7 +90,12 @@ export const mutations = {
   },
   DELETE_WIDGET(state, widgetId) {
     const index = state.widgets.findIndex((widget) => widget.id === widgetId)
-    state.widgets.splice(index, 1)
+    if (index !== -1) {
+      state.widgets.splice(index, 1)
+    }
+    if (state.selectedWidgetId === widgetId) {
+      state.selectedWidgetId = null
+    }
   },
   SET_LOADING(state, value) {
     state.loading = value
@@ -161,9 +183,7 @@ export const actions = {
     commit('RESET')
     commit('SET_DASHBOARD_ID', dashboardId)
     const { data } = await WidgetService($client).getAllWidgets(dashboardId)
-    data.forEach((widget) => {
-      commit('ADD_WIDGET', widget)
-    })
+    commit('SET_WIDGETS', data)
     await dispatch('setLoading', false)
     await dispatch('fetchNewDataSources', dashboardId)
 
@@ -179,12 +199,15 @@ export const actions = {
     const { $client } = this
     const { data: dataSourcesData } =
       await DataSourceService($client).getAllDataSources(dashboardId)
-    dataSourcesData.forEach(async (dataSource) => {
-      if (!getters.getDataSourceById(dataSource.id)) {
-        commit('ADD_DATA_SOURCE', dataSource)
-        await dispatch('dispatchDataSource', dataSource.id)
-      }
-    })
+
+    await Promise.all(
+      dataSourcesData
+        .filter((dataSource) => !getters.getDataSourceById(dataSource.id))
+        .map(async (dataSource) => {
+          commit('ADD_DATA_SOURCE', dataSource)
+          await dispatch('dispatchDataSource', dataSource.id)
+        })
+    )
   },
   async createWidget({ commit, dispatch }, { dashboard, widget }) {
     const { $client } = this
@@ -205,13 +228,16 @@ export const actions = {
     await dispatch('application/refreshPermissions', dashboard, { root: true })
     return createdWidget
   },
-  async handleNewWidgetCreated(
-    { commit, dispatch },
-    { tempWidgetId, createdWidget }
-  ) {
-    commit('UPDATE_WIDGET', { widgetId: tempWidgetId, values: createdWidget })
+  async handleNewWidgetCreated({ commit, dispatch }, payload) {
+    const { tempWidgetId, createdWidget = payload } = payload
+    if (tempWidgetId) {
+      commit('UPDATE_WIDGET', { widgetId: tempWidgetId, values: createdWidget })
+    } else {
+      commit('ADD_WIDGET', createdWidget)
+    }
     dispatch('selectWidget', createdWidget.id)
     await dispatch('fetchNewDataSources', createdWidget.dashboard_id)
+    return createdWidget
   },
   async dispatchDataSource({ commit }, dataSourceId) {
     const { $client } = this
@@ -230,6 +256,28 @@ export const actions = {
   },
   handleWidgetDeleted({ commit }, widgetId) {
     commit('DELETE_WIDGET', widgetId)
+  },
+  async updateWidgetLayout({ commit }, { dashboardId, layout }) {
+    const { $client } = this
+    const { data } = await WidgetService($client).updateLayout(
+      dashboardId,
+      layout
+    )
+    commit('SET_WIDGETS', data)
+    return data
+  },
+  async deleteWidgetWithLayout({ commit }, { dashboardId, widgetId, layout }) {
+    const { $client } = this
+    const { data } = await WidgetService($client).deleteWithLayout(
+      dashboardId,
+      widgetId,
+      layout
+    )
+    commit('SET_WIDGETS', data)
+    return data
+  },
+  handleWidgetsLayoutUpdated({ commit }, widgets) {
+    commit('SET_WIDGETS', widgets)
   },
 }
 
@@ -250,7 +298,19 @@ export const getters = {
     return state.widgets.find((widget) => widget.id === widgetId)
   },
   getWidgets(state) {
-    return state.widgets.toSorted((a, b) => a.order - b.order)
+    return state.widgets.toSorted((first, second) => {
+      const byY = (first.grid_y ?? 0) - (second.grid_y ?? 0)
+      if (byY !== 0) {
+        return byY
+      }
+
+      const byX = (first.grid_x ?? 0) - (second.grid_x ?? 0)
+      if (byX !== 0) {
+        return byX
+      }
+
+      return first.id - second.id
+    })
   },
   getSelectedWidgetId(state) {
     return state.selectedWidgetId

--- a/web-frontend/modules/dashboard/utils/widgetGridLayout.js
+++ b/web-frontend/modules/dashboard/utils/widgetGridLayout.js
@@ -1,0 +1,153 @@
+export const DASHBOARD_DESKTOP_GRID_COLUMNS = 6
+export const DASHBOARD_TABLET_GRID_COLUMNS = 4
+export const DASHBOARD_MOBILE_GRID_COLUMNS = 1
+
+const DESKTOP_BREAKPOINT = 920
+const TABLET_BREAKPOINT = 600
+
+const FALLBACK_GRID_LAYOUT = {
+  min_width: 1,
+  min_height: 1,
+  max_width: DASHBOARD_DESKTOP_GRID_COLUMNS,
+  max_height: 16,
+}
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max)
+
+const asGridNumber = (value, fallback) =>
+  Number.isInteger(value) ? value : fallback
+
+export function getDashboardGridColumns(viewportWidth) {
+  if (viewportWidth >= DESKTOP_BREAKPOINT) {
+    return DASHBOARD_DESKTOP_GRID_COLUMNS
+  }
+  if (viewportWidth >= TABLET_BREAKPOINT) {
+    return DASHBOARD_TABLET_GRID_COLUMNS
+  }
+  return DASHBOARD_MOBILE_GRID_COLUMNS
+}
+
+export function sortWidgetsByGridPosition(widgets) {
+  return [...widgets].sort((first, second) => {
+    const byY = asGridNumber(first.grid_y, 0) - asGridNumber(second.grid_y, 0)
+    if (byY !== 0) {
+      return byY
+    }
+
+    const byX = asGridNumber(first.grid_x, 0) - asGridNumber(second.grid_x, 0)
+    if (byX !== 0) {
+      return byX
+    }
+
+    return first.id - second.id
+  })
+}
+
+function getCanonicalLayoutItem(widget) {
+  return {
+    i: widget.id,
+    x: asGridNumber(widget.grid_x, 0),
+    y: asGridNumber(widget.grid_y, 0),
+    w: clamp(
+      asGridNumber(widget.grid_width, DASHBOARD_DESKTOP_GRID_COLUMNS),
+      1,
+      DASHBOARD_DESKTOP_GRID_COLUMNS
+    ),
+    h: Math.max(1, asGridNumber(widget.grid_height, 9)),
+  }
+}
+
+function collides(first, second) {
+  return (
+    first.x < second.x + second.w &&
+    second.x < first.x + first.w &&
+    first.y < second.y + second.h &&
+    second.y < first.y + first.h
+  )
+}
+
+function firstAvailableRow(layout, item) {
+  let y = 0
+  const candidate = { ...item, y }
+
+  while (layout.some((other) => collides(candidate, other))) {
+    y += 1
+    candidate.y = y
+  }
+
+  return y
+}
+
+function projectLayoutItem(item, columns) {
+  if (columns === DASHBOARD_DESKTOP_GRID_COLUMNS) {
+    return { ...item }
+  }
+
+  if (columns === DASHBOARD_MOBILE_GRID_COLUMNS) {
+    return { ...item, x: 0, w: 1 }
+  }
+
+  const scale = columns / DASHBOARD_DESKTOP_GRID_COLUMNS
+  const width = clamp(Math.round(item.w * scale), 1, columns)
+  const x = clamp(Math.round(item.x * scale), 0, columns - width)
+
+  return { ...item, x, w: width }
+}
+
+/**
+ * Returns a visual layout for the available viewport width. Only the six-column
+ * layout is persisted; tablet and mobile positions are deterministic projections.
+ */
+export function createWidgetGridLayout(
+  widgets,
+  columns = DASHBOARD_DESKTOP_GRID_COLUMNS
+) {
+  const canonicalLayout = sortWidgetsByGridPosition(widgets).map(
+    getCanonicalLayoutItem
+  )
+
+  if (columns === DASHBOARD_DESKTOP_GRID_COLUMNS) {
+    return canonicalLayout
+  }
+
+  return canonicalLayout.reduce((projectedLayout, item) => {
+    const projectedItem = projectLayoutItem(item, columns)
+    projectedItem.y = firstAvailableRow(projectedLayout, projectedItem)
+    projectedLayout.push(projectedItem)
+    return projectedLayout
+  }, [])
+}
+
+export function getWidgetGridItemConstraints(widget, columns, layoutItem) {
+  const constraints = widget?.grid_layout || FALLBACK_GRID_LAYOUT
+  const maxW = Math.min(
+    columns,
+    asGridNumber(constraints.max_width, DASHBOARD_DESKTOP_GRID_COLUMNS)
+  )
+  const maxH = asGridNumber(constraints.max_height, 16)
+
+  return {
+    minW: Math.min(
+      maxW,
+      layoutItem.w,
+      Math.max(1, asGridNumber(constraints.min_width, 1))
+    ),
+    minH: Math.min(
+      maxH,
+      layoutItem.h,
+      Math.max(1, asGridNumber(constraints.min_height, 1))
+    ),
+    maxW,
+    maxH,
+  }
+}
+
+export function toWidgetLayoutPayload(layout) {
+  return layout.map((item) => ({
+    id: Number(item.i),
+    grid_x: item.x,
+    grid_y: item.y,
+    grid_width: item.w,
+    grid_height: item.h,
+  }))
+}

--- a/web-frontend/package.json
+++ b/web-frontend/package.json
@@ -98,6 +98,7 @@
     "eslint": "^9.39.3",
     "flush-promises": "^1.0.2",
     "form-data": "4.0.6",
+    "grid-layout-plus": "^1.1.1",
     "highlight.js": "^11.11.1",
     "iconoir": "^6.11.0",
     "js-sha256": "^0.11.1",

--- a/web-frontend/test/unit/dashboard/store/dashboardApplication.spec.js
+++ b/web-frontend/test/unit/dashboard/store/dashboardApplication.spec.js
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { actions } from '@baserow/modules/dashboard/store/dashboardApplication'
+import DataSourceService from '@baserow/modules/dashboard/services/dataSource'
+
+vi.mock('@baserow/modules/dashboard/services/dataSource', () => ({
+  default: vi.fn(),
+}))
+
+describe('Dashboard application store', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('fetchNewDataSources waits for every data source to be dispatched', async () => {
+    const dataSource = { id: 1 }
+    const getAllDataSources = vi.fn().mockResolvedValue({
+      data: [dataSource],
+    })
+    DataSourceService.mockReturnValue({ getAllDataSources })
+
+    let resolveDispatch
+    const dispatchPromise = new Promise((resolve) => {
+      resolveDispatch = resolve
+    })
+    const dispatch = vi.fn().mockReturnValue(dispatchPromise)
+    const commit = vi.fn()
+    const getters = {
+      getDataSourceById: vi.fn().mockReturnValue(undefined),
+    }
+
+    const fetchPromise = actions.fetchNewDataSources.call(
+      { $client: {} },
+      { commit, dispatch, getters },
+      42
+    )
+
+    await vi.waitFor(() => {
+      expect(dispatch).toHaveBeenCalledWith('dispatchDataSource', 1)
+    })
+
+    let completed = false
+    void fetchPromise.then(() => {
+      completed = true
+    })
+    await Promise.resolve()
+    expect(completed).toBe(false)
+
+    resolveDispatch()
+    await fetchPromise
+
+    expect(commit).toHaveBeenCalledWith('ADD_DATA_SOURCE', dataSource)
+  })
+})

--- a/web-frontend/test/unit/dashboard/utils/widgetGridLayout.spec.js
+++ b/web-frontend/test/unit/dashboard/utils/widgetGridLayout.spec.js
@@ -1,0 +1,93 @@
+import {
+  createWidgetGridLayout,
+  getDashboardGridColumns,
+  getWidgetGridItemConstraints,
+  toWidgetLayoutPayload,
+} from '@baserow/modules/dashboard/utils/widgetGridLayout'
+
+const summary = (id, gridX, gridY, gridWidth, gridHeight) => ({
+  id,
+  grid_x: gridX,
+  grid_y: gridY,
+  grid_width: gridWidth,
+  grid_height: gridHeight,
+  grid_layout: {
+    min_width: 1,
+    min_height: 4,
+    max_width: 6,
+    max_height: 6,
+  },
+})
+
+describe('widgetGridLayout', () => {
+  test('selects a layout from the viewport width', () => {
+    expect(getDashboardGridColumns(920)).toBe(6)
+    expect(getDashboardGridColumns(700)).toBe(4)
+    expect(getDashboardGridColumns(599)).toBe(1)
+  })
+
+  test('keeps the canonical six-column layout', () => {
+    const layout = createWidgetGridLayout(
+      [summary(2, 2, 0, 4, 4), summary(1, 0, 0, 2, 4)],
+      6
+    )
+
+    expect(layout).toEqual([
+      { i: 1, x: 0, y: 0, w: 2, h: 4 },
+      { i: 2, x: 2, y: 0, w: 4, h: 4 },
+    ])
+  })
+
+  test('projects a two-plus-four row to four columns', () => {
+    const layout = createWidgetGridLayout(
+      [summary(1, 0, 0, 2, 4), summary(2, 2, 0, 4, 4)],
+      4
+    )
+
+    expect(layout).toEqual([
+      { i: 1, x: 0, y: 0, w: 1, h: 4 },
+      { i: 2, x: 1, y: 0, w: 3, h: 4 },
+    ])
+  })
+
+  test('stacks widgets on mobile without persisting the projection', () => {
+    const layout = createWidgetGridLayout(
+      [summary(1, 0, 0, 2, 4), summary(2, 2, 0, 4, 4)],
+      1
+    )
+
+    expect(layout).toEqual([
+      { i: 1, x: 0, y: 0, w: 1, h: 4 },
+      { i: 2, x: 0, y: 4, w: 1, h: 4 },
+    ])
+  })
+
+  test('uses visual constraints that fit a projected widget', () => {
+    const chart = {
+      grid_layout: {
+        min_width: 3,
+        min_height: 8,
+        max_width: 6,
+        max_height: 16,
+      },
+    }
+
+    expect(
+      getWidgetGridItemConstraints(chart, 4, { i: 1, x: 0, y: 0, w: 2, h: 9 })
+    ).toEqual({ minW: 2, minH: 8, maxW: 4, maxH: 16 })
+  })
+
+  test('serializes a Grid Layout Plus layout for the canonical API', () => {
+    expect(
+      toWidgetLayoutPayload([{ i: '12', x: 2, y: 4, w: 3, h: 9 }])
+    ).toEqual([
+      {
+        id: 12,
+        grid_x: 2,
+        grid_y: 4,
+        grid_width: 3,
+        grid_height: 9,
+      },
+    ])
+  })
+})

--- a/web-frontend/yarn.lock
+++ b/web-frontend/yarn.lock
@@ -1179,6 +1179,13 @@
   dependencies:
     "@floating-ui/utils" "^0.2.10"
 
+"@floating-ui/core@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.8.0.tgz#d01c0bbea02e4a57f6fd7d5de6fc2c5c7dca40e1"
+  integrity sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==
+  dependencies:
+    "@floating-ui/utils" "^0.2.12"
+
 "@floating-ui/dom@^1.0.0":
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.7.4.tgz#ee667549998745c9c3e3e84683b909c31d6c9a77"
@@ -1187,10 +1194,23 @@
     "@floating-ui/core" "^1.7.3"
     "@floating-ui/utils" "^0.2.10"
 
+"@floating-ui/dom@^1.7.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.8.0.tgz#8a20e6facbe2456afdbeb6c8b968a72df689cf63"
+  integrity sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==
+  dependencies:
+    "@floating-ui/core" "^1.8.0"
+    "@floating-ui/utils" "^0.2.12"
+
 "@floating-ui/utils@^0.2.10":
   version "0.2.10"
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.10.tgz#a2a1e3812d14525f725d011a73eceb41fef5bc1c"
   integrity sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==
+
+"@floating-ui/utils@^0.2.12":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.12.tgz#afefe785949f16ac4cdd1e695935a321572dd56a"
+  integrity sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==
 
 "@humanfs/core@^0.19.1":
   version "0.19.1"
@@ -1214,6 +1234,11 @@
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
+
+"@interactjs/types@1.10.28":
+  version "1.10.28"
+  resolved "https://registry.yarnpkg.com/@interactjs/types/-/types-1.10.28.tgz#c928ee3a23663136d696f0ca1d5c72e4dd61d5c7"
+  integrity sha512-vPmu4HWmsg0Fub3BPKGk7DuozkhgVK84TVkziY47v8Uh0A14gph55/vVRaQN4oZov0lGNJNK6Jyddim2qd/4vw==
 
 "@intlify/bundle-utils@11.0.7":
   version "11.0.7"
@@ -1435,6 +1460,11 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@juggle/resize-observer@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.4.0.tgz#08d6c5e20cf7e4cc02fd181c4b0c225cd31dbb60"
+  integrity sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==
 
 "@keyv/bigmap@^1.3.0":
   version "1.3.0"
@@ -4591,6 +4621,20 @@
     node-gyp-build "^4.2.2"
     picomatch "^4.0.2"
     resolve-from "^5.0.0"
+
+"@vexip-ui/hooks@^2.8.0":
+  version "2.9.4"
+  resolved "https://registry.yarnpkg.com/@vexip-ui/hooks/-/hooks-2.9.4.tgz#fbae097129ab5d14832bd403c220d54d6c939a30"
+  integrity sha512-dGUiBAeHIsnSVigGSPHcuHBVqrSGW8LV+zGohvOpBfXs8Ynn5ZcSmybIWJ3G826NsicPu9rqwcJG8uvSgG4k4Q==
+  dependencies:
+    "@floating-ui/dom" "^1.7.0"
+    "@juggle/resize-observer" "^3.4.0"
+    "@vexip-ui/utils" "2.16.4"
+
+"@vexip-ui/utils@2.16.4", "@vexip-ui/utils@^2.16.1":
+  version "2.16.4"
+  resolved "https://registry.yarnpkg.com/@vexip-ui/utils/-/utils-2.16.4.tgz#3429376a8f9e88040e969c21f14e70fe25d36127"
+  integrity sha512-KX+Q4EsuwDp6ZlRJ7OAkiYxu52D5CVM8zpqQz/FXYV+JUtzl9T3dvxgtA8gQ0wm5Sh/xT6jp8Wo4X7tLAzRh/A==
 
 "@vitejs/plugin-vue-jsx@^5.1.5":
   version "5.1.5"
@@ -7827,6 +7871,15 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, 
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
+grid-layout-plus@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/grid-layout-plus/-/grid-layout-plus-1.1.1.tgz#129f1dd6ba555a1d319d73e415821ae4fb6c35c8"
+  integrity sha512-7CWehJubrVC8Ps5QFUlnDsp0kiREvKfi3Pdjp21EyY8BNzSusqI3Utcxvu1Y9UUKe3YExvbhJzIxHK6rorbRaQ==
+  dependencies:
+    "@vexip-ui/hooks" "^2.8.0"
+    "@vexip-ui/utils" "^2.16.1"
+    interactjs "^1.10.27"
+
 gzip-size@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-7.0.0.tgz#9f9644251f15bc78460fccef4055ae5a5562ac60"
@@ -8175,6 +8228,13 @@ ini@^1.3.4, ini@^1.3.5:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+
+interactjs@^1.10.27:
+  version "1.10.28"
+  resolved "https://registry.yarnpkg.com/interactjs/-/interactjs-1.10.28.tgz#17f91e61214e4947d16953ba7987f9495b0874d2"
+  integrity sha512-QCa4ksTPd2p/FZ4I6hrH6fogjLqru1TxYywRiKYNuLZtrlAxTIYUa/MYsE7PnUgWZJU3SrGVDjiz065BeaXYng==
+  dependencies:
+    "@interactjs/types" "1.10.28"
 
 ioredis@^5.10.1:
   version "5.10.1"


### PR DESCRIPTION
### What is in this PR
- Implements #3306 by storing dashboard widgets on a six-column grid, including a zero-downtime migration that stacks existing widgets full-width.
- Adds desktop-only drag and drop plus horizontal and vertical resize in the existing global dashboard edit mode. Collision handling keeps the layout compact vertically.
- Persists layout changes atomically with undo/redo support, permissions validation, realtime updates, and conflict validation.
- Projects the stored layout responsively to four columns on tablet and a stacked one-column layout on mobile; manipulation controls are disabled below desktop.
- Keeps the dashboard view clean: widget cards are opaque, while layout feedback is shown only during drag or resize.
- Adds backend, frontend unit, and dashboard E2E coverage, plus the changelog entry.

### How to test this PR
1. Open a dashboard with multiple widgets on a desktop viewport and enable the global dashboard edit mode.
2. Drag widgets and resize them horizontally and vertically. Verify that widgets snap to the six-column layout and that colliding widgets are repositioned vertically.
3. Reload the dashboard and confirm the layout and widget data are restored without indefinite loading states.
4. Open the same dashboard in a second browser session and verify a saved layout update is reflected through realtime events.
5. Reduce the viewport to tablet and mobile widths. Verify the four-column and stacked projections respectively, with drag and resize disabled.
6. Verify existing widget context menus remain available outside edit mode.

### Checklist

- [x] A changelog entry has been added to changelog/entries/unreleased using changelog/src/changelog.py
- [x] New/updated Premium/Enterprise features are separated correctly in the premium or enterprise folder
- [ ] The latest Chrome and Firefox have been used to test any new frontend features (automated E2E coverage targets both browsers; final manual Firefox check remains)
- [x] Documentation is not required for this internal dashboard layout behavior
- [x] Quality Standards are met (targeted backend and frontend tests, formatting, and diff checks passed)
- [x] Performance: not applicable; this does not affect table runtime paths
- [x] The redoc API pages are generated from the API schema; no API-token endpoint changed
- [x] Our custom API docs are not affected because no API-token endpoint changed
- [x] The UI/UX has been verified in the browser against the dashboard edit-mode design
- [x] Security impact has been considered: layout updates validate dashboard scope, permissions, collisions, and bounds