### PR TITLE
fix: permissions for data source dispatch endpoint

### DIFF
--- a/backend/src/baserow/contrib/builder/api/data_sources/views.py
+++ b/backend/src/baserow/contrib/builder/api/data_sources/views.py
@@ -456,7 +456,7 @@ class MoveDataSourceView(APIView):
 
 
 class DispatchDataSourceView(APIView):
-    permission_classes = (AllowAny,)
+    permission_classes = (IsAuthenticated,)
 
     @extend_schema(
         parameters=[
@@ -513,6 +513,8 @@ class DispatchDataSourceView(APIView):
         """
 
         data_source = DataSourceHandler().get_data_source(data_source_id)
+        if data_source.page.builder.is_published:
+            raise PermissionException
 
         dispatch_context = BuilderDispatchContext(
             request,
@@ -528,7 +530,7 @@ class DispatchDataSourceView(APIView):
 
 
 class DispatchDataSourcesView(APIView):
-    permission_classes = (AllowAny,)
+    permission_classes = (IsAuthenticated,)
 
     @extend_schema(
         parameters=[
@@ -566,8 +568,13 @@ class DispatchDataSourcesView(APIView):
         """
 
         page = PageHandler().get_page(page_id)
+        if page.builder.is_published:
+            raise PermissionException
+
         dispatch_context = BuilderDispatchContext(
-            request, page, only_expose_public_allowed_properties=False
+            request,
+            page,
+            only_expose_public_allowed_properties=False,
         )
         service_contents = DataSourceService().dispatch_page_data_sources(
             request.user, page, dispatch_context

--- a/backend/tests/baserow/contrib/builder/api/data_sources/test_data_source_views.py
+++ b/backend/tests/baserow/contrib/builder/api/data_sources/test_data_source_views.py
@@ -2305,7 +2305,7 @@ def test_dispatch_data_source_anonymous_unpublished_builder_is_denied(
     response = api_client.post(url, {}, format="json")
 
     assert response.status_code == HTTP_401_UNAUTHORIZED
-    assert response.json()["error"] == "PERMISSION_DENIED"
+    assert response.json()["detail"] == "Authentication credentials were not provided."
 
 
 @pytest.mark.django_db
@@ -2617,6 +2617,7 @@ def test_dispatch_data_source_view(
     mock_builder_dispatch_context,
     mock_dispatch_data_source,
     api_client,
+    data_fixture,
 ):
     """
     Test the DispatchDataSourceView endpoint.
@@ -2625,7 +2626,9 @@ def test_dispatch_data_source_view(
     filter any fields in the Editor.
     """
 
+    user, token = data_fixture.create_user_and_token()
     mock_data_source = MagicMock()
+    mock_data_source.page.builder.is_published = False
     mock_get_data_source.return_value = mock_data_source
 
     mock_dispatch_context = MagicMock()
@@ -2639,7 +2642,7 @@ def test_dispatch_data_source_view(
         "api:builder:data_source:dispatch",
         kwargs={"data_source_id": mock_data_source_id},
     )
-    response = api_client.post(url)
+    response = api_client.post(url, HTTP_AUTHORIZATION=f"JWT {token}")
 
     assert response.status_code == 200
     assert response.json() == mock_response
@@ -2724,6 +2727,41 @@ def test_private_dispatch_data_source_view_returns_all_fields(api_client, data_f
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("dispatch_all", [False, True])
+@pytest.mark.parametrize("authenticated", [False, True])
+def test_published_internal_dispatch_is_denied(
+    api_client, data_fixture, dispatch_all, authenticated
+):
+    user, token = data_fixture.create_user_and_token()
+    workspace = data_fixture.create_workspace(user=user)
+    builder = data_fixture.create_builder_application(user=user, workspace=workspace)
+    page = data_fixture.create_builder_page(user=user, builder=builder)
+    data_source = data_fixture.create_builder_local_baserow_list_rows_data_source(
+        user=user,
+        page=page,
+    )
+
+    builder.workspace = None
+    builder.save()
+    data_fixture.create_builder_custom_domain(published_to=builder)
+
+    if dispatch_all:
+        url = reverse(
+            "api:builder:data_source:dispatch-all", kwargs={"page_id": page.id}
+        )
+    else:
+        url = reverse(
+            "api:builder:data_source:dispatch",
+            kwargs={"data_source_id": data_source.id},
+        )
+
+    headers = {"HTTP_AUTHORIZATION": f"JWT {token}"} if authenticated else {}
+    response = api_client.post(url, {}, format="json", **headers)
+
+    assert response.status_code == HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
 @patch(
     "baserow.contrib.builder.api.data_sources.views.DataSourceService.dispatch_page_data_sources"
 )
@@ -2734,6 +2772,7 @@ def test_dispatch_data_sources_view(
     mock_builder_dispatch_context,
     mock_dispatch_page_data_sources,
     api_client,
+    data_fixture,
 ):
     """
     Test the DispatchDataSourcesView
@@ -2743,7 +2782,9 @@ def test_dispatch_data_sources_view(
     filter any fields in the Editor.
     """
 
+    user, token = data_fixture.create_user_and_token()
     mock_page = MagicMock()
+    mock_page.builder.is_published = False
     mock_get_page.return_value = mock_page
 
     mock_dispatch_context = MagicMock()
@@ -2756,7 +2797,7 @@ def test_dispatch_data_sources_view(
     url = reverse(
         "api:builder:data_source:dispatch-all", kwargs={"page_id": mock_page_id}
     )
-    response = api_client.post(url)
+    response = api_client.post(url, HTTP_AUTHORIZATION=f"JWT {token}")
 
     assert response.status_code == 200
     assert response.json() == mock_service_contents

--- a/changelog/entries/unreleased/bug/add_right_permission_classes_to_internal_data_source_dispatc.json
+++ b/changelog/entries/unreleased/bug/add_right_permission_classes_to_internal_data_source_dispatc.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Add right permission classes to internal data source dispatch endpoints",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-08-04"
+}

--- a/e2e-tests/tests/database/table_import.spec.ts
+++ b/e2e-tests/tests/database/table_import.spec.ts
@@ -94,9 +94,19 @@ test.describe("Table import job restore after reload", () => {
 
     // Reload the page while the import is still running. We deliberately
     // don't wait for "networkidle" — the job poller fires every 2s, so
-    // networkidle won't settle and would eat the test budget. The next
-    // click auto-waits for the title to appear.
+    // networkidle won't settle and would eat the test budget.
     await page.reload();
+
+    // Wait until Nuxt finishes hydrating. The sidebar is server-rendered, so
+    // without this the click below lands on the SSR markup before Vue attaches
+    // its listener and is silently lost — the database never expands and the
+    // "New table" link never appears.
+    await page.waitForFunction(
+      () =>
+        typeof (window as any).useNuxtApp === "function" &&
+        !(window as any).useNuxtApp().isHydrating,
+      { timeout: 15000 }
+    );
 
     // Navigate back to the database
     await page.getByTitle("ImportTestDb").click();
@@ -260,6 +270,15 @@ test.describe("Table import job restore after reload", () => {
     // here — the job poller fires every 2s so networkidle won't settle and
     // would consume the test budget before the post-reload checks run.
     await page.reload();
+
+    // Wait until Nuxt finishes hydrating, so the clicks below aren't dispatched
+    // against the not-yet-hydrated SSR markup.
+    await page.waitForFunction(
+      () =>
+        typeof (window as any).useNuxtApp === "function" &&
+        !(window as any).useNuxtApp().isHydrating,
+      { timeout: 15000 }
+    );
 
     // After reload, navigate back to the table and reopen the import modal
     await page.getByTitle("ExistingImportDb").click();

--- a/enterprise/backend/tests/baserow_enterprise_tests/integrations/local_baserow/test_user_source_types.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/integrations/local_baserow/test_user_source_types.py
@@ -43,7 +43,6 @@ from baserow.core.user_sources.registries import (
 )
 from baserow.core.user_sources.service import UserSourceService
 from baserow.core.utils import MirrorDict, Progress
-from baserow.test_utils.helpers import AnyStr
 from baserow_enterprise.integrations.local_baserow.models import LocalBaserowUserSource
 from baserow_enterprise.integrations.local_baserow.user_source_types import (
     LocalBaserowUserSourceType,
@@ -1105,9 +1104,14 @@ def test_public_dispatch_data_source_with_ab_user_using_user_source(
         table=table,
         row_id="2",
     )
+    for field in fields:
+        data_fixture.create_builder_heading_element(
+            page=page,
+            value=f"get('data_source.{data_source.id}.field_{field.id}')",
+        )
 
     # Create the user table for the user_source
-    user_table, user_fields, user_rows = data_fixture.build_table(
+    user_table, user_fields, _ = data_fixture.build_table(
         user=user,
         columns=[
             ("Email", "text"),
@@ -1138,11 +1142,12 @@ def test_public_dispatch_data_source_with_ab_user_using_user_source(
     DomainHandler().publish(domain1, progress)
     domain1.refresh_from_db()
 
-    user_source_type = user_source.get_type()
-
-    user = user_rows[0]
-
-    user_source_user = user_source_type.get_user(user_source, email="test@baserow.io")
+    published_user_source = user_source.get_type().model_class.objects.get(
+        application=domain1.published_to
+    )
+    user_source_user = published_user_source.get_type().get_user(
+        published_user_source, email="test@baserow.io"
+    )
 
     refresh_token = user_source_user.get_refresh_token()
     access_token = refresh_token.access_token
@@ -1151,7 +1156,7 @@ def test_public_dispatch_data_source_with_ab_user_using_user_source(
     published_data_source = published_page.datasource_set.first()
 
     url = reverse(
-        "api:builder:data_source:dispatch",
+        "api:builder:domains:public_dispatch",
         kwargs={"data_source_id": published_data_source.id},
     )
 
@@ -1159,13 +1164,11 @@ def test_public_dispatch_data_source_with_ab_user_using_user_source(
         url,
         {},
         format="json",
-        HTTP_AUTHORIZATION_US=f"JWT {access_token}",
+        HTTP_AUTHORIZATION=f"JWT {access_token}",
     )
 
     assert response.status_code == HTTP_200_OK
     assert response.json() == {
-        "id": 2,
-        "order": AnyStr(),
         fields[0].name: "Audi",
         fields[1].name: "Orange",
     }


### PR DESCRIPTION
### What is in this PR

Fixes the permissions on the dispatch data source endpoint.

### How to test this PR

See PR submission.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
