### PR TITLE
fix(database): pass correct field key in kanban deleteStack forceUpdate dispatch

### DIFF
--- a/changelog/entries/unreleased/bug/5846_fix_field_store_crash_when_deleting_a_kanban_singleselect_st.json
+++ b/changelog/entries/unreleased/bug/5846_fix_field_store_crash_when_deleting_a_kanban_singleselect_st.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix field store crash when deleting a Kanban single-select stack.",
+    "issue_origin": "github",
+    "issue_number": 5846,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-04"
+}

--- a/premium/web-frontend/modules/baserow_premium/store/view/kanban.js
+++ b/premium/web-frontend/modules/baserow_premium/store/view/kanban.js
@@ -1120,7 +1120,7 @@ export const actions = {
       await dispatch(
         'field/forceUpdate',
         {
-          singleSelectField,
+          field: singleSelectField,
           oldField: clone(singleSelectField),
           data,
           relatedFields: data.related_fields,

--- a/premium/web-frontend/test/unit/premium/store/view/kanban.spec.js
+++ b/premium/web-frontend/test/unit/premium/store/view/kanban.spec.js
@@ -1,4 +1,5 @@
 import kanbanStore from '@baserow_premium/store/view/kanban'
+import fieldStore from '@baserow/modules/database/store/field'
 import { TestApp } from '@baserow/test/helpers/testApp'
 import { UNDO_REDO_ACTION_GROUP_HEADER } from '@baserow/modules/database/utils/action'
 
@@ -23,6 +24,7 @@ describe('Kanban view store', () => {
     store = testApp.createStore({
       modules: {
         kanban: kanbanStore,
+        field: fieldStore,
       },
     })
   })
@@ -508,5 +510,55 @@ describe('Kanban view store', () => {
     expect(JSON.parse(JSON.stringify(store.state.kanban.stacks))).toStrictEqual(
       before
     )
+  })
+
+  test('deleteStack updates the field in the store instead of throwing', async () => {
+    const singleSelectField = {
+      id: 1,
+      table_id: 99,
+      name: 'Status',
+      type: 'single_select',
+      select_options: [
+        { id: 1, value: 'A', color: 'blue' },
+        { id: 2, value: 'B', color: 'red' },
+      ],
+    }
+
+    const fieldState = Object.assign(fieldStore.state(), {
+      items: [singleSelectField],
+    })
+    store.replaceState({ ...store.state, field: fieldState })
+
+    const state = Object.assign(kanbanStore.state(), {
+      singleSelectFieldId: 1,
+      stacks: {},
+    })
+    store.replaceState({ ...store.state, kanban: state })
+
+    const updatedField = {
+      id: 1,
+      table_id: 99,
+      name: 'Status',
+      type: 'single_select',
+      select_options: [{ id: 1, value: 'A', color: 'blue' }],
+      related_fields: [],
+    }
+    testApp.mock.onPatch('/database/fields/1/').reply(200, updatedField)
+
+    const originalGetAll = store.$registry.getAll.bind(store.$registry)
+    vi.spyOn(store.$registry, 'getAll').mockImplementation((namespace) =>
+      namespace === 'view' ? {} : originalGetAll(namespace)
+    )
+
+    const doFieldUpdate = await store.dispatch('kanban/deleteStack', {
+      singleSelectField,
+      optionId: 2,
+      deferredFieldUpdate: true,
+    })
+
+    await doFieldUpdate()
+
+    expect(store.state.field.items[0].id).toBe(1)
+    expect(store.state.field.items[0].select_options).toHaveLength(1)
   })
 })


### PR DESCRIPTION
Deleting a Kanban stack throws `TypeError: Cannot read properties of undefined (reading 'id')` because `deleteStack` dispatches `field/forceUpdate` with the field under the wrong payload key (`singleSelectField` instead of `field`).

**Root cause:** Object shorthand `{ singleSelectField }` creates key `singleSelectField`, but `forceUpdate` destructures `{ field }` — so `field` is `undefined`.

### How to test this PR

1. Open Kanban view → right-click a stack → Delete → verify no console error
   and the stack disappears without reload
2. Create and update stacks to verify no regression in sibling actions
3. Run tests: `just f yarn test:premium premium/web-frontend/test/unit/premium/store/view/kanban.spec.js`

Closes #5846

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
