### PR TITLE
fix: show complete padding values in style sidebar

### DIFF
--- a/changelog/entries/unreleased/bug/5809_fixed_truncated_padding_values_in_the_app_builder_style_side.json
+++ b/changelog/entries/unreleased/bug/5809_fixed_truncated_padding_values_in_the_app_builder_style_side.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed truncated padding values in the App Builder style sidebar.",
+    "issue_origin": "github",
+    "issue_number": 5809,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-08-04"
+}

--- a/web-frontend/modules/core/assets/scss/components/builder/padding_selector.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/padding_selector.scss
@@ -14,9 +14,11 @@
 
   .form-input__icon-right {
     position: absolute;
-    top: 50%;
+    top: 0;
+    bottom: 0;
     right: 8px;
-    margin-top: -8px;
+    display: flex;
+    align-items: center;
     padding-right: 0;
   }
 }

--- a/web-frontend/modules/core/assets/scss/components/builder/padding_selector.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/padding_selector.scss
@@ -5,4 +5,18 @@
 
 .padding-selector__input {
   flex: 1;
+  min-width: 0;
+
+  .form-input__input {
+    padding-left: 8px;
+    padding-right: 28px;
+  }
+
+  .form-input__icon-right {
+    position: absolute;
+    top: 50%;
+    right: 8px;
+    margin-top: -8px;
+    padding-right: 0;
+  }
 }


### PR DESCRIPTION
### What is in this PR

Fixes #5809 by preventing padding values from being truncated in the App Builder style sidebar.

The padding selector’s flex layout did not allow its inputs to shrink correctly, so complete values could be clipped. This change allows the inputs to size within the available space and adjusts the input/right-side icon spacing. 


### How to test this PR

1. Open an App Builder application and select an element with padding controls in the style sidebar (button for instance)
2. Enter or inspect padding values for each side.
3. Confirm that complete values remain visible


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder (N/A — core frontend CSS only)
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated (N/A — no documentation change needed)
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met (the changelog test is blocked by the local pytest-django configuration)
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables (N/A — no table behavior changes)
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes (N/A — no REST API changes)
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens (N/A — no endpoint changes)
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered (no security impact; CSS-only change)