### PR TITLE
feat: Assistant onboarding suggests prompt based on industry and team

### DIFF
--- a/changelog/entries/unreleased/feature/assistant_onboarding_improvements.json
+++ b/changelog/entries/unreleased/feature/assistant_onboarding_improvements.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Assistant onboarding now suggests what database to build based on your industry and team",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-08-07"
+}

--- a/enterprise/backend/src/baserow_enterprise/api/assistant/serializers.py
+++ b/enterprise/backend/src/baserow_enterprise/api/assistant/serializers.py
@@ -357,3 +357,41 @@ class AssistantRateChatMessageSerializer(serializers.Serializer):
         if data["sentiment"] != "DISLIKE":
             validated_data["feedback"] = ""
         return validated_data
+
+
+class OnboardingPromptSuggestionsRequestSerializer(serializers.Serializer):
+    industry = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        default="",
+        max_length=48,
+        help_text="The industry the user works in.",
+    )
+    team = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        default="",
+        max_length=48,
+        help_text="The team the user is part of.",
+    )
+    language = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        default="",
+        max_length=10,
+        help_text=(
+            "ISO 639 language code the suggestions must be written in. Falls back "
+            "to the language of the user's profile."
+        ),
+    )
+
+
+class OnboardingPromptSuggestionSerializer(serializers.Serializer):
+    name = serializers.CharField(help_text="Short label describing the suggestion.")
+    prompt = serializers.CharField(
+        help_text="The prompt that can be used to create the database."
+    )
+
+
+class OnboardingPromptSuggestionsSerializer(serializers.Serializer):
+    suggestions = OnboardingPromptSuggestionSerializer(many=True)

--- a/enterprise/backend/src/baserow_enterprise/api/assistant/urls.py
+++ b/enterprise/backend/src/baserow_enterprise/api/assistant/urls.py
@@ -4,6 +4,7 @@ from .views import (
     AssistantChatMessageFeedbackView,
     AssistantChatsView,
     AssistantChatView,
+    AssistantOnboardingPromptSuggestionsView,
 )
 
 app_name = "baserow_enterprise.api.assistant"
@@ -28,5 +29,10 @@ urlpatterns = [
         "messages/<int:message_id>/feedback/",
         AssistantChatMessageFeedbackView.as_view(),
         name="message_feedback",
+    ),
+    path(
+        "onboarding/prompt-suggestions/",
+        AssistantOnboardingPromptSuggestionsView.as_view(),
+        name="onboarding_prompt_suggestions",
     ),
 ]

--- a/enterprise/backend/src/baserow_enterprise/api/assistant/views.py
+++ b/enterprise/backend/src/baserow_enterprise/api/assistant/views.py
@@ -7,6 +7,7 @@ from django.http import StreamingHttpResponse
 from drf_spectacular.openapi import OpenApiParameter, OpenApiTypes
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from loguru import logger
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.status import HTTP_204_NO_CONTENT
 from rest_framework.views import APIView
