### PR TITLE
fix(database): guard empty rows in webhook related-table filter computation

### DIFF
--- a/backend/src/baserow/contrib/database/rows/webhook_event_types.py
+++ b/backend/src/baserow/contrib/database/rows/webhook_event_types.py
@@ -156,6 +156,9 @@ class RowsEventType(RespectSendWebhookEvents, WebhookEventType):
         :return: A list of row IDs in the related table that have changed.
         """
 
+        if not rows:
+            return []
+
         model = rows[0]._meta.model
         table_field_objs = model.get_field_objects()
 
@@ -251,7 +254,7 @@ class RowsEventType(RespectSendWebhookEvents, WebhookEventType):
 
         q = self._get_filters_for_webhooks_to_call(model=model, table=table, **kwargs)
 
-        if kwargs.get("rows") is not None:
+        if kwargs.get("rows"):
             q |= self.get_filters_for_related_webhook_to_call(
                 model=model, table=table, **kwargs
             )

--- a/backend/tests/baserow/contrib/database/rows/test_row_webhook_event_types.py
+++ b/backend/tests/baserow/contrib/database/rows/test_row_webhook_event_types.py
@@ -8,7 +8,10 @@ import pytest
 
 from baserow.contrib.database.fields.handler import FieldHandler
 from baserow.contrib.database.rows.handler import RowHandler
-from baserow.contrib.database.rows.webhook_event_types import RowsUpdatedEventType
+from baserow.contrib.database.rows.webhook_event_types import (
+    RowsDeletedEventType,
+    RowsUpdatedEventType,
+)
 from baserow.contrib.database.webhooks.handler import WebhookHandler
 from baserow.contrib.database.webhooks.models import TableWebhook
 from baserow.contrib.database.webhooks.registries import webhook_event_type_registry
@@ -974,3 +977,30 @@ def test_rows_updated_can_trigger_webhooks_in_linked_tables_without_additional_q
         assert len(_without_version_checks(captured.captured_queries)) >= len(
             _without_version_checks(captured2.captured_queries)
         )
+
+
+@pytest.mark.django_db()
+def test_get_filters_for_webhooks_to_call_with_empty_rows(data_fixture):
+    user = data_fixture.create_user()
+    table_a, table_b, link_a_to_b = data_fixture.create_two_linked_tables(user=user)
+
+    event_type: RowsDeletedEventType = webhook_event_type_registry.get("rows.deleted")
+    model_a = table_a.get_model()
+
+    q = event_type.get_filters_for_webhooks_to_call(
+        model=model_a, table=table_a, rows=[]
+    )
+
+    assert list(TableWebhook.objects.filter(q).values_list("id", flat=True)) == []
+
+
+@pytest.mark.django_db()
+def test_get_related_table_row_ids_with_changes_empty_rows(data_fixture):
+    user = data_fixture.create_user()
+    table_a, table_b, link_a_to_b = data_fixture.create_two_linked_tables(user=user)
+
+    event_type: RowsDeletedEventType = webhook_event_type_registry.get("rows.deleted")
+
+    result = event_type.get_related_table_row_ids_with_changes(table_b, rows=[])
+
+    assert result == []

--- a/changelog/entries/unreleased/bug/5838_guard_webhook_filter_computation_against_empty_rows_lists_to.json
+++ b/changelog/entries/unreleased/bug/5838_guard_webhook_filter_computation_against_empty_rows_lists_to.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Guard webhook filter computation against empty rows lists to prevent IndexError on undo.",
+    "issue_origin": "github",
+    "issue_number": 5838,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-04"
+}


### PR DESCRIPTION
### What is in this PR

Webhook filter computation crashes with `IndexError: list index out of range` when `rows=[]` is passed to `get_related_table_row_ids_with_changes`. This happens on undo of a create-rows action with zero rows on a table with a two-way link-row field.

**Root cause:** Two defects — `get_related_table_row_ids_with_changes` dereferences `rows[0]` without an empty guard, and the boundary check at `get_filters_for_webhooks_to_call` used `is not None` which passes empty lists through.

**Fix:**
- Add `if not rows: return []` early return in `get_related_table_row_ids_with_changes` — protects both call sites (filter computation at line 94 and payload generation at line 313)
- Tighten boundary check from `if kwargs.get("rows") is not None:` to `if kwargs.get("rows"):` — skips unnecessary related-table field loop for empty batches


### How to test this PR

1. Run tests: `just pytest tests/baserow/contrib/database/rows/test_row_webhook_event_types.py -k "empty_rows"`
2. Both tests verify empty rows don't crash: one at the integration level (`get_filters_for_webhooks_to_call`), one directly on the method (`get_related_table_row_ids_with_changes`)

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