@@ -36,6 +37,9 @@ from baserow_enterprise.assistant.exceptions import (
 from baserow_enterprise.assistant.handler import AssistantHandler
 from baserow_enterprise.assistant.model_profiles import check_lm_ready_or_raise
 from baserow_enterprise.assistant.models import AssistantChatPrediction
+from baserow_enterprise.assistant.onboarding import (
+    generate_onboarding_prompt_suggestions,
+)
 from baserow_enterprise.assistant.operations import ChatAssistantChatOperationType
 from baserow_enterprise.assistant.types import (
     AiCancelledMessage,
@@ -57,6 +61,8 @@ from .serializers import (
     AssistantMessageRequestSerializer,
     AssistantMessageSerializer,
     AssistantRateChatMessageSerializer,
+    OnboardingPromptSuggestionsRequestSerializer,
+    OnboardingPromptSuggestionsSerializer,
 )
 
 
@@ -326,3 +332,39 @@ class AssistantChatMessageFeedbackView(APIView):
             update_fields=["human_sentiment", "human_feedback", "updated_on"]
         )
         return Response(status=HTTP_204_NO_CONTENT)
+
+
+class AssistantOnboardingPromptSuggestionsView(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    @extend_schema(
+        tags=["AI Assistant"],
+        operation_id="get_assistant_onboarding_prompt_suggestions",
+        description=(
+            "Suggests databases the user could create during the onboarding, based "
+            "on the industry and team they provided. The first suggestion is the "
+            "most relevant one.\n\n"
+        ),
+        request=OnboardingPromptSuggestionsRequestSerializer,
+        responses={
+            200: OnboardingPromptSuggestionsSerializer,
+            400: get_error_schema(["ERROR_ASSISTANT_MODEL_NOT_SUPPORTED"]),
+        },
+    )
+    @validate_body(OnboardingPromptSuggestionsRequestSerializer, return_validated=True)
+    @map_exceptions(
+        {AssistantModelNotSupportedError: ERROR_ASSISTANT_MODEL_NOT_SUPPORTED}
+    )
+    def post(self, request: Request, data) -> Response:
+        check_lm_ready_or_raise()
+
+        suggestions = generate_onboarding_prompt_suggestions(
+            industry=data["industry"],
+            team=data["team"],
+            language=data["language"] or request.user.profile.language,
+        )
+
+        serializer = OnboardingPromptSuggestionsSerializer(
+            {"suggestions": [s.model_dump() for s in suggestions]}
+        )
+        return Response(serializer.data)

--- a/enterprise/backend/src/baserow_enterprise/assistant/model_profiles.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/model_profiles.py
@@ -35,6 +35,7 @@ SUBAGENT = "subagent"  # database, builder, automations
 UTILITY = "utility"  # formula, fixer (precision-oriented)
 SAMPLE = "sample"  # sample row generation (creative)
 TITLE = "title"  # title generation
+SUGGESTIONS = "suggestions"  # onboarding prompt suggestions (creative)
 
 # ---------------------------------------------------------------------------
 # Per-model profiles
@@ -67,6 +68,11 @@ _DEFAULT_PROFILE: dict[str, ModelSettings] = {
         "timeout": 10,
         "max_tokens": AssistantChat.TITLE_MAX_LENGTH,
     },
+    SUGGESTIONS: {
+        "temperature": 0.6,
+        "timeout": 30,
+        "max_tokens": 4096,
+    },
 }
 
 _MODEL_PROFILES: dict[str, dict[str, ModelSettings]] = {
@@ -91,6 +97,11 @@ _MODEL_PROFILES: dict[str, dict[str, ModelSettings]] = {
         TITLE: {
             **_DEFAULT_PROFILE[TITLE],
         },
+        SUGGESTIONS: {
+            # No groq_reasoning_format here for the same reason as UTILITY: this
+            # is a structured-output task and reasoning tokens pollute it.
+            **_DEFAULT_PROFILE[SUGGESTIONS],
+        },
     },
 }
 
@@ -107,7 +118,7 @@ def get_model_settings(model: str, role: str) -> ModelSettings:
     operators to override it without changing code.
 
     :param model: pydantic-ai model string (e.g. ``"groq:openai/gpt-oss-120b"``).
-    :param role: One of ORCHESTRATOR, SUBAGENT, UTILITY, TITLE.
+    :param role: One of ORCHESTRATOR, SUBAGENT, UTILITY, SAMPLE, TITLE, SUGGESTIONS.
     :return: A ModelSettings dict suitable for ``model_settings=`` parameter.
     """
 

--- a/enterprise/backend/src/baserow_enterprise/assistant/onboarding.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/onboarding.py
@@ -1,0 +1,86 @@
+from pydantic import BaseModel, Field
+from pydantic_ai import Agent
+
+from baserow_enterprise.assistant.model_profiles import (
+    SUGGESTIONS,
+    get_model_settings,
+    get_model_string,
+)
+from baserow_enterprise.assistant.retrying_model import RetryingModel
+
+ONBOARDING_SUGGESTIONS_INSTRUCTIONS = """\
+<identity>
+You suggest the first database someone should build in Baserow, based on where \
+they work and what they do.
+</identity>
+
+<rules>
+1. Every prompt is written as if the user typed it themselves: "Track ...", \
+"Keep an overview of ...". Never address the user, never mention Baserow, AI, \
+tables, fields or views.
+2. Keep each prompt to 2 or 3 short sentences, about 35 words. It must be \
+readable at a glance.
+3. Say what is tracked and name a handful of the details that belong to it. \
+Nothing more.
+4. Suggest work that this specific team, in this specific industry, actually \
+does. Generic ideas that would fit any company are a failure.
+5. Every suggestion must cover a different area of their work. Do not offer \
+variations of the same idea.
+6. Order them by how obviously useful they are, most useful first.
+7. `name` is a label of at most four words that describes what is tracked.
+8. Use plain, everyday language. No jargon, no buzzwords.
+</rules>
+"""
+
+
+class OnboardingPromptSuggestion(BaseModel):
+    name: str = Field(description="Label of at most four words.")
+    prompt: str = Field(
+        description="2 to 3 short sentences describing the database to build."
+    )
+
+
+class OnboardingPromptSuggestions(BaseModel):
+    suggestions: list[OnboardingPromptSuggestion]
+
+
+onboarding_suggestions_agent: Agent[None, OnboardingPromptSuggestions] = Agent(
+    output_type=OnboardingPromptSuggestions,
+    instructions=ONBOARDING_SUGGESTIONS_INSTRUCTIONS,
+    retries=2,
+    name="onboarding_suggestions_agent",
+)
+
+
+def generate_onboarding_prompt_suggestions(
+    industry: str,
+    team: str,
+    language: str,
+    amount: int = 4,
+) -> list[OnboardingPromptSuggestion]:
+    """
+    Asks the language model for `amount` database ideas tailored to the answers
+    given during the onboarding.
+
+    :param industry: The industry the user works in.
+    :param team: The team the user is part of.
+    :param language: ISO 639-1 code the suggestions must be written in.
+    :param amount: How many suggestions to ask for.
+    :return: The suggestions, most useful first.
+    """
+
+    user_prompt = (
+        f"Industry: {industry or 'unknown'}\n"
+        f"Team: {team or 'unknown'}\n\n"
+        f"Suggest exactly {amount} databases this person could build. "
+        f"Write every name and prompt in the language with ISO 639-1 code "
+        f"'{language}'."
+    )
+
+    model_string = get_model_string()
+    result = onboarding_suggestions_agent.run_sync(
+        user_prompt,
+        model=RetryingModel(model_string),
+        model_settings=get_model_settings(model_string, SUGGESTIONS),
+    )
+    return result.output.suggestions[:amount]

--- a/enterprise/backend/tests/baserow_enterprise_tests/assistant/test_onboarding_suggestions.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/assistant/test_onboarding_suggestions.py
@@ -1,0 +1,163 @@
+from django.shortcuts import reverse
+
+import pytest
+from rest_framework.status import (
+    HTTP_200_OK,
+    HTTP_400_BAD_REQUEST,
+    HTTP_401_UNAUTHORIZED,
+)
+
+from baserow_enterprise.assistant.exceptions import AssistantModelNotSupportedError
+from baserow_enterprise.assistant.onboarding import (
+    OnboardingPromptSuggestion,
+    OnboardingPromptSuggestions,
+    generate_onboarding_prompt_suggestions,
+)
+
+URL = reverse("assistant:onboarding_prompt_suggestions")
+
+
+def make_run_sync_mock(mocker, amount=4):
+    result = mocker.MagicMock()
+    result.output = OnboardingPromptSuggestions(
+        suggestions=[
+            OnboardingPromptSuggestion(name=f"Name {i}", prompt=f"Prompt {i}")
+            for i in range(amount)
+        ]
+    )
+    return mocker.patch(
+        "baserow_enterprise.assistant.onboarding.onboarding_suggestions_agent.run_sync",
+        return_value=result,
+    )
+
+
+@pytest.mark.django_db
+def test_suggestions_requires_authentication(api_client):
+    response = api_client.post(URL, {}, format="json")
+    assert response.status_code == HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_suggestions_returns_the_generated_suggestions(
+    api_client, data_fixture, mocker
+):
+    _, token = data_fixture.create_user_and_token()
+    mocker.patch(
+        "baserow_enterprise.api.assistant.views.check_lm_ready_or_raise",
+        return_value=None,
+    )
+    mocker.patch(
+        "baserow_enterprise.assistant.onboarding.get_model_string",
+        return_value="openai:gpt-4o",
+    )
+    run_sync = make_run_sync_mock(mocker)
+
+    response = api_client.post(
+        URL,
+        {"industry": "Marketing", "team": "Client services"},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_200_OK
+    suggestions = response.json()["suggestions"]
+    assert len(suggestions) == 4
+    assert suggestions[0] == {"name": "Name 0", "prompt": "Prompt 0"}
+
+    user_prompt = run_sync.call_args.args[0]
+    assert "Marketing" in user_prompt
+    assert "Client services" in user_prompt
+
+
+@pytest.mark.django_db
+def test_suggestions_falls_back_to_the_profile_language(
+    api_client, data_fixture, mocker
+):
+    _, token = data_fixture.create_user_and_token(language="fr")
+    mocker.patch(
+        "baserow_enterprise.api.assistant.views.check_lm_ready_or_raise",
+        return_value=None,
+    )
+    mocker.patch(
+        "baserow_enterprise.assistant.onboarding.get_model_string",
+        return_value="openai:gpt-4o",
+    )
+    run_sync = make_run_sync_mock(mocker)
+
+    api_client.post(URL, {}, format="json", HTTP_AUTHORIZATION=f"JWT {token}")
+
+    assert "'fr'" in run_sync.call_args.args[0]
+
+
+@pytest.mark.django_db
+def test_suggestions_language_overrides_the_profile_language(
+    api_client, data_fixture, mocker
+):
+    _, token = data_fixture.create_user_and_token(language="fr")
+    mocker.patch(
+        "baserow_enterprise.api.assistant.views.check_lm_ready_or_raise",
+        return_value=None,
+    )
+    mocker.patch(
+        "baserow_enterprise.assistant.onboarding.get_model_string",
+        return_value="openai:gpt-4o",
+    )
+    run_sync = make_run_sync_mock(mocker)
+
+    api_client.post(
+        URL, {"language": "nl"}, format="json", HTTP_AUTHORIZATION=f"JWT {token}"
+    )
+
+    assert "'nl'" in run_sync.call_args.args[0]
+
+
+@pytest.mark.django_db
+def test_suggestions_errors_when_the_model_is_not_supported(
+    api_client, data_fixture, mocker
+):
+    _, token = data_fixture.create_user_and_token()
+    mocker.patch(
+        "baserow_enterprise.api.assistant.views.check_lm_ready_or_raise",
+        side_effect=AssistantModelNotSupportedError("nope"),
+    )
+
+    response = api_client.post(
+        URL, {}, format="json", HTTP_AUTHORIZATION=f"JWT {token}"
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_ASSISTANT_MODEL_NOT_SUPPORTED"
+
+
+@pytest.mark.django_db
+def test_generate_returns_at_most_the_requested_amount(mocker):
+    mocker.patch(
+        "baserow_enterprise.assistant.onboarding.get_model_string",
+        return_value="openai:gpt-4o",
+    )
+    make_run_sync_mock(mocker, amount=15)
+
+    suggestions = generate_onboarding_prompt_suggestions("Marketing", "Ops", "en")
+
+    assert len(suggestions) == 4
+
+
+@pytest.mark.django_db
+def test_suggestions_rejects_long_answers(api_client, data_fixture, mocker):
+    _, token = data_fixture.create_user_and_token()
+    mocker.patch(
+        "baserow_enterprise.api.assistant.views.check_lm_ready_or_raise",
+        return_value=None,
+    )
+
+    response = api_client.post(
+        URL,
+        {"industry": "a" * 49, "team": "b" * 49},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    detail = response.json()["detail"]
+    assert "industry" in detail
+    assert "team" in detail

--- a/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/ai_onboarding.scss
+++ b/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/ai_onboarding.scss
@@ -46,8 +46,15 @@
   gap: 24px 14px;
 }
 
-.ai-prompt-suggestion:hover {
-  text-decoration: none;
+.ai-prompt-suggestion {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
 }
 
 .ai-prompt-suggestion__preview {

--- a/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/ai_onboarding.scss
+++ b/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/ai_onboarding.scss
@@ -1,0 +1,108 @@
+.ai-onboarding-questions__progress {
+  font-size: 12px;
+  font-weight: 500;
+  color: $palette-neutral-700;
+  margin-bottom: 8px;
+}
+
+.ai-onboarding-questions__explanation {
+  margin-bottom: 24px;
+  color: $palette-neutral-900;
+}
+
+.ai-prompt-loading {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid $palette-cyan-200;
+  background-color: $palette-cyan-50;
+  padding: 20px 16px;
+  margin-bottom: 24px;
+
+  @include rounded($rounded-md);
+}
+
+.ai-prompt-loading__text {
+  color: $palette-cyan-700;
+}
+
+.ai-prompt-suggestions__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+
+.ai-prompt-suggestions__title {
+  font-size: 12px;
+  font-weight: 500;
+  color: $palette-neutral-700;
+}
+
+.ai-prompt-suggestions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px 14px;
+}
+
+.ai-prompt-suggestion:hover {
+  text-decoration: none;
+}
+
+.ai-prompt-suggestion__preview {
+  border: 1px solid $palette-neutral-200;
+  background: $palette-neutral-25;
+  color: $palette-neutral-900;
+  padding: 12px;
+  font-size: 11px;
+  margin-bottom: 10px;
+
+  @include rounded($rounded-md);
+
+  .ai-prompt-suggestion--active & {
+    border-color: $palette-blue-500;
+    box-shadow: 0 0 0 1px $palette-blue-500;
+  }
+
+  .ai-prompt-suggestion--skeleton & {
+    animation: ai-prompt-suggestion-pulse 1.4s ease-in-out infinite;
+  }
+}
+
+.ai-prompt-suggestion__preview-text {
+  display: -webkit-box;
+  overflow: hidden;
+  line-height: 16px;
+  height: 48px;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+
+.ai-prompt-suggestion__name {
+  @extend %ellipsis;
+
+  font-weight: 500;
+  line-height: 20px;
+  color: $palette-neutral-1200;
+
+  .ai-prompt-suggestion--skeleton & {
+    height: 12px;
+    width: 60%;
+    background: $palette-neutral-200;
+    animation: ai-prompt-suggestion-pulse 1.4s ease-in-out infinite;
+
+    @include rounded($rounded);
+  }
+}
+
+@keyframes ai-prompt-suggestion-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.4;
+  }
+}

--- a/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/ai_onboarding.scss
+++ b/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/ai_onboarding.scss
@@ -1,8 +1,18 @@
 .ai-onboarding-questions__progress {
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 500;
-  color: $palette-neutral-700;
+  color: $palette-neutral-1000;
   margin-bottom: 8px;
+}
+
+.ai-onboarding-question-enter-active,
+.ai-onboarding-question-leave-active {
+  transition: opacity 0.15s ease;
+}
+
+.ai-onboarding-question-enter-from,
+.ai-onboarding-question-leave-to {
+  opacity: 0;
 }
 
 .ai-onboarding-questions__explanation {

--- a/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/all.scss
+++ b/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/all.scss
@@ -24,6 +24,7 @@
 @import 'core_code_service_form';
 @import 'assistant';
 @import 'assistant_onboarding';
+@import 'ai_onboarding';
 @import 'date_dependency';
 @import 'data_scanner';
 @import 'restricted_view_filter_context';

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/onboarding/AIDatabaseOnboardingForm.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/onboarding/AIDatabaseOnboardingForm.vue
@@ -1,32 +1,38 @@
 <template>
   <form @submit.prevent>
-    <div class="ai-onboarding-questions__progress">
-      {{
-        $t('aiDatabaseOnboardingForm.progress', {
-          current: phaseIndex + 1,
-          total: phases.length,
-        })
-      }}
-    </div>
+    <i18n-t
+      scope="global"
+      keypath="aiDatabaseOnboardingForm.progress"
+      tag="div"
+      class="ai-onboarding-questions__progress"
+    >
+      <template #current>
+        <span>{{ phaseIndex + 1 }}</span>
+      </template>
+      <template #total>{{ phases.length }}</template>
+    </i18n-t>
     <p class="ai-onboarding-questions__explanation">
       {{ $t('aiDatabaseOnboardingForm.explanation') }}
     </p>
-    <FormGroup
-      :label="$t(`aiDatabaseOnboardingForm.${phase}Label`)"
-      :helper-text="$t(`aiDatabaseOnboardingForm.${phase}Description`)"
-      small-label
-      required
-    >
-      <FormInput
-        ref="input"
-        v-model="values[phase]"
-        :placeholder="$t(`aiDatabaseOnboardingForm.${phase}Placeholder`)"
-        :maxlength="48"
-        size="large"
-        @input="updateValue()"
-        @keydown.enter.prevent="continueOnEnter()"
-      />
-    </FormGroup>
+    <Transition name="ai-onboarding-question" mode="out-in" @enter="focus()">
+      <FormGroup
+        :key="phase"
+        :label="$t(`aiDatabaseOnboardingForm.${phase}Label`)"
+        :helper-text="$t(`aiDatabaseOnboardingForm.${phase}Description`)"
+        small-label
+        required
+      >
+        <FormInput
+          ref="input"
+          v-model="values[phase]"
+          :placeholder="$t(`aiDatabaseOnboardingForm.${phase}Placeholder`)"
+          :maxlength="48"
+          size="large"
+          @input="updateValue()"
+          @keydown.enter.prevent="continueOnEnter()"
+        />
+      </FormGroup>
+    </Transition>
   </form>
 </template>
 
@@ -69,7 +75,8 @@ export default {
     },
     goToPhase(index) {
       this.phaseIndex = index
-      this.focus()
+      // The input of the new question is only in the DOM once the transition
+      // enters, so focussing is done from there.
       this.updateValue()
     },
     continueOnEnter() {

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/onboarding/AIDatabaseOnboardingForm.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/onboarding/AIDatabaseOnboardingForm.vue
@@ -1,105 +1,95 @@
 <template>
-  <form @submit.prevent="submit">
+  <form @submit.prevent>
+    <div class="ai-onboarding-questions__progress">
+      {{
+        $t('aiDatabaseOnboardingForm.progress', {
+          current: phaseIndex + 1,
+          total: phases.length,
+        })
+      }}
+    </div>
+    <p class="ai-onboarding-questions__explanation">
+      {{ $t('aiDatabaseOnboardingForm.explanation') }}
+    </p>
     <FormGroup
-      :label="$t('aiDatabaseOnboardingForm.label')"
-      :helper-text="$t('aiDatabaseOnboardingForm.description')"
+      :label="$t(`aiDatabaseOnboardingForm.${phase}Label`)"
+      :helper-text="$t(`aiDatabaseOnboardingForm.${phase}Description`)"
       small-label
       required
     >
-      <FormTextarea
-        ref="promptInput"
-        v-model="values.prompt"
-        :placeholder="$t('aiDatabaseOnboardingForm.placeholder')"
-        :rows="4"
-        @input=";[v$.values.prompt.$touch(), updateValue()]"
+      <FormInput
+        ref="input"
+        v-model="values[phase]"
+        :placeholder="$t(`aiDatabaseOnboardingForm.${phase}Placeholder`)"
+        :maxlength="48"
+        size="large"
+        @input="updateValue()"
+        @keydown.enter.prevent="continueOnEnter()"
       />
     </FormGroup>
-    <div class="flex flex-wrap margin-top-2 margin-bottom-2">
-      <Button
-        v-for="example in examples"
-        :key="example.id"
-        tag="a"
-        type="secondary"
-        @click="setPrompt(example.prompt)"
-        >{{ example.name }}</Button
-      >
-    </div>
   </form>
 </template>
 
 <script>
-import form from '@baserow/modules/core/mixins/form'
-import { useVuelidate } from '@vuelidate/core'
-import { required } from '@vuelidate/validators'
-import { useI18n } from 'vue-i18n'
-
 export default {
   name: 'AIDatabaseOnboardingForm',
-  mixins: [form],
-  emits: ['input'],
-  setup() {
-    return { v$: useVuelidate({ $lazy: true }) }
-  },
-  mounted() {
-    this.$nextTick(() => {
-      this.$refs.promptInput.focus()
-    })
-  },
+  emits: ['input', 'next-step'],
   data() {
-    const { t } = useI18n()
     return {
+      phases: ['industry', 'team'],
+      phaseIndex: 0,
       values: {
-        prompt: '',
+        industry: '',
+        team: '',
       },
-      examples: [
-        {
-          id: 'project-tracker',
-          name: t('aiDatabaseOnboardingForm.exampleProjectTrackerName'),
-          prompt: t('aiDatabaseOnboardingForm.exampleProjectTrackerPrompt'),
-        },
-        {
-          id: 'product-roadmap',
-          name: t('aiDatabaseOnboardingForm.exampleProductRoadmapName'),
-          prompt: t('aiDatabaseOnboardingForm.exampleProductRoadmapPrompt'),
-        },
-        {
-          id: 'company-asset-tracker',
-          name: t('aiDatabaseOnboardingForm.exampleCompanyAssetTrackerName'),
-          prompt: t(
-            'aiDatabaseOnboardingForm.exampleCompanyAssetTrackerPrompt'
-          ),
-        },
-        {
-          id: 'team-check-ins',
-          name: t('aiDatabaseOnboardingForm.exampleTeamCheckInsName'),
-          prompt: t('aiDatabaseOnboardingForm.exampleTeamCheckInsPrompt'),
-        },
-        {
-          id: 'bug-tracker',
-          name: t('aiDatabaseOnboardingForm.exampleBugTrackerName'),
-          prompt: t('aiDatabaseOnboardingForm.exampleBugTrackerPrompt'),
-        },
-      ],
     }
   },
+  computed: {
+    phase() {
+      return this.phases[this.phaseIndex]
+    },
+  },
+  mounted() {
+    this.focus()
+    this.updateValue()
+  },
   methods: {
+    beforeNext() {
+      if (this.phaseIndex >= this.phases.length - 1) {
+        return false
+      }
+      this.goToPhase(this.phaseIndex + 1)
+      return true
+    },
+    canGoBack() {
+      return this.phaseIndex > 0
+    },
+    goBack() {
+      this.goToPhase(this.phaseIndex - 1)
+    },
+    goToPhase(index) {
+      this.phaseIndex = index
+      this.focus()
+      this.updateValue()
+    },
+    continueOnEnter() {
+      if (this.isValid() && !this.beforeNext()) {
+        this.$emit('next-step')
+      }
+    },
+    focus() {
+      this.$nextTick(() => {
+        this.$refs.input?.focus()
+      })
+    },
+    isValid() {
+      return this.values[this.phase].trim() !== ''
+    },
     updateValue() {
       this.$nextTick(() => {
         this.$emit('input', this.values)
       })
     },
-    setPrompt(prompt) {
-      this.values.prompt = prompt
-      this.v$.values.prompt.$touch()
-      this.updateValue()
-    },
-  },
-  validations() {
-    return {
-      values: {
-        prompt: { required },
-      },
-    }
   },
 }
 </script>

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/onboarding/AIOnboardingDetailsModal.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/onboarding/AIOnboardingDetailsModal.vue
@@ -1,0 +1,70 @@
+<template>
+  <Modal ref="modal" :small="true">
+    <h2 class="box__title">{{ $t('aiOnboardingDetailsModal.title') }}</h2>
+    <form @submit.prevent="submit">
+      <FormGroup
+        v-for="field in fields"
+        :key="field"
+        :label="$t(`aiDatabaseOnboardingForm.${field}Label`)"
+        :helper-text="$t(`aiDatabaseOnboardingForm.${field}Description`)"
+        small-label
+        required
+        class="margin-bottom-2"
+      >
+        <FormInput
+          v-model="values[field]"
+          :placeholder="$t(`aiDatabaseOnboardingForm.${field}Placeholder`)"
+          :maxlength="48"
+          size="large"
+        />
+      </FormGroup>
+      <div class="actions actions--right">
+        <Button type="primary" size="large" :disabled="!isValid">{{
+          $t('aiOnboardingDetailsModal.submit')
+        }}</Button>
+      </div>
+    </form>
+  </Modal>
+</template>
+
+<script>
+import modal from '@baserow/modules/core/mixins/modal'
+
+export default {
+  name: 'AIOnboardingDetailsModal',
+  mixins: [modal],
+  props: {
+    industry: { type: String, required: true },
+    team: { type: String, required: true },
+  },
+  emits: ['updated'],
+  data() {
+    return {
+      fields: ['industry', 'team'],
+      values: {
+        industry: '',
+        team: '',
+      },
+    }
+  },
+  computed: {
+    isValid() {
+      return this.fields.every((field) => this.values[field].trim() !== '')
+    },
+  },
+  methods: {
+    show(...args) {
+      this.fields.forEach((field) => {
+        this.values[field] = this[field]
+      })
+      this.$refs.modal.show(...args)
+    },
+    submit() {
+      if (this.isValid) {
+        this.$emit('updated', { ...this.values })
+        this.hide()
+      }
+    },
+  },
+}
+</script>

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/onboarding/AIPromptStep.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/onboarding/AIPromptStep.vue
@@ -1,71 +1,81 @@
 <template>
   <div>
     <h1>{{ $t('aiPromptStep.title') }}</h1>
-    <p>{{ $t('aiPromptStep.description') }}</p>
 
-    <div v-if="loading" class="ai-prompt-loading">
-      <div class="loading"></div>
-      <div class="ai-prompt-loading__text">
-        {{ $t('aiPromptStep.generating') }}
+    <template v-if="hasVisibleError">
+      <Error :error="error"></Error>
+      <p>{{ $t('aiPromptStep.errorOtherOptions') }}</p>
+    </template>
+    <template v-else>
+      <p>{{ $t('aiPromptStep.description') }}</p>
+
+      <div v-if="loading" class="ai-prompt-loading">
+        <div class="loading"></div>
+        <div class="ai-prompt-loading__text">
+          {{ $t('aiPromptStep.generating') }}
+        </div>
       </div>
-    </div>
-    <FormGroup
-      v-else
-      :label="$t('aiPromptStep.label')"
-      small-label
-      required
-      class="margin-bottom-2"
-    >
-      <FormTextarea
-        ref="promptInput"
-        v-model="prompt"
-        :placeholder="$t('aiPromptStep.placeholder')"
-        :rows="5"
-        @input="promptEdited = true"
-      />
-    </FormGroup>
+      <FormGroup
+        v-else
+        :label="$t('aiPromptStep.label')"
+        small-label
+        required
+        class="margin-bottom-2"
+      >
+        <FormTextarea
+          ref="promptInput"
+          v-model="prompt"
+          :placeholder="$t('aiPromptStep.placeholder')"
+          :rows="5"
+          @input="promptEdited = true"
+        />
+      </FormGroup>
 
-    <div class="ai-prompt-suggestions__head">
-      <div class="ai-prompt-suggestions__title">
-        {{ $t('aiPromptStep.suggestionsTitle') }}
+      <div class="ai-prompt-suggestions__head">
+        <div class="ai-prompt-suggestions__title">
+          {{ $t('aiPromptStep.suggestionsTitle') }}
+        </div>
+        <ButtonText
+          icon="iconoir-edit-pencil"
+          :disabled="loading"
+          @click="editDetails()"
+          >{{ $t('aiPromptStep.editDetails') }}</ButtonText
+        >
       </div>
-      <ButtonText icon="iconoir-edit-pencil" @click="editDetails()">{{
-        $t('aiPromptStep.editDetails')
-      }}</ButtonText>
-    </div>
 
-    <div class="ai-prompt-suggestions">
-      <template v-if="loading">
-        <div
-          v-for="index in 4"
-          :key="index"
-          class="ai-prompt-suggestion ai-prompt-suggestion--skeleton"
+      <div class="ai-prompt-suggestions">
+        <template v-if="loading">
+          <div
+            v-for="index in 4"
+            :key="index"
+            class="ai-prompt-suggestion ai-prompt-suggestion--skeleton"
+          >
+            <div class="ai-prompt-suggestion__preview">
+              <div class="ai-prompt-suggestion__preview-text"></div>
+            </div>
+            <div class="ai-prompt-suggestion__name"></div>
+          </div>
+        </template>
+        <button
+          v-for="suggestion in suggestions"
+          v-else
+          :key="suggestion.name"
+          type="button"
+          class="ai-prompt-suggestion"
+          :class="{
+            'ai-prompt-suggestion--active': suggestion.prompt === prompt,
+          }"
+          @click="selectSuggestion(suggestion)"
         >
           <div class="ai-prompt-suggestion__preview">
-            <div class="ai-prompt-suggestion__preview-text"></div>
+            <div class="ai-prompt-suggestion__preview-text">
+              {{ suggestion.prompt }}
+            </div>
           </div>
-          <div class="ai-prompt-suggestion__name"></div>
-        </div>
-      </template>
-      <button
-        v-for="suggestion in suggestions"
-        v-else
-        :key="suggestion.name"
-        type="button"
-        class="ai-prompt-suggestion"
-        :class="{
-          'ai-prompt-suggestion--active': suggestion.prompt === prompt,
-        }"
-        @click="selectSuggestion(suggestion)"
-      >
-        <div class="ai-prompt-suggestion__preview">
-          <div class="ai-prompt-suggestion__preview-text">
-            {{ suggestion.prompt }}
-          </div>
-        </div>
-        <div class="ai-prompt-suggestion__name">{{ suggestion.name }}</div>
-      </button>
-    </div>
+          <div class="ai-prompt-suggestion__name">{{ suggestion.name }}</div>
+        </button>
+      </div>
+    </template>
 
     <AIOnboardingDetailsModal
       ref="detailsModal"
@@ -80,11 +90,13 @@
 import AIOnboardingDetailsModal from '@baserow_enterprise/components/onboarding/AIOnboardingDetailsModal'
 import AssistantService from '@baserow_enterprise/services/assistant'
 import { DatabaseOnboardingType } from '@baserow/modules/database/onboardingTypes'
-import { notifyIf } from '@baserow/modules/core/utils/error'
+import { ResponseErrorMessage } from '@baserow/modules/core/plugins/clientHandler'
+import error from '@baserow/modules/core/mixins/error'
 
 export default {
   name: 'AIPromptStep',
   components: { AIOnboardingDetailsModal },
+  mixins: [error],
   props: {
     data: {
       type: Object,
@@ -101,19 +113,6 @@ export default {
       details: this.answers(),
       lastAnswers: this.answers(),
     }
-  },
-  computed: {
-    examples() {
-      return [
-        'ProjectTracker',
-        'ProductRoadmap',
-        'CompanyAssetTracker',
-        'TeamCheckIns',
-      ].map((example) => ({
-        name: this.$t(`aiDatabaseOnboardingForm.example${example}Name`),
-        prompt: this.$t(`aiDatabaseOnboardingForm.example${example}Prompt`),
-      }))
-    },
   },
   watch: {
     prompt() {
@@ -157,6 +156,7 @@ export default {
     },
     async fetchSuggestions() {
       const requested = this.details
+      this.hideError()
       this.loading = true
       try {
         const suggestions = await AssistantService(
@@ -172,12 +172,19 @@ export default {
         if (!this.promptEdited && suggestions.length > 0) {
           this.prompt = suggestions[0].prompt
         }
-      } catch (error) {
+      } catch (requestError) {
         if (requested !== this.details) {
           return
         }
-        this.suggestions = this.examples
-        notifyIf(error)
+        // Without suggestions the assistant most likely can't build the database
+        // either, so the error replaces the form instead of being a toast that's
+        // easily missed.
+        this.handleError(requestError, null, {
+          ERROR_ASSISTANT_MODEL_NOT_SUPPORTED: new ResponseErrorMessage(
+            this.$t('aiPromptStep.modelNotSupportedTitle'),
+            this.$t('aiPromptStep.modelNotSupportedMessage')
+          ),
+        })
       }
       this.loading = false
     },
@@ -193,7 +200,7 @@ export default {
       this.fetchSuggestions()
     },
     isValid() {
-      return this.prompt.trim() !== ''
+      return !this.hasVisibleError && this.prompt.trim() !== ''
     },
   },
 }

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/onboarding/AIPromptStep.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/onboarding/AIPromptStep.vue
@@ -1,0 +1,193 @@
+<template>
+  <div>
+    <h1>{{ $t('aiPromptStep.title') }}</h1>
+    <p>{{ $t('aiPromptStep.description') }}</p>
+
+    <div v-if="loading" class="ai-prompt-loading">
+      <div class="loading"></div>
+      <div class="ai-prompt-loading__text">
+        {{ $t('aiPromptStep.generating') }}
+      </div>
+    </div>
+    <FormGroup
+      v-else
+      :label="$t('aiPromptStep.label')"
+      small-label
+      required
+      class="margin-bottom-2"
+    >
+      <FormTextarea
+        ref="promptInput"
+        v-model="prompt"
+        :placeholder="$t('aiPromptStep.placeholder')"
+        :rows="5"
+        @input="promptEdited = true"
+      />
+    </FormGroup>
+
+    <div class="ai-prompt-suggestions__head">
+      <div class="ai-prompt-suggestions__title">
+        {{ $t('aiPromptStep.suggestionsTitle') }}
+      </div>
+      <ButtonText tag="a" icon="iconoir-edit-pencil" @click="editDetails()">{{
+        $t('aiPromptStep.editDetails')
+      }}</ButtonText>
+    </div>
+
+    <div class="ai-prompt-suggestions">
+      <template v-if="loading">
+        <div
+          v-for="index in 4"
+          :key="index"
+          class="ai-prompt-suggestion ai-prompt-suggestion--skeleton"
+        >
+          <div class="ai-prompt-suggestion__preview">
+            <div class="ai-prompt-suggestion__preview-text"></div>
+          </div>
+          <div class="ai-prompt-suggestion__name"></div>
+        </div>
+      </template>
+      <a
+        v-for="suggestion in suggestions"
+        v-else
+        :key="suggestion.name"
+        class="ai-prompt-suggestion"
+        :class="{
+          'ai-prompt-suggestion--active': suggestion.prompt === prompt,
+        }"
+        @click="selectSuggestion(suggestion)"
+      >
+        <div class="ai-prompt-suggestion__preview">
+          <div class="ai-prompt-suggestion__preview-text">
+            {{ suggestion.prompt }}
+          </div>
+        </div>
+        <div class="ai-prompt-suggestion__name">{{ suggestion.name }}</div>
+      </a>
+    </div>
+
+    <AIOnboardingDetailsModal
+      ref="detailsModal"
+      :industry="details.industry"
+      :team="details.team"
+      @updated="detailsUpdated"
+    />
+  </div>
+</template>
+
+<script>
+import AIOnboardingDetailsModal from '@baserow_enterprise/components/onboarding/AIOnboardingDetailsModal'
+import AssistantService from '@baserow_enterprise/services/assistant'
+import { DatabaseOnboardingType } from '@baserow/modules/database/onboardingTypes'
+import { notifyIf } from '@baserow/modules/core/utils/error'
+
+export default {
+  name: 'AIPromptStep',
+  components: { AIOnboardingDetailsModal },
+  props: {
+    data: {
+      type: Object,
+      required: true,
+    },
+  },
+  emits: ['update-data'],
+  data() {
+    return {
+      loading: false,
+      prompt: '',
+      promptEdited: false,
+      suggestions: [],
+      details: this.answers(),
+    }
+  },
+  computed: {
+    examples() {
+      return [
+        'ProjectTracker',
+        'ProductRoadmap',
+        'CompanyAssetTracker',
+        'TeamCheckIns',
+      ].map((example) => ({
+        name: this.$t(`aiDatabaseOnboardingForm.example${example}Name`),
+        prompt: this.$t(`aiDatabaseOnboardingForm.example${example}Prompt`),
+      }))
+    },
+  },
+  watch: {
+    prompt() {
+      this.emitData()
+    },
+  },
+  mounted() {
+    this.emitData()
+    this.fetchSuggestions()
+  },
+  activated() {
+    // The onboarding keeps this step alive, so the user can go back, change their
+    // answers and end up here again with suggestions that no longer match.
+    const answers = this.answers()
+    if (
+      answers.industry !== this.details.industry ||
+      answers.team !== this.details.team
+    ) {
+      this.details = answers
+      this.fetchSuggestions()
+    }
+  },
+  methods: {
+    emitData() {
+      this.$emit('update-data', {
+        prompt: this.prompt,
+        language: this.$i18n.locale,
+      })
+    },
+    answers() {
+      const database = this.data[DatabaseOnboardingType.getType()] || {}
+      return {
+        industry: database.industry || '',
+        team: database.team || '',
+      }
+    },
+    async fetchSuggestions() {
+      const requested = this.details
+      this.loading = true
+      try {
+        const suggestions = await AssistantService(
+          this.$client
+        ).fetchOnboardingPromptSuggestions({
+          ...requested,
+          language: this.$i18n.locale,
+        })
+        if (requested !== this.details) {
+          return
+        }
+        this.suggestions = suggestions
+        if (!this.promptEdited && suggestions.length > 0) {
+          this.prompt = suggestions[0].prompt
+        }
+      } catch (error) {
+        if (requested !== this.details) {
+          return
+        }
+        this.suggestions = this.examples
+        notifyIf(error)
+      }
+      this.loading = false
+    },
+    selectSuggestion(suggestion) {
+      this.prompt = suggestion.prompt
+      this.promptEdited = false
+    },
+    editDetails() {
+      this.$refs.detailsModal.show()
+    },
+    detailsUpdated(details) {
+      this.details = details
+      this.fetchSuggestions()
+    },
+    isValid() {
+      return this.prompt.trim() !== ''
+    },
+  },
+}
+</script>

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/onboarding/AIPromptStep.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/onboarding/AIPromptStep.vue
@@ -29,7 +29,7 @@
       <div class="ai-prompt-suggestions__title">
         {{ $t('aiPromptStep.suggestionsTitle') }}
       </div>
-      <ButtonText tag="a" icon="iconoir-edit-pencil" @click="editDetails()">{{
+      <ButtonText icon="iconoir-edit-pencil" @click="editDetails()">{{
         $t('aiPromptStep.editDetails')
       }}</ButtonText>
     </div>
@@ -47,10 +47,11 @@
           <div class="ai-prompt-suggestion__name"></div>
         </div>
       </template>
-      <a
+      <button
         v-for="suggestion in suggestions"
         v-else
         :key="suggestion.name"
+        type="button"
         class="ai-prompt-suggestion"
         :class="{
           'ai-prompt-suggestion--active': suggestion.prompt === prompt,
@@ -63,7 +64,7 @@
           </div>
         </div>
         <div class="ai-prompt-suggestion__name">{{ suggestion.name }}</div>
-      </a>
+      </button>
     </div>
 
     <AIOnboardingDetailsModal
@@ -98,6 +99,7 @@ export default {
       promptEdited: false,
       suggestions: [],
       details: this.answers(),
+      lastAnswers: this.answers(),
     }
   },
   computed: {
@@ -117,6 +119,9 @@ export default {
     prompt() {
       this.emitData()
     },
+    details() {
+      this.emitData()
+    },
   },
   mounted() {
     this.emitData()
@@ -127,9 +132,10 @@ export default {
     // answers and end up here again with suggestions that no longer match.
     const answers = this.answers()
     if (
-      answers.industry !== this.details.industry ||
-      answers.team !== this.details.team
+      answers.industry !== this.lastAnswers.industry ||
+      answers.team !== this.lastAnswers.team
     ) {
+      this.lastAnswers = answers
       this.details = answers
       this.fetchSuggestions()
     }
@@ -139,6 +145,7 @@ export default {
       this.$emit('update-data', {
         prompt: this.prompt,
         language: this.$i18n.locale,
+        ...this.details,
       })
     },
     answers() {

--- a/enterprise/web-frontend/modules/baserow_enterprise/databaseOnboardingStepTypes.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/databaseOnboardingStepTypes.js
@@ -1,14 +1,10 @@
 import { DatabaseOnboardingStepType } from '@baserow/modules/database/databaseOnboardingStepTypes'
 import AIDatabaseOnboardingForm from '@baserow_enterprise/components/onboarding/AIDatabaseOnboardingForm'
-import { nextTick } from 'vue'
-import { pageFinished } from '@baserow/modules/core/utils/routing.js'
-import { DatabaseOnboardingType } from '@baserow/modules/database/onboardingTypes.js'
-import { waitFor } from '@baserow/modules/core/utils/queue.js'
-import AssistantOnboardingMessage from '@baserow_enterprise/components/assistant/AssistantOnboardingMessage.vue'
 
 /**
  * AI-assisted database onboarding step type. Only visible when an LLM model is
- * configured in the enterprise settings.
+ * configured in the enterprise settings. Asks a few questions about the user, after
+ * which the AIPromptOnboardingType step asks for the actual prompt.
  */
 export class AIDatabaseOnboardingStepType extends DatabaseOnboardingStepType {
   static getType() {
@@ -38,53 +34,9 @@ export class AIDatabaseOnboardingStepType extends DatabaseOnboardingStepType {
   }
 
   isValid(data, vuelidate, refs) {
-    const component = refs.stepComponent
-    return (
-      !!component &&
-      !!component.v$ &&
-      !component.v$.$invalid &&
-      component.v$.$dirty
-    )
-  }
-
-  async completeAfterWorkspace(workspace, stepData, callback) {
-    await this.app.$store.dispatch('workspace/select', workspace)
-    const message = this.app.$i18n.t('aiDatabaseOnboardingStepType.prompt', {
-      prompt: stepData.prompt,
-    })
-    callback(null, AssistantOnboardingMessage)
-    await this.app.$store.dispatch('assistant/sendMessage', {
-      message,
-      workspace,
-    })
-    const chat = this.app.$store.getters['assistant/currentChat']
-    await waitFor(() => {
-      const currentChat = this.app.$store.getters['assistant/currentChat']
-      return !currentChat?.running
-    }, 50)
-    const tableLocation = this.app.$store.getters[
-      'assistant/uiLocationHistory'
-    ].filter((location) => location.type === 'database-table')[0]
-    if (!tableLocation) {
-      throw new Error('The assistant did not create a table.')
-    }
-    return { tableLocation, chat }
-  }
-
-  getCompletedRoute(data, responses) {
-    const response = responses[DatabaseOnboardingType.getType()]
-    nextTick(async () => {
-      await pageFinished(this.app)
-      await nextTick()
-      await this.app.$bus.$emit('toggle-right-sidebar', true)
-      await this.app.$store.dispatch('assistant/selectChat', response.chat)
-    })
-    return {
-      name: 'database-table',
-      params: {
-        databaseId: response.tableLocation.database_id,
-        tableId: response.tableLocation.table_id,
-      },
-    }
+    // Right after switching tabs the ref still points at the component of the
+    // previously selected type, which has no `isValid`. The next render, once the
+    // ref has caught up, gets the real answer.
+    return refs.stepComponent?.isValid?.() === true
   }
 }

--- a/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
+++ b/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
@@ -833,9 +833,14 @@
     "ai": "Kuma AI"
   },
   "aiDatabaseOnboardingForm": {
-    "label": "Describe your database",
-    "placeholder": "e.g. Create project management solution",
-    "description": "Describe what you want to track. Kuma will create the tables and fields.",
+    "progress": "Question {current} of {total}",
+    "explanation": "Kuma builds your workspace for you. Answering a couple of questions lets it suggest what to build first, so you start with something that matches the work you actually do.",
+    "industryLabel": "What industry are you in?",
+    "industryDescription": "A few words are enough, like \"Manufacturing\", \"Aerospace\" or \"Digital marketing\".",
+    "industryPlaceholder": "e.g. Digital marketing",
+    "teamLabel": "Which team are you on?",
+    "teamDescription": "For example \"Client services\", \"Finance\" or \"Operations\".",
+    "teamPlaceholder": "e.g. Client services",
     "exampleProjectTrackerName": "Project Tracker",
     "exampleProjectTrackerPrompt": "Create a project tracker with Projects, Tasks, Assignees, Status, Priority, Due dates, and dependencies.",
     "exampleProductRoadmapName": "Product Roadmap",
@@ -843,12 +848,25 @@
     "exampleCompanyAssetTrackerName": "Company Asset Tracker",
     "exampleCompanyAssetTrackerPrompt": "Create an asset tracker with Assets, Categories, Serial numbers, Purchase date, Assigned to, Location, and warranty expiry.",
     "exampleTeamCheckInsName": "Team Check-ins",
-    "exampleTeamCheckInsPrompt": "Create a weekly team check-in tracker with Team members, Date, Wins, Blockers, Mood, Priorities, and follow-ups.",
-    "exampleBugTrackerName": "Bug Tracker",
-    "exampleBugTrackerPrompt": "Create a bug tracker with Bugs, Severity, Status, Steps to reproduce, Environment, Reporter, Assignee, and fix version."
+    "exampleTeamCheckInsPrompt": "Create a weekly team check-in tracker with Team members, Date, Wins, Blockers, Mood, Priorities, and follow-ups."
   },
-  "aiDatabaseOnboardingStepType": {
-    "prompt": "Create a database including tables, fields, example rows, and example views matching this description: {prompt}"
+  "aiPromptStep": {
+    "title": "What should Kuma build for you?",
+    "description": "We've written a first suggestion based on your answers. Change it, or pick another one below.",
+    "label": "Describe your database",
+    "placeholder": "e.g. Track client projects with deadlines, owners and status.",
+    "generating": "Kuma is writing a suggestion for you…",
+    "suggestionsTitle": "Or start with one of these",
+    "editDetails": "Edit details"
+  },
+  "aiOnboardingDetailsModal": {
+    "title": "Edit your details",
+    "submit": "Update suggestions"
+  },
+  "aiPromptOnboardingType": {
+    "prompt": "Create a database including tables, fields, example rows, and example views matching this description: {prompt}",
+    "context": "The person asking works in {industry}, on the {team} team. Use that to pick realistic tables, fields and example rows.",
+    "language": "Write everything you create in the language with ISO 639-1 code \"{language}\"."
   },
   "assistantOnboardingMessage": {
     "instructing": "Instructing Kuma to create your database."

--- a/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
+++ b/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
@@ -840,15 +840,7 @@
     "industryPlaceholder": "e.g. Digital marketing",
     "teamLabel": "Which team are you on?",
     "teamDescription": "For example \"Client services\", \"Finance\" or \"Operations\".",
-    "teamPlaceholder": "e.g. Client services",
-    "exampleProjectTrackerName": "Project Tracker",
-    "exampleProjectTrackerPrompt": "Create a project tracker with Projects, Tasks, Assignees, Status, Priority, Due dates, and dependencies.",
-    "exampleProductRoadmapName": "Product Roadmap",
-    "exampleProductRoadmapPrompt": "Create a product roadmap with Initiatives, Features, Owners, Status, Priority, Target quarter, and release notes.",
-    "exampleCompanyAssetTrackerName": "Company Asset Tracker",
-    "exampleCompanyAssetTrackerPrompt": "Create an asset tracker with Assets, Categories, Serial numbers, Purchase date, Assigned to, Location, and warranty expiry.",
-    "exampleTeamCheckInsName": "Team Check-ins",
-    "exampleTeamCheckInsPrompt": "Create a weekly team check-in tracker with Team members, Date, Wins, Blockers, Mood, Priorities, and follow-ups."
+    "teamPlaceholder": "e.g. Client services"
   },
   "aiPromptStep": {
     "title": "What should Kuma build for you?",
@@ -857,7 +849,10 @@
     "placeholder": "e.g. Track client projects with deadlines, owners and status.",
     "generating": "Kuma is writing a suggestion for you…",
     "suggestionsTitle": "Or start with one of these",
-    "editDetails": "Edit details"
+    "editDetails": "Edit details",
+    "modelNotSupportedTitle": "Kuma is unavailable",
+    "modelNotSupportedMessage": "Kuma can't be reached because no working AI model is configured, so it can't build a database for you right now. Trying again won't help until that's fixed.",
+    "errorOtherOptions": "Go back to start a database in another way, for example from a template, an import, or from scratch."
   },
   "aiOnboardingDetailsModal": {
     "title": "Edit your details",

--- a/enterprise/web-frontend/modules/baserow_enterprise/onboardingTypes.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/onboardingTypes.js
@@ -1,0 +1,87 @@
+import { nextTick } from 'vue'
+import { OnboardingType } from '@baserow/modules/core/onboardingTypes'
+import { DatabaseOnboardingType } from '@baserow/modules/database/onboardingTypes'
+import DatabaseAppLayoutPreview from '@baserow/modules/database/components/onboarding/DatabaseAppLayoutPreview'
+import { pageFinished } from '@baserow/modules/core/utils/routing.js'
+import { waitFor } from '@baserow/modules/core/utils/queue.js'
+import AIPromptStep from '@baserow_enterprise/components/onboarding/AIPromptStep'
+import AssistantOnboardingMessage from '@baserow_enterprise/components/assistant/AssistantOnboardingMessage.vue'
+import { AIDatabaseOnboardingStepType } from '@baserow_enterprise/databaseOnboardingStepTypes'
+
+export class AIPromptOnboardingType extends OnboardingType {
+  static getType() {
+    return 'ai_prompt'
+  }
+
+  getOrder() {
+    return 5050
+  }
+
+  getFormComponent() {
+    return AIPromptStep
+  }
+
+  getPreviewComponent() {
+    return DatabaseAppLayoutPreview
+  }
+
+  condition(data) {
+    const database = data[DatabaseOnboardingType.getType()]
+    return database?.type === AIDatabaseOnboardingStepType.getType()
+  }
+
+  async complete(data, responses, callback) {
+    const { $i18n: i18n } = this.app
+    const workspace = responses[DatabaseOnboardingType.getType()].workspace
+    const database = data[DatabaseOnboardingType.getType()]
+
+    await this.app.$store.dispatch('workspace/select', workspace)
+
+    const stepData = data[this.getType()]
+    const message = [
+      i18n.t('aiPromptOnboardingType.prompt', { prompt: stepData.prompt }),
+      i18n.t('aiPromptOnboardingType.context', {
+        industry: database.industry,
+        team: database.team,
+      }),
+      i18n.t('aiPromptOnboardingType.language', {
+        language: stepData.language,
+      }),
+    ].join(' ')
+
+    callback(null, AssistantOnboardingMessage)
+    await this.app.$store.dispatch('assistant/sendMessage', {
+      message,
+      workspace,
+    })
+    const chat = this.app.$store.getters['assistant/currentChat']
+    await waitFor(() => {
+      const currentChat = this.app.$store.getters['assistant/currentChat']
+      return !currentChat?.running
+    }, 50)
+    const tableLocation = this.app.$store.getters[
+      'assistant/uiLocationHistory'
+    ].filter((location) => location.type === 'database-table')[0]
+    if (!tableLocation) {
+      throw new Error('The assistant did not create a table.')
+    }
+    return { tableLocation, chat }
+  }
+
+  getCompletedRoute(data, responses) {
+    const response = responses[this.getType()]
+    nextTick(async () => {
+      await pageFinished(this.app)
+      await nextTick()
+      await this.app.$bus.$emit('toggle-right-sidebar', true)
+      await this.app.$store.dispatch('assistant/selectChat', response.chat)
+    })
+    return {
+      name: 'database-table',
+      params: {
+        databaseId: response.tableLocation.database_id,
+        tableId: response.tableLocation.table_id,
+      },
+    }
+  }
+}

--- a/enterprise/web-frontend/modules/baserow_enterprise/onboardingTypes.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/onboardingTypes.js
@@ -33,7 +33,6 @@ export class AIPromptOnboardingType extends OnboardingType {
   async complete(data, responses, callback) {
     const { $i18n: i18n } = this.app
     const workspace = responses[DatabaseOnboardingType.getType()].workspace
-    const database = data[DatabaseOnboardingType.getType()]
 
     await this.app.$store.dispatch('workspace/select', workspace)
 
@@ -41,8 +40,8 @@ export class AIPromptOnboardingType extends OnboardingType {
     const message = [
       i18n.t('aiPromptOnboardingType.prompt', { prompt: stepData.prompt }),
       i18n.t('aiPromptOnboardingType.context', {
-        industry: database.industry,
-        team: database.team,
+        industry: stepData.industry,
+        team: stepData.team,
       }),
       i18n.t('aiPromptOnboardingType.language', {
         language: stepData.language,

--- a/enterprise/web-frontend/modules/baserow_enterprise/plugin.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/plugin.js
@@ -95,6 +95,7 @@ import { CustomCodeBuilderSettingType } from '@baserow_enterprise/builderSetting
 import { RealtimePushTwoWaySyncStrategyType } from '@baserow_enterprise/twoWaySyncStrategyTypes'
 import { RestrictedViewOwnershipType } from '@baserow_enterprise/viewOwnershipTypes'
 import { AIDatabaseOnboardingStepType } from '@baserow_enterprise/databaseOnboardingStepTypes'
+import { AIPromptOnboardingType } from '@baserow_enterprise/onboardingTypes'
 import {
   CoreCodeServiceType,
   CoreXLSFileReaderServiceType,
@@ -285,6 +286,7 @@ export default defineNuxtPlugin({
       'databaseOnboardingStep',
       new AIDatabaseOnboardingStepType(context)
     )
+    $registry.register('onboarding', new AIPromptOnboardingType(context))
 
     $registry.register(
       'fieldContextItem',

--- a/enterprise/web-frontend/modules/baserow_enterprise/services/assistant.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/services/assistant.js
@@ -147,6 +147,21 @@ export default (client) => {
       return data
     },
 
+    async fetchOnboardingPromptSuggestions({ industry, team, language }) {
+      const { data } = await client.post(
+        '/assistant/onboarding/prompt-suggestions/',
+        {
+          industry,
+          team,
+          language,
+        },
+        {
+          baseURL: getAssistantBaseURL(client),
+        }
+      )
+      return data.suggestions
+    },
+
     async cancelMessage(chatUuid) {
       await client.delete(`/assistant/chat/${chatUuid}/cancel/`, {
         baseURL: getAssistantBaseURL(client),

--- a/enterprise/web-frontend/test/unit/enterprise/onboarding/aiDatabaseOnboardingForm.spec.js
+++ b/enterprise/web-frontend/test/unit/enterprise/onboarding/aiDatabaseOnboardingForm.spec.js
@@ -1,0 +1,105 @@
+import { defineComponent, nextTick } from 'vue'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+
+import AIDatabaseOnboardingForm from '@baserow_enterprise/components/onboarding/AIDatabaseOnboardingForm'
+import { AIDatabaseOnboardingStepType } from '@baserow_enterprise/databaseOnboardingStepTypes'
+
+const FormGroupStub = defineComponent({
+  name: 'FormGroup',
+  props: { label: { type: String, default: '' } },
+  template: '<div class="form-group-stub" :data-label="label"><slot /></div>',
+})
+
+const FormInputStub = defineComponent({
+  name: 'FormInput',
+  props: { modelValue: { type: String, default: '' } },
+  emits: ['update:modelValue', 'input'],
+  methods: { focus() {} },
+  template:
+    '<input class="form-input-stub" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value); $emit(\'input\', $event)" />',
+})
+
+async function mountComponent() {
+  return await mountSuspended(AIDatabaseOnboardingForm, {
+    global: {
+      stubs: {
+        FormGroup: FormGroupStub,
+        FormInput: FormInputStub,
+      },
+      mocks: { $t: (key) => key },
+    },
+  })
+}
+
+const label = (wrapper) =>
+  wrapper.find('.form-group-stub').attributes('data-label')
+
+const answer = async (wrapper, value) => {
+  await wrapper.find('.form-input-stub').setValue(value)
+  await nextTick()
+}
+
+const stepType = new AIDatabaseOnboardingStepType({})
+
+describe('AI database onboarding form', () => {
+  test('asks the two questions one by one before moving on', async () => {
+    const wrapper = await mountComponent()
+
+    expect(label(wrapper)).toBe('aiDatabaseOnboardingForm.industryLabel')
+    await answer(wrapper, 'Marketing')
+    expect(wrapper.vm.beforeNext()).toBe(true)
+    await nextTick()
+
+    expect(label(wrapper)).toBe('aiDatabaseOnboardingForm.teamLabel')
+    await answer(wrapper, 'Client services')
+
+    // The last question hands control back so the onboarding branches to the
+    // prompt step.
+    expect(wrapper.vm.beforeNext()).toBe(false)
+    const emitted = wrapper.emitted('input').at(-1)[0]
+    expect(emitted).toMatchObject({
+      industry: 'Marketing',
+      team: 'Client services',
+    })
+  })
+
+  test('the continue button stays disabled until the question is answered', async () => {
+    const wrapper = await mountComponent()
+
+    expect(wrapper.vm.isValid()).toBe(false)
+    await answer(wrapper, '  ')
+    expect(wrapper.vm.isValid()).toBe(false)
+    await answer(wrapper, 'Acme')
+    expect(wrapper.vm.isValid()).toBe(true)
+  })
+
+  test('the onboarding back button moves between the questions', async () => {
+    const wrapper = await mountComponent()
+
+    // The first question is the start, so the onboarding itself decides whether
+    // there is anything to go back to.
+    expect(wrapper.vm.canGoBack()).toBe(false)
+
+    await answer(wrapper, 'Marketing')
+    wrapper.vm.beforeNext()
+    await nextTick()
+
+    expect(wrapper.vm.canGoBack()).toBe(true)
+    wrapper.vm.goBack()
+    await nextTick()
+
+    expect(label(wrapper)).toBe('aiDatabaseOnboardingForm.industryLabel')
+    expect(wrapper.find('.form-input-stub').element.value).toBe('Marketing')
+  })
+
+  test('reports invalid while the ref still points at another tab', () => {
+    // Switching tabs renders us once while `stepComponent` is still the form of
+    // the previously selected type, which has no `isValid`.
+    const otherTabsForm = { $props: {} }
+
+    expect(stepType.isValid({}, null, { stepComponent: otherTabsForm })).toBe(
+      false
+    )
+    expect(stepType.isValid({}, null, {})).toBe(false)
+  })
+})

--- a/enterprise/web-frontend/test/unit/enterprise/onboarding/aiDatabaseOnboardingForm.spec.js
+++ b/enterprise/web-frontend/test/unit/enterprise/onboarding/aiDatabaseOnboardingForm.spec.js
@@ -10,25 +10,43 @@ const FormGroupStub = defineComponent({
   template: '<div class="form-group-stub" :data-label="label"><slot /></div>',
 })
 
+let focused = null
+
 const FormInputStub = defineComponent({
   name: 'FormInput',
-  props: { modelValue: { type: String, default: '' } },
+  props: {
+    modelValue: { type: String, default: '' },
+    placeholder: { type: String, default: '' },
+  },
   emits: ['update:modelValue', 'input'],
-  methods: { focus() {} },
+  methods: {
+    focus() {
+      focused = this.placeholder
+    },
+  },
   template:
     '<input class="form-input-stub" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value); $emit(\'input\', $event)" />',
 })
 
-async function mountComponent() {
+async function mountComponent(stubs = {}) {
+  focused = null
   return await mountSuspended(AIDatabaseOnboardingForm, {
     global: {
       stubs: {
         FormGroup: FormGroupStub,
         FormInput: FormInputStub,
+        ...stubs,
       },
       mocks: { $t: (key) => key },
     },
   })
+}
+
+// The questions fade in and out, so the next one is only in the DOM after the
+// transition has run.
+const flushTransition = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  await nextTick()
 }
 
 const label = (wrapper) =>
@@ -90,6 +108,19 @@ describe('AI database onboarding form', () => {
 
     expect(label(wrapper)).toBe('aiDatabaseOnboardingForm.industryLabel')
     expect(wrapper.find('.form-input-stub').element.value).toBe('Marketing')
+  })
+
+  test('the next question is faded in and gets the focus', async () => {
+    const wrapper = await mountComponent({ transition: false })
+    await flushTransition()
+    expect(focused).toBe('aiDatabaseOnboardingForm.industryPlaceholder')
+
+    await answer(wrapper, 'Marketing')
+    wrapper.vm.beforeNext()
+    await flushTransition()
+
+    expect(label(wrapper)).toBe('aiDatabaseOnboardingForm.teamLabel')
+    expect(focused).toBe('aiDatabaseOnboardingForm.teamPlaceholder')
   })
 
   test('reports invalid while the ref still points at another tab', () => {

--- a/enterprise/web-frontend/test/unit/enterprise/onboarding/aiPromptStep.spec.js
+++ b/enterprise/web-frontend/test/unit/enterprise/onboarding/aiPromptStep.spec.js
@@ -27,7 +27,9 @@ const FormTextareaStub = defineComponent({
 
 const ButtonTextStub = defineComponent({
   name: 'ButtonText',
-  template: '<a class="button-text-stub"><slot /></a>',
+  props: { disabled: { type: Boolean, default: false } },
+  template:
+    '<button class="button-text-stub" :disabled="disabled"><slot /></button>',
 })
 
 const DetailsModalStub = defineComponent({
@@ -35,6 +37,28 @@ const DetailsModalStub = defineComponent({
   methods: { show() {} },
   template: '<div />',
 })
+
+const ErrorStub = defineComponent({
+  name: 'Error',
+  props: { error: { type: Object, required: true } },
+  template:
+    '<div v-if="error.visible" class="error-stub">{{ error.title }} {{ error.message }}</div>',
+})
+
+// Mimics what the client adds to a failed request, so the component can look up
+// the message that belongs to the error code.
+const apiError = (code) => {
+  const error = new Error(code)
+  error.handler = {
+    getMessage: (name, specificErrorMap) =>
+      specificErrorMap?.[code] || {
+        title: 'Something went wrong',
+        message: 'Something went wrong',
+      },
+    handled: () => {},
+  }
+  return error
+}
 
 const suggestions = [
   { name: 'Client projects', prompt: 'Track client projects for Acme.' },
@@ -59,6 +83,7 @@ const globalOptions = {
     FormTextarea: FormTextareaStub,
     ButtonText: ButtonTextStub,
     AIOnboardingDetailsModal: DetailsModalStub,
+    Error: ErrorStub,
   },
   mocks: { $t: (key) => key, $i18n: { locale: 'en' } },
 }
@@ -132,6 +157,21 @@ describe('AI prompt step', () => {
       industry: 'Marketing',
       team: 'Client services',
     })
+  })
+
+  test('the details cannot be changed while the suggestions load', async () => {
+    AssistantService.mockReturnValue({
+      fetchOnboardingPromptSuggestions: vi
+        .fn()
+        .mockReturnValue(new Promise(() => {})),
+    })
+
+    const wrapper = await mountComponent()
+    await nextTick()
+
+    expect(
+      wrapper.find('.button-text-stub').attributes('disabled')
+    ).toBeDefined()
   })
 
   test('changed details are part of the data of the step', async () => {
@@ -257,19 +297,62 @@ describe('AI prompt step', () => {
     )
   })
 
-  test('falls back to the static examples when the request fails', async () => {
+  test('explains that the model is unavailable and blocks continuing', async () => {
     AssistantService.mockReturnValue({
       fetchOnboardingPromptSuggestions: vi
         .fn()
-        .mockRejectedValue(new Error('nope')),
+        .mockRejectedValue(apiError('ERROR_ASSISTANT_MODEL_NOT_SUPPORTED')),
     })
 
     const wrapper = await mountComponent()
     await flushPromises()
 
-    // The step is never left empty, and the user can still write their own.
-    expect(wrapper.findAll('.ai-prompt-suggestion--skeleton')).toHaveLength(0)
-    expect(wrapper.findAll('.ai-prompt-suggestion')).toHaveLength(4)
-    expect(wrapper.find('.form-textarea-stub').element.value).toBe('')
+    expect(wrapper.find('.error-stub').text()).toContain(
+      'aiPromptStep.modelNotSupportedTitle'
+    )
+    // Kuma can't build the database either, so there is nothing to fill out.
+    expect(wrapper.find('.form-textarea-stub').exists()).toBe(false)
+    expect(wrapper.findAll('.ai-prompt-suggestion')).toHaveLength(0)
+    expect(wrapper.vm.isValid()).toBe(false)
+  })
+
+  test('shows the generic error for any other failure', async () => {
+    AssistantService.mockReturnValue({
+      fetchOnboardingPromptSuggestions: vi
+        .fn()
+        .mockRejectedValue(apiError('ERROR_SOMETHING_ELSE')),
+    })
+
+    const wrapper = await mountComponent()
+    await flushPromises()
+
+    expect(wrapper.find('.error-stub').text()).toContain('Something went wrong')
+    expect(wrapper.find('.form-textarea-stub').exists()).toBe(false)
+  })
+
+  test('the error disappears when the suggestions can be fetched again', async () => {
+    AssistantService.mockReturnValue({
+      fetchOnboardingPromptSuggestions: vi
+        .fn()
+        .mockRejectedValue(apiError('ERROR_ASSISTANT_MODEL_NOT_SUPPORTED')),
+    })
+
+    const wrapper = await mountComponent()
+    await flushPromises()
+    expect(wrapper.find('.error-stub').exists()).toBe(true)
+
+    AssistantService.mockReturnValue({
+      fetchOnboardingPromptSuggestions: vi.fn().mockResolvedValue(suggestions),
+    })
+    wrapper.findComponent(DetailsModalStub).vm.$emit('updated', {
+      industry: 'Retail',
+      team: 'Sales',
+    })
+    await flushPromises()
+
+    expect(wrapper.find('.error-stub').exists()).toBe(false)
+    expect(wrapper.find('.form-textarea-stub').element.value).toBe(
+      suggestions[0].prompt
+    )
   })
 })

--- a/enterprise/web-frontend/test/unit/enterprise/onboarding/aiPromptStep.spec.js
+++ b/enterprise/web-frontend/test/unit/enterprise/onboarding/aiPromptStep.spec.js
@@ -41,27 +41,50 @@ const suggestions = [
   { name: 'Content calendar', prompt: 'Plan and schedule social posts.' },
 ]
 
+// The onboarding keeps the steps alive, so leaving and coming back to the step must
+// be tested the same way.
+const KeepAliveHost = defineComponent({
+  components: { AIPromptStep },
+  props: {
+    data: { type: Object, required: true },
+    visible: { type: Boolean, default: true },
+  },
+  template:
+    '<KeepAlive><AIPromptStep v-if="visible" :data="data" /></KeepAlive>',
+})
+
+const globalOptions = {
+  stubs: {
+    FormGroup: FormGroupStub,
+    FormTextarea: FormTextareaStub,
+    ButtonText: ButtonTextStub,
+    AIOnboardingDetailsModal: DetailsModalStub,
+  },
+  mocks: { $t: (key) => key, $i18n: { locale: 'en' } },
+}
+
+function onboardingData(database = {}) {
+  return {
+    database: {
+      type: 'ai',
+      industry: 'Marketing',
+      team: 'Client services',
+      ...database,
+    },
+  }
+}
+
 async function mountComponent(database = {}) {
   return await mountSuspended(AIPromptStep, {
-    props: {
-      data: {
-        database: {
-          type: 'ai',
-          industry: 'Marketing',
-          team: 'Client services',
-          ...database,
-        },
-      },
-    },
-    global: {
-      stubs: {
-        FormGroup: FormGroupStub,
-        FormTextarea: FormTextareaStub,
-        ButtonText: ButtonTextStub,
-        AIOnboardingDetailsModal: DetailsModalStub,
-      },
-      mocks: { $t: (key) => key, $i18n: { locale: 'en' } },
-    },
+    props: { data: onboardingData(database) },
+    global: globalOptions,
+  })
+}
+
+async function mountKeptAlive() {
+  return await mountSuspended(KeepAliveHost, {
+    props: { data: onboardingData() },
+    global: globalOptions,
   })
 }
 
@@ -106,7 +129,69 @@ describe('AI prompt step', () => {
     expect(wrapper.emitted('update-data').at(-1)[0]).toEqual({
       prompt: suggestions[1].prompt,
       language: 'en',
+      industry: 'Marketing',
+      team: 'Client services',
     })
+  })
+
+  test('changed details are part of the data of the step', async () => {
+    const wrapper = await mountComponent()
+    await flushPromises()
+
+    wrapper.findComponent(DetailsModalStub).vm.$emit('updated', {
+      industry: 'Retail',
+      team: 'Sales',
+    })
+    await flushPromises()
+
+    expect(wrapper.emitted('update-data').at(-1)[0]).toEqual(
+      expect.objectContaining({ industry: 'Retail', team: 'Sales' })
+    )
+  })
+
+  test('changed details survive leaving and coming back to the step', async () => {
+    const host = await mountKeptAlive()
+    await flushPromises()
+
+    host.findComponent(DetailsModalStub).vm.$emit('updated', {
+      industry: 'Retail',
+      team: 'Sales',
+    })
+    await flushPromises()
+
+    await host.setProps({ visible: false })
+    await host.setProps({ visible: true })
+    await flushPromises()
+
+    expect(
+      host.findComponent(AIPromptStep).emitted('update-data').at(-1)[0]
+    ).toEqual(expect.objectContaining({ industry: 'Retail', team: 'Sales' }))
+  })
+
+  test('changing the earlier answers replaces the details', async () => {
+    const host = await mountKeptAlive()
+    await flushPromises()
+
+    host.findComponent(DetailsModalStub).vm.$emit('updated', {
+      industry: 'Retail',
+      team: 'Sales',
+    })
+    await flushPromises()
+
+    await host.setProps({ visible: false })
+    await host.setProps({
+      visible: true,
+      data: {
+        database: { type: 'ai', industry: 'Hotels', team: 'Front desk' },
+      },
+    })
+    await flushPromises()
+
+    expect(
+      host.findComponent(AIPromptStep).emitted('update-data').at(-1)[0]
+    ).toEqual(
+      expect.objectContaining({ industry: 'Hotels', team: 'Front desk' })
+    )
   })
 
   test('a hand written prompt survives regenerating the suggestions', async () => {

--- a/enterprise/web-frontend/test/unit/enterprise/onboarding/aiPromptStep.spec.js
+++ b/enterprise/web-frontend/test/unit/enterprise/onboarding/aiPromptStep.spec.js
@@ -1,0 +1,190 @@
+import { defineComponent, nextTick } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+
+import AIPromptStep from '@baserow_enterprise/components/onboarding/AIPromptStep'
+import AssistantService from '@baserow_enterprise/services/assistant'
+
+vi.mock('@baserow_enterprise/services/assistant', () => ({
+  default: vi.fn(),
+}))
+
+vi.mock('@baserow/modules/core/utils/error', () => ({ notifyIf: vi.fn() }))
+
+const FormGroupStub = defineComponent({
+  name: 'FormGroup',
+  template: '<div class="form-group-stub"><slot /></div>',
+})
+
+const FormTextareaStub = defineComponent({
+  name: 'FormTextarea',
+  props: { modelValue: { type: String, default: '' } },
+  emits: ['update:modelValue', 'input'],
+  methods: { focus() {} },
+  template:
+    '<textarea class="form-textarea-stub" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value); $emit(\'input\', $event)" />',
+})
+
+const ButtonTextStub = defineComponent({
+  name: 'ButtonText',
+  template: '<a class="button-text-stub"><slot /></a>',
+})
+
+const DetailsModalStub = defineComponent({
+  name: 'AIOnboardingDetailsModal',
+  methods: { show() {} },
+  template: '<div />',
+})
+
+const suggestions = [
+  { name: 'Client projects', prompt: 'Track client projects for Acme.' },
+  { name: 'Content calendar', prompt: 'Plan and schedule social posts.' },
+]
+
+async function mountComponent(database = {}) {
+  return await mountSuspended(AIPromptStep, {
+    props: {
+      data: {
+        database: {
+          type: 'ai',
+          industry: 'Marketing',
+          team: 'Client services',
+          ...database,
+        },
+      },
+    },
+    global: {
+      stubs: {
+        FormGroup: FormGroupStub,
+        FormTextarea: FormTextareaStub,
+        ButtonText: ButtonTextStub,
+        AIOnboardingDetailsModal: DetailsModalStub,
+      },
+      mocks: { $t: (key) => key, $i18n: { locale: 'en' } },
+    },
+  })
+}
+
+describe('AI prompt step', () => {
+  beforeEach(() => {
+    AssistantService.mockReturnValue({
+      fetchOnboardingPromptSuggestions: vi.fn().mockResolvedValue(suggestions),
+    })
+  })
+
+  test('prefills the first suggestion and lists them all', async () => {
+    const wrapper = await mountComponent()
+    await nextTick()
+    await nextTick()
+
+    expect(wrapper.find('.form-textarea-stub').element.value).toBe(
+      suggestions[0].prompt
+    )
+
+    const cards = wrapper.findAll('.ai-prompt-suggestion')
+    expect(cards).toHaveLength(2)
+    expect(cards.at(0).classes()).toContain('ai-prompt-suggestion--active')
+    expect(cards.at(0).find('.ai-prompt-suggestion__name').text()).toBe(
+      'Client projects'
+    )
+    expect(cards.at(0).find('.ai-prompt-suggestion__preview').text()).toBe(
+      suggestions[0].prompt
+    )
+  })
+
+  test('clicking a suggestion sets it as the prompt', async () => {
+    const wrapper = await mountComponent()
+    await nextTick()
+    await nextTick()
+
+    await wrapper.findAll('.ai-prompt-suggestion').at(1).trigger('click')
+    await nextTick()
+
+    expect(wrapper.find('.form-textarea-stub').element.value).toBe(
+      suggestions[1].prompt
+    )
+    expect(wrapper.emitted('update-data').at(-1)[0]).toEqual({
+      prompt: suggestions[1].prompt,
+      language: 'en',
+    })
+  })
+
+  test('a hand written prompt survives regenerating the suggestions', async () => {
+    const wrapper = await mountComponent()
+    await nextTick()
+    await nextTick()
+
+    await wrapper.find('.form-textarea-stub').setValue('My own prompt')
+    await nextTick()
+
+    const fetch = vi
+      .fn()
+      .mockResolvedValue([
+        { name: 'Something else', prompt: 'A brand new suggestion.' },
+      ])
+    AssistantService.mockReturnValue({
+      fetchOnboardingPromptSuggestions: fetch,
+    })
+
+    wrapper.findComponent(DetailsModalStub).vm.$emit('updated', {
+      industry: 'Retail',
+      team: 'Sales',
+    })
+    await flushPromises()
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.objectContaining({ industry: 'Retail', team: 'Sales' })
+    )
+    expect(wrapper.find('.form-textarea-stub').element.value).toBe(
+      'My own prompt'
+    )
+    expect(wrapper.find('.ai-prompt-suggestion__name').text()).toBe(
+      'Something else'
+    )
+  })
+
+  test('a picked suggestion is replaced when the suggestions regenerate', async () => {
+    const wrapper = await mountComponent()
+    await flushPromises()
+
+    await wrapper.findAll('.ai-prompt-suggestion').at(1).trigger('click')
+    await nextTick()
+    expect(wrapper.find('.form-textarea-stub').element.value).toBe(
+      suggestions[1].prompt
+    )
+
+    AssistantService.mockReturnValue({
+      fetchOnboardingPromptSuggestions: vi
+        .fn()
+        .mockResolvedValue([
+          { name: 'Something else', prompt: 'A brand new suggestion.' },
+        ]),
+    })
+
+    wrapper.findComponent(DetailsModalStub).vm.$emit('updated', {
+      industry: 'Retail',
+      team: 'Sales',
+    })
+    await flushPromises()
+
+    expect(wrapper.find('.form-textarea-stub').element.value).toBe(
+      'A brand new suggestion.'
+    )
+  })
+
+  test('falls back to the static examples when the request fails', async () => {
+    AssistantService.mockReturnValue({
+      fetchOnboardingPromptSuggestions: vi
+        .fn()
+        .mockRejectedValue(new Error('nope')),
+    })
+
+    const wrapper = await mountComponent()
+    await flushPromises()
+
+    // The step is never left empty, and the user can still write their own.
+    expect(wrapper.findAll('.ai-prompt-suggestion--skeleton')).toHaveLength(0)
+    expect(wrapper.findAll('.ai-prompt-suggestion')).toHaveLength(4)
+    expect(wrapper.find('.form-textarea-stub').element.value).toBe('')
+  })
+})

--- a/web-frontend/modules/core/assets/scss/components/onboarding.scss
+++ b/web-frontend/modules/core/assets/scss/components/onboarding.scss
@@ -78,12 +78,16 @@
 
 .onboarding__body {
   height: 100%;
-  margin: 40px auto 0;
+  margin: 0 auto;
   max-width: 542px;
   padding: 0 40px;
   width: 100%;
   display: flex;
   flex-direction: column;
+}
+
+.onboarding__back {
+  margin-bottom: 16px;
 }
 
 .onboarding__actions {

--- a/web-frontend/modules/core/components/FormInput.vue
+++ b/web-frontend/modules/core/components/FormInput.vue
@@ -40,6 +40,7 @@
         :placeholder="placeholder"
         :required="required"
         :autocomplete="autocomplete"
+        :maxlength="maxlength"
         @blur="onBlur"
         @click="$emit('click', $event)"
         @focus="$emit('focus', $event)"
@@ -101,6 +102,7 @@ const props = defineProps({
   required: Boolean,
   removeNumberInputControls: Boolean,
   autocomplete: { type: String, default: '' },
+  maxlength: { type: Number, default: null },
   min: { type: Number, default: -1 },
   max: { type: Number, default: -1 },
   step: { type: Number, default: -1 },

--- a/web-frontend/modules/core/components/onboarding/MoreStep.vue
+++ b/web-frontend/modules/core/components/onboarding/MoreStep.vue
@@ -100,13 +100,16 @@ export default {
     /**
      * An earlier step can already have asked which team the user is on, like the
      * AI one does. We don't want to ask that twice, so their answer is used as is.
+     * The answer of the last step wins because that's the one the user could have
+     * corrected most recently.
      */
     prefilledTeam() {
       return (
         Object.entries(this.data)
           .filter(([type]) => type !== MoreOnboardingType.getType())
           .map(([, stepData]) => stepData?.team)
-          .find((team) => team) || ''
+          .filter((team) => team)
+          .pop() || ''
       )
     },
     chosenTeam() {
@@ -152,7 +155,7 @@ export default {
     how() {
       this.updateValue()
     },
-    team() {
+    chosenTeam() {
       this.updateValue()
     },
     country() {

--- a/web-frontend/modules/core/components/onboarding/MoreStep.vue
+++ b/web-frontend/modules/core/components/onboarding/MoreStep.vue
@@ -23,6 +23,7 @@
       </Dropdown>
     </FormGroup>
     <FormGroup
+      v-if="!prefilledTeam"
       :label="$t('teamStep.description')"
       :error="v$.team.$error"
       required
@@ -73,9 +74,16 @@
 import { useVuelidate } from '@vuelidate/core'
 import { required, helpers } from '@vuelidate/validators'
 import { countryList } from '@baserow/modules/core/utils/countries'
+import { MoreOnboardingType } from '@baserow/modules/core/onboardingTypes'
 
 export default {
   name: 'MoreStep',
+  props: {
+    data: {
+      type: Object,
+      required: true,
+    },
+  },
   emits: ['update-data'],
   setup() {
     return { v$: useVuelidate({ $lazy: true }) }
@@ -89,6 +97,21 @@ export default {
     }
   },
   computed: {
+    /**
+     * An earlier step can already have asked which team the user is on, like the
+     * AI one does. We don't want to ask that twice, so their answer is used as is.
+     */
+    prefilledTeam() {
+      return (
+        Object.entries(this.data)
+          .filter(([type]) => type !== MoreOnboardingType.getType())
+          .map(([, stepData]) => stepData?.team)
+          .find((team) => team) || ''
+      )
+    },
+    chosenTeam() {
+      return this.prefilledTeam || this.team
+    },
     hows() {
       return [
         this.$t('moreStep.howSearchEngine'),
@@ -146,24 +169,27 @@ export default {
     updateValue() {
       this.$emit('update-data', {
         how: this.how,
-        team: this.team,
+        team: this.chosenTeam,
         country: this.country,
         share: this.share,
       })
     },
   },
   validations() {
-    return {
+    const rules = {
       how: {
-        required: helpers.withMessage(this.$t('error.requiredField'), required),
-      },
-      team: {
         required: helpers.withMessage(this.$t('error.requiredField'), required),
       },
       country: {
         required: helpers.withMessage(this.$t('error.requiredField'), required),
       },
     }
+    if (!this.prefilledTeam) {
+      rules.team = {
+        required: helpers.withMessage(this.$t('error.requiredField'), required),
+      }
+    }
+    return rules
   },
 }
 </script>

--- a/web-frontend/modules/core/locales/en.json
+++ b/web-frontend/modules/core/locales/en.json
@@ -970,6 +970,7 @@
     "title": "Onboarding",
     "creating": "Creating your first workspace",
     "continue": "Continue",
+    "back": "Back",
     "skip": "Skip for now",
     "cancel": "I don't want help setting up",
     "failedTitle": "Something went wrong",

--- a/web-frontend/modules/core/onboardingTypes.js
+++ b/web-frontend/modules/core/onboardingTypes.js
@@ -19,6 +19,18 @@ export class OnboardingType extends Registerable {
    * where the user must make a choice. It must contain a method called `isValid`.
    * If `true` is returned, then the user can click on the continue button. It can
    * $emit the `update-data` event to
+   *
+   * It can optionally implement `beforeNext`, which is called when the user clicks
+   * on the continue button. Returning `true` means the component handled the click
+   * itself, and the onboarding must stay on this step. It can also $emit the
+   * `next-step` event to move on without the user clicking continue.
+   *
+   * A component that asks several questions in a row can implement `canGoBack` and
+   * `goBack` to make the back button move between its own questions instead of
+   * going to the previous step.
+   *
+   * Note that the components are kept alive, so `mounted` is only called once. Use
+   * the `activated` hook to react to becoming visible again.
    */
   getFormComponent() {
     throw new Error('getFormComponent is not implemented')

--- a/web-frontend/modules/core/pages/onboarding.vue
+++ b/web-frontend/modules/core/pages/onboarding.vue
@@ -54,12 +54,29 @@
         <div ref="bodyWrapper" class="onboarding__body-wrapper">
           <div class="onboarding__body">
             <div>
-              <component
-                :is="step.getFormComponent()"
-                ref="form"
-                :data="data"
-                @update-data="updateData"
-              ></component>
+              <div class="onboarding__back">
+                <ButtonText
+                  :ph-autocapture="'onboarding-back-step-' + step.getType()"
+                  tag="a"
+                  icon="iconoir-nav-arrow-left"
+                  :disabled="!canGoBack()"
+                  @click="previous()"
+                  >{{ $t('onboarding.back') }}</ButtonText
+                >
+              </div>
+              <!--
+              The steps are kept alive so that going back doesn't throw away what the
+              user already filled out.
+              -->
+              <KeepAlive>
+                <component
+                  :is="step.getFormComponent()"
+                  ref="form"
+                  :data="data"
+                  @update-data="updateData"
+                  @next-step="goToNextStep"
+                ></component>
+              </KeepAlive>
             </div>
             <div class="onboarding__actions">
               <Button
@@ -170,18 +187,57 @@ export default {
   },
   methods: {
     /**
-     * Called when the user wants to go to the user step. This means that the provided
-     * form values must be valid. If the onboarding reached the end, it should
-     * automatically complete it.
+     * Called when the user clicks on the continue button. A form component can
+     * handle that click itself by implementing `beforeNext` and returning `true`,
+     * which is needed when it asks several questions in a row.
      */
     async next() {
+      if (this.$refs.form?.beforeNext?.() === true) {
+        return
+      }
+      await this.goToNextStep()
+    },
+    /**
+     * Called when the user clicks on the back button. A form component that walks
+     * through several questions itself handles the click by implementing
+     * `canGoBack` and `goBack`.
+     */
+    previous() {
+      // A disabled anchor still fires a click, so the guard has to be here too.
+      if (!this.canGoBack()) {
+        return
+      }
+      if (this.$refs.form?.canGoBack?.() === true) {
+        this.$refs.form.goBack()
+      } else {
+        this.stepIndex--
+        this.afterStepChange()
+      }
+    },
+    /**
+     * `isValid` and `canGoBack` read from the step's component, which is only
+     * available in `$refs` after it has rendered. Steps are kept alive, so there is
+     * no `mounted` that emits data and re-renders us, and we must do it ourselves.
+     */
+    afterStepChange() {
+      this.$nextTick(() => {
+        this.$refs.bodyWrapper.scrollTop = 0
+        this.$forceUpdate()
+      })
+    },
+    canGoBack() {
+      return this.stepIndex > 0 || this.$refs.form?.canGoBack?.() === true
+    },
+    /**
+     * Moves to the next step. If the onboarding reached the end, it should
+     * automatically complete it.
+     */
+    async goToNextStep() {
       if (this.stepIndex === this.steps.length - 1) {
         await this.complete()
       } else {
         this.stepIndex++
-        this.$nextTick(() => {
-          this.$refs.bodyWrapper.scrollTop = 0
-        })
+        this.afterStepChange()
       }
     },
     /**
@@ -192,7 +248,7 @@ export default {
       // If the step is skipped, we don't want to store any left over data of the form
       // because that can influence what happens when completing.
       delete this.data[this.step.getType()]
-      await this.next()
+      await this.goToNextStep()
     },
     /**
      * Called when all the steps have been filled out. It will start the process off

--- a/web-frontend/modules/core/pages/onboarding.vue
+++ b/web-frontend/modules/core/pages/onboarding.vue
@@ -57,7 +57,6 @@
               <div class="onboarding__back">
                 <ButtonText
                   :ph-autocapture="'onboarding-back-step-' + step.getType()"
-                  tag="a"
                   icon="iconoir-nav-arrow-left"
                   :disabled="!canGoBack()"
                   @click="previous()"
@@ -184,6 +183,12 @@ export default {
     canSkip() {
       return this.step.canSkip()
     },
+    updateData() {
+      const type = this.step.getType()
+      return (data) => {
+        this.data = { ...this.data, [type]: data }
+      }
+    },
   },
   methods: {
     /**
@@ -203,10 +208,6 @@ export default {
      * `canGoBack` and `goBack`.
      */
     previous() {
-      // A disabled anchor still fires a click, so the guard has to be here too.
-      if (!this.canGoBack()) {
-        return
-      }
       if (this.$refs.form?.canGoBack?.() === true) {
         this.$refs.form.goBack()
       } else {
@@ -408,9 +409,6 @@ export default {
       await this.$store.dispatch('workspace/clearAll')
       await this.$store.dispatch('application/clearAll')
       this.$router.push({ name: 'dashboard' })
-    },
-    updateData(data) {
-      this.data = { ...this.data, [this.step.getType()]: data }
     },
     isValid() {
       const form = this.$refs?.form

--- a/web-frontend/modules/database/components/onboarding/DatabaseStep.vue
+++ b/web-frontend/modules/database/components/onboarding/DatabaseStep.vue
@@ -37,6 +37,7 @@
       ref="stepComponent"
       @input="updateValue($event)"
       @selected-template="selectedTemplate"
+      @next-step="$emit('next-step')"
     ></component>
   </div>
 </template>
@@ -55,7 +56,7 @@ export default {
       type: Object,
     },
   },
-  emits: ['update-data'],
+  emits: ['update-data', 'next-step'],
   setup() {
     return { v$: useVuelidate({ $lazy: true }) }
   },
@@ -116,6 +117,15 @@ export default {
   methods: {
     isValid() {
       return this.selectedStepType.isValid(this.data, this.v$, this.$refs)
+    },
+    beforeNext() {
+      return this.$refs.stepComponent?.beforeNext?.() === true
+    },
+    canGoBack() {
+      return this.$refs.stepComponent?.canGoBack?.() === true
+    },
+    goBack() {
+      this.$refs.stepComponent.goBack()
     },
     updateValue(params = {}) {
       this.$nextTick(() => {

--- a/web-frontend/test/unit/core/components/onboarding/moreStep.spec.js
+++ b/web-frontend/test/unit/core/components/onboarding/moreStep.spec.js
@@ -64,6 +64,23 @@ describe('More onboarding step', () => {
     )
   })
 
+  test('follows the earlier answer when it changes', async () => {
+    const wrapper = await mountComponent({
+      database: { type: 'ai', team: 'Client services' },
+    })
+    await nextTick()
+
+    await wrapper.setProps({
+      data: {
+        database: { type: 'ai', team: 'Client services' },
+        ai_prompt: { team: 'Sales' },
+      },
+    })
+    await nextTick()
+
+    expect(wrapper.emitted('update-data').at(-1)[0].team).toBe('Sales')
+  })
+
   test('does not treat its own answer as an earlier one', async () => {
     const wrapper = await mountComponent({ more: { team: 'Marketing' } })
     await nextTick()

--- a/web-frontend/test/unit/core/components/onboarding/moreStep.spec.js
+++ b/web-frontend/test/unit/core/components/onboarding/moreStep.spec.js
@@ -1,0 +1,73 @@
+import { defineComponent, nextTick } from 'vue'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+
+import MoreStep from '@baserow/modules/core/components/onboarding/MoreStep'
+
+const FormGroupStub = defineComponent({
+  name: 'FormGroup',
+  props: { label: { type: String, default: '' } },
+  template: '<div class="form-group-stub" :data-label="label"><slot /></div>',
+})
+
+const DropdownStub = defineComponent({
+  name: 'Dropdown',
+  props: { modelValue: { type: String, default: '' } },
+  template: '<div class="dropdown-stub"><slot /></div>',
+})
+
+const DropdownItemStub = defineComponent({
+  name: 'DropdownItem',
+  template: '<div />',
+})
+
+const CheckboxStub = defineComponent({
+  name: 'Checkbox',
+  template: '<div />',
+})
+
+async function mountComponent(data) {
+  return await mountSuspended(MoreStep, {
+    props: { data },
+    global: {
+      stubs: {
+        FormGroup: FormGroupStub,
+        Dropdown: DropdownStub,
+        DropdownItem: DropdownItemStub,
+        Checkbox: CheckboxStub,
+      },
+      mocks: { $t: (key) => key },
+    },
+  })
+}
+
+const labels = (wrapper) =>
+  wrapper.findAll('.form-group-stub').map((g) => g.attributes('data-label'))
+
+describe('More onboarding step', () => {
+  test('asks for the team when no earlier step collected one', async () => {
+    const wrapper = await mountComponent({})
+    await nextTick()
+
+    expect(labels(wrapper)).toContain('teamStep.description')
+    expect(wrapper.emitted('update-data').at(-1)[0].team).toBe('')
+  })
+
+  test('skips the team question and reuses the earlier answer', async () => {
+    const wrapper = await mountComponent({
+      database: { type: 'ai', team: 'Client services' },
+    })
+    await nextTick()
+
+    expect(labels(wrapper)).not.toContain('teamStep.description')
+    expect(wrapper.emitted('update-data').at(-1)[0].team).toBe(
+      'Client services'
+    )
+  })
+
+  test('does not treat its own answer as an earlier one', async () => {
+    const wrapper = await mountComponent({ more: { team: 'Marketing' } })
+    await nextTick()
+
+    expect(labels(wrapper)).toContain('teamStep.description')
+  })
+})


### PR DESCRIPTION
### What is in this PR

This PR makes the onboarding via Kuma a bit easier. It will first ask for your industry and team. Based on that it suggests a couple of prompts that could be useful for the user. The user can of course make changes to the prompt and then let Kuma build the database.

It also introduces a back button. A small thing that I was annoyed by myself is that you can't go back. If I choose the "From scratch" part to check it out, then I can now go back to the start and follow a different path.

https://github.com/user-attachments/assets/d469e3d2-c7fb-4d00-8306-edd84ff1d055


https://github.com/user-attachments/assets/af1b9075-93be-4281-80d6-e3f227551955


### How to test this PR

- Follow a couple of steps and use the back button. Confirm that you're back to the correct steps.
- When choosing the Kuma AI path, then observe that no team question is asked in the last step. This is because it has already been provided ealier. The raw team text value provided in the Kuma AI step should be used.
- Confirm that all other paths (file import, airtable import, template, etc) still work.
- Using the Kuma AI path, confirm that a correct prompt suggestions are given based on the input.
- Use the "Change details" button to change the industry and team and observe that the suggestions are reloaded. Only the main prompt input should not change if you've made changes in the text input.
- Confirm that if a different language is chosen that the suggestions and final database is in that language. It should work, but also depends on translated prompts to give the correct output. That has not yet been done.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
