### PR TITLE
fix(database): use rich clipboard data and fix format tokens for date paste

### DIFF
--- a/changelog/entries/unreleased/bug/5870_fixed_date_copypaste_between_usformat_fields_silently_swappi.json
+++ b/changelog/entries/unreleased/bug/5870_fixed_date_copypaste_between_usformat_fields_silently_swappi.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed date copy-paste between US-format fields silently swapping month and day for ambiguous dates.",
+    "issue_origin": "github",
+    "issue_number": 5870,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-10"
+}

--- a/web-frontend/modules/database/fieldTypes.js
+++ b/web-frontend/modules/database/fieldTypes.js
@@ -2559,6 +2559,12 @@ class BaseDateFieldType extends FieldType {
    * correct format for the field. If it can't be parsed null is returned.
    */
   prepareValueForPaste(field, clipboardData, richClipboardData) {
+    if (richClipboardData) {
+      const richDateValue = this.parseInputValue(field, richClipboardData)
+      if (richDateValue) {
+        return this.formatValue(field, richDateValue)
+      }
+    }
     const dateValue = this.parseInputValue(field, clipboardData || '')
     return this.formatValue(field, dateValue)
   }
@@ -2585,11 +2591,15 @@ class BaseDateFieldType extends FieldType {
     const s = containsDash ? '-' : '/'
 
     const usFieldFormats = getDateTimeFormatsFor(
+      `MM${s}DD${s}YYYY`,
       `M${s}D${s}YYYY`,
+      `YYYY${s}DD${s}MM`,
       `YYYY${s}D${s}M`
     )
     const euFieldFormats = getDateTimeFormatsFor(
+      `DD${s}MM${s}YYYY`,
       `D${s}M${s}YYYY`,
+      `YYYY${s}MM${s}DD`,
       `YYYY${s}M${s}D`
     )
     if (field.date_format === 'US') {

--- a/web-frontend/modules/database/fieldTypes.js
+++ b/web-frontend/modules/database/fieldTypes.js
@@ -2551,7 +2551,16 @@ class BaseDateFieldType extends FieldType {
   }
 
   prepareRichValueForCopy(field, value) {
-    return value
+    if (!value) {
+      return value
+    }
+    return {
+      type: 'date',
+      version: 1,
+      value,
+      includeTime: !!field.date_include_time,
+      timezone: getFieldTimezone(field) || null,
+    }
   }
 
   /**
@@ -2560,9 +2569,15 @@ class BaseDateFieldType extends FieldType {
    */
   prepareValueForPaste(field, clipboardData, richClipboardData) {
     if (richClipboardData) {
-      const richDateValue = this.parseInputValue(field, richClipboardData)
-      if (richDateValue) {
-        return this.formatValue(field, richDateValue)
+      const isoValue =
+        typeof richClipboardData === 'object' &&
+        richClipboardData?.type === 'date'
+          ? richClipboardData.value
+          : typeof richClipboardData === 'string'
+            ? richClipboardData
+            : null
+      if (isoValue && moment.utc(isoValue).isValid()) {
+        return this.formatValue(field, isoValue)
       }
     }
     const dateValue = this.parseInputValue(field, clipboardData || '')
@@ -2593,13 +2608,11 @@ class BaseDateFieldType extends FieldType {
     const usFieldFormats = getDateTimeFormatsFor(
       `MM${s}DD${s}YYYY`,
       `M${s}D${s}YYYY`,
-      `YYYY${s}DD${s}MM`,
       `YYYY${s}D${s}M`
     )
     const euFieldFormats = getDateTimeFormatsFor(
       `DD${s}MM${s}YYYY`,
       `D${s}M${s}YYYY`,
-      `YYYY${s}MM${s}DD`,
       `YYYY${s}M${s}D`
     )
     if (field.date_format === 'US') {

--- a/web-frontend/modules/database/fieldTypes.js
+++ b/web-frontend/modules/database/fieldTypes.js
@@ -2569,14 +2569,25 @@ class BaseDateFieldType extends FieldType {
    */
   prepareValueForPaste(field, clipboardData, richClipboardData) {
     if (richClipboardData) {
-      const isoValue =
+      let isoValue = null
+      if (
         typeof richClipboardData === 'object' &&
         richClipboardData?.type === 'date'
-          ? richClipboardData.value
-          : typeof richClipboardData === 'string'
-            ? richClipboardData
-            : null
-      if (isoValue && moment.utc(isoValue).isValid()) {
+      ) {
+        isoValue = richClipboardData.value
+      } else if (
+        typeof richClipboardData === 'string' &&
+        /^\d{4}-\d{2}-\d{2}/.test(richClipboardData)
+      ) {
+        isoValue = richClipboardData
+      }
+      if (isoValue && moment.utc(isoValue, moment.ISO_8601, true).isValid()) {
+        if (
+          typeof richClipboardData === 'object' &&
+          richClipboardData.type === 'date'
+        ) {
+          return this._convertRichDateValue(field, richClipboardData)
+        }
         return this.formatValue(field, isoValue)
       }
     }
@@ -2652,6 +2663,39 @@ class BaseDateFieldType extends FieldType {
 
   parseFromLinkedRowItemValue(field, value) {
     return this.parseInputValue(field, value)
+  }
+
+  _convertRichDateValue(field, richPayload) {
+    const date = moment.utc(richPayload.value)
+    if (!date.isValid()) {
+      return null
+    }
+    const targetIncludeTime = !!field.date_include_time
+    const targetTimezone = getFieldTimezone(field)
+    const sourceTimezone = richPayload.timezone
+
+    if (targetIncludeTime && !richPayload.includeTime) {
+      // date-only → datetime: interpret source date as midnight in target timezone
+      if (targetTimezone) {
+        const localMidnight = moment.tz(
+          date.format('YYYY-MM-DD'),
+          'YYYY-MM-DD',
+          targetTimezone
+        )
+        return localMidnight.utc().format()
+      }
+      return date.format()
+    }
+
+    if (!targetIncludeTime && richPayload.includeTime) {
+      // datetime → date-only: convert to source timezone then extract calendar date
+      if (sourceTimezone) {
+        return date.tz(sourceTimezone).format('YYYY-MM-DD')
+      }
+      return date.format('YYYY-MM-DD')
+    }
+
+    return this.formatValue(field, richPayload.value)
   }
 
   formatValue(field, value) {

--- a/web-frontend/test/unit/database/fieldTypes.spec.js
+++ b/web-frontend/test/unit/database/fieldTypes.spec.js
@@ -403,7 +403,7 @@ const datePrepareValueForCopy = [
 ]
 
 const datePrepareValueForPaste = [
-  // --- EU format: text-only paste (external) ---
+  // --- Group 1: EU format text-only paste (external) ---
   {
     fieldValue: '04/12/2021',
     field: { date_format: 'EU' },
@@ -440,12 +440,12 @@ const datePrepareValueForPaste = [
     expectedValue: '2021-12-04T22:57:00Z',
   },
   {
-    fieldValue: '04/16/2021', // Unambiguous US date in EU field (day > 12)
+    fieldValue: '04/16/2021',
     field: { date_format: 'EU' },
     expectedValue: '2021-04-16',
   },
 
-  // --- US format: text-only paste (external) ---
+  // --- Group 2: US format text-only paste (external) ---
   {
     fieldValue: '12/04/2021',
     field: { date_format: 'US' },
@@ -462,60 +462,58 @@ const datePrepareValueForPaste = [
     expectedValue: '2021-12-04T22:57:00Z',
   },
 
-  // --- US format: zero-padded ambiguous dates (the core bug) ---
+  // --- Group 3: Zero-padded ambiguous dates (core bug #5870) ---
   {
-    fieldValue: '01/10/2026', // Ambiguous: US reads as Jan 10
+    fieldValue: '01/10/2026',
     field: { date_format: 'US' },
     expectedValue: '2026-01-10',
   },
   {
-    fieldValue: '03/05/2026', // Ambiguous: US reads as Mar 5
+    fieldValue: '03/05/2026',
     field: { date_format: 'US' },
     expectedValue: '2026-03-05',
   },
   {
-    fieldValue: '09/12/2021', // Ambiguous: US reads as Sep 12
+    fieldValue: '09/12/2021',
     field: { date_format: 'US' },
     expectedValue: '2021-09-12',
   },
-
-  // --- EU format: zero-padded ambiguous dates ---
   {
-    fieldValue: '10/01/2026', // Ambiguous: EU reads as Oct 1
+    fieldValue: '10/01/2026',
     field: { date_format: 'EU' },
     expectedValue: '2026-01-10',
   },
   {
-    fieldValue: '05/03/2026', // Ambiguous: EU reads as May 3
+    fieldValue: '05/03/2026',
     field: { date_format: 'EU' },
     expectedValue: '2026-03-05',
   },
 
-  // --- Non-padded dates (external paste from typed input) ---
+  // --- Group 4: Non-padded dates (external typed input) ---
   {
-    fieldValue: '1/5/2024', // Non-padded US
+    fieldValue: '1/5/2024',
     field: { date_format: 'US' },
     expectedValue: '2024-01-05',
   },
   {
-    fieldValue: '5/1/2024', // Non-padded EU
+    fieldValue: '5/1/2024',
     field: { date_format: 'EU' },
     expectedValue: '2024-01-05',
   },
 
-  // --- Unambiguous dates (day > 12) ---
+  // --- Group 5: Unambiguous dates (day > 12) ---
   {
-    fieldValue: '01/15/2026', // Day > 12, must be US
+    fieldValue: '01/15/2026',
     field: { date_format: 'US' },
     expectedValue: '2026-01-15',
   },
   {
-    fieldValue: '15/01/2026', // Day > 12, must be EU
+    fieldValue: '15/01/2026',
     field: { date_format: 'EU' },
     expectedValue: '2026-01-15',
   },
 
-  // --- ISO format ---
+  // --- Group 6: ISO format text paste ---
   {
     fieldValue: '2026-01-10',
     field: { date_format: 'ISO' },
@@ -527,48 +525,323 @@ const datePrepareValueForPaste = [
     expectedValue: '2026-01-10',
   },
 
-  // --- Rich clipboard: internal paste uses ISO value ---
+  // --- Group 7: Rich clipboard typed payload — same format round-trip ---
   {
-    fieldValue: '10/01/2026', // Text says Oct 1 in EU
-    richValue: '2026-01-10', // ISO says Jan 10
-    field: { date_format: 'EU' },
-    expectedValue: '2026-01-10', // Rich value wins
+    fieldValue: '01/10/2026',
+    richValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10',
+      includeTime: false,
+      timezone: null,
+    },
+    field: { date_format: 'US' },
+    expectedValue: '2026-01-10',
   },
   {
-    fieldValue: '01/10/2026', // Text says Jan 10 in US
-    richValue: '2026-01-10', // ISO confirms Jan 10
+    fieldValue: '10/01/2026',
+    richValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10',
+      includeTime: false,
+      timezone: null,
+    },
+    field: { date_format: 'EU' },
+    expectedValue: '2026-01-10',
+  },
+
+  // --- Group 8: Rich clipboard — cross-format paste ---
+  {
+    fieldValue: '01/10/2026',
+    richValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10',
+      includeTime: false,
+      timezone: null,
+    },
+    field: { date_format: 'EU' },
+    expectedValue: '2026-01-10',
+  },
+  {
+    fieldValue: '10/01/2026',
+    richValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10',
+      includeTime: false,
+      timezone: null,
+    },
     field: { date_format: 'US' },
     expectedValue: '2026-01-10',
   },
 
-  // --- Rich clipboard: cross-format internal paste ---
+  // --- Group 9: Rich clipboard — datetime with timezone preservation ---
   {
-    fieldValue: '01/10/2026', // US-formatted text
-    richValue: '2026-01-10', // ISO: Jan 10
-    field: { date_format: 'EU' }, // Target is EU
-    expectedValue: '2026-01-10', // Rich value preserves correct date
+    fieldValue: '01/10/2026 14:30',
+    richValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10T14:30:00Z',
+      includeTime: true,
+      timezone: 'UTC',
+    },
+    field: { date_format: 'US', date_include_time: true },
+    expectedValue: '2026-01-10T14:30:00Z',
   },
   {
-    fieldValue: '10/01/2026', // EU-formatted text
-    richValue: '2026-01-10', // ISO: Jan 10
-    field: { date_format: 'US' }, // Target is US
-    expectedValue: '2026-01-10', // Rich value preserves correct date
+    fieldValue: '01/10/2026 15:30',
+    richValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10T14:30:00Z',
+      includeTime: true,
+      timezone: 'Europe/Rome',
+    },
+    field: {
+      date_format: 'US',
+      date_include_time: true,
+      date_force_timezone: 'Europe/Rome',
+    },
+    expectedValue: '2026-01-10T14:30:00Z',
+  },
+  // Key regression: Rome→Rome, absolute time preserved (not re-interpreted as wall-clock)
+  {
+    fieldValue: '10/01/2026 15:30',
+    richValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10T14:30:00Z',
+      includeTime: true,
+      timezone: 'Europe/Rome',
+    },
+    field: {
+      date_format: 'EU',
+      date_include_time: true,
+      date_force_timezone: 'Europe/Rome',
+    },
+    expectedValue: '2026-01-10T14:30:00Z',
   },
 
-  // --- Rich clipboard: invalid rich value falls back to text ---
+  // --- Group 10: Rich clipboard — cross-timezone (absolute time preserved) ---
   {
-    fieldValue: '03/15/2026', // Unambiguous US date
-    richValue: 'not-a-date',
+    fieldValue: '01/10/2026 15:30',
+    richValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10T14:30:00Z',
+      includeTime: true,
+      timezone: 'Europe/Rome',
+    },
+    field: {
+      date_format: 'US',
+      date_include_time: true,
+      date_force_timezone: 'America/New_York',
+    },
+    expectedValue: '2026-01-10T14:30:00Z',
+  },
+  {
+    fieldValue: '01/10/2026 14:30',
+    richValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10T14:30:00Z',
+      includeTime: true,
+      timezone: 'UTC',
+    },
+    field: {
+      date_format: 'US',
+      date_include_time: true,
+      date_force_timezone: 'Europe/Rome',
+    },
+    expectedValue: '2026-01-10T14:30:00Z',
+  },
+
+  // --- Group 11: Rich clipboard — DST boundary ---
+  {
+    fieldValue: '03/08/2026 02:30',
+    richValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-03-08T07:30:00Z',
+      includeTime: true,
+      timezone: 'America/New_York',
+    },
+    field: {
+      date_format: 'US',
+      date_include_time: true,
+      date_force_timezone: 'America/New_York',
+    },
+    expectedValue: '2026-03-08T07:30:00Z',
+  },
+
+  // --- Group 12: Rich clipboard — no forced timezone (null) ---
+  {
+    fieldValue: '01/10/2026 14:30',
+    richValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10T14:30:00Z',
+      includeTime: true,
+      timezone: null,
+    },
+    field: {
+      date_format: 'US',
+      date_include_time: true,
+      date_force_timezone: null,
+    },
+    expectedValue: '2026-01-10T14:30:00Z',
+  },
+
+  // --- Group 13: Rich clipboard — date-only ↔ datetime conversion ---
+  {
+    fieldValue: '01/10/2026',
+    richValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10',
+      includeTime: false,
+      timezone: null,
+    },
+    field: { date_format: 'US', date_include_time: true },
+    expectedValue: '2026-01-10T00:00:00Z',
+  },
+  {
+    fieldValue: '01/10/2026 14:30',
+    richValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10T14:30:00Z',
+      includeTime: true,
+      timezone: 'UTC',
+    },
     field: { date_format: 'US' },
-    expectedValue: '2026-03-15', // Falls back to text parsing
+    expectedValue: '2026-01-10',
   },
 
-  // --- Rich clipboard: datetime with rich value ---
+  // --- Group 14: Rich clipboard — 12h format target ---
+  {
+    fieldValue: '01/10/2026 02:30 PM',
+    richValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10T14:30:00Z',
+      includeTime: true,
+      timezone: 'UTC',
+    },
+    field: {
+      date_format: 'US',
+      date_include_time: true,
+      date_time_format: '12',
+    },
+    expectedValue: '2026-01-10T14:30:00Z',
+  },
+
+  // --- Group 15: Rich clipboard — legacy string format (backward compat) ---
+  {
+    fieldValue: '10/01/2026',
+    richValue: '2026-01-10',
+    field: { date_format: 'EU' },
+    expectedValue: '2026-01-10',
+  },
   {
     fieldValue: '01/10/2026 14:30',
     richValue: '2026-01-10T14:30:00Z',
     field: { date_format: 'US', date_include_time: true },
     expectedValue: '2026-01-10T14:30:00Z',
+  },
+
+  // --- Group 16: Rich clipboard — invalid/garbage payloads fall back to text ---
+  {
+    fieldValue: '03/15/2026',
+    richValue: 'not-a-date',
+    field: { date_format: 'US' },
+    expectedValue: '2026-03-15',
+  },
+  {
+    fieldValue: '03/15/2026',
+    richValue: { type: 'date', version: 1, value: 'garbage' },
+    field: { date_format: 'US' },
+    expectedValue: '2026-03-15',
+  },
+  {
+    fieldValue: '03/15/2026',
+    richValue: 42,
+    field: { date_format: 'US' },
+    expectedValue: '2026-03-15',
+  },
+  {
+    fieldValue: '03/15/2026',
+    richValue: null,
+    field: { date_format: 'US' },
+    expectedValue: '2026-03-15',
+  },
+
+  // --- Group 17: Year-first slash input (no regression from develop) ---
+  {
+    fieldValue: '2026/01/10',
+    field: { date_format: 'US' },
+    expectedValue: '2026-01-10',
+  },
+  {
+    fieldValue: '2026/01/10',
+    field: { date_format: 'EU' },
+    expectedValue: '2026-01-10',
+  },
+]
+
+const datePrepareRichValueForCopy = [
+  {
+    fieldValue: '2026-01-10',
+    field: { date_format: 'US', date_include_time: false },
+    expectedValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10',
+      includeTime: false,
+      timezone: null,
+    },
+  },
+  {
+    fieldValue: '2026-01-10T14:30:00Z',
+    field: {
+      date_format: 'EU',
+      date_include_time: true,
+      date_force_timezone: 'Europe/Rome',
+    },
+    expectedValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10T14:30:00Z',
+      includeTime: true,
+      timezone: 'Europe/Rome',
+    },
+  },
+  {
+    fieldValue: '2026-01-10T14:30:00Z',
+    field: {
+      date_format: 'US',
+      date_include_time: true,
+      date_force_timezone: 'UTC',
+    },
+    expectedValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10T14:30:00Z',
+      includeTime: true,
+      timezone: 'UTC',
+    },
+  },
+  {
+    fieldValue: null,
+    field: { date_format: 'US', date_include_time: false },
+    expectedValue: null,
+  },
+  {
+    fieldValue: '',
+    field: { date_format: 'US', date_include_time: false },
+    expectedValue: '',
   },
 ]
 
@@ -902,6 +1175,55 @@ describe('FieldType tests', () => {
       expect(result).toBe(value.expectedValue)
     }
   )
+  test.each(datePrepareRichValueForCopy)(
+    'Verify that prepareRichValueForCopy for DateFieldType for value $fieldValue returns expected typed payload',
+    (value) => {
+      const result = new DateFieldType().prepareRichValueForCopy(
+        value.field,
+        value.fieldValue
+      )
+      expect(result).toEqual(value.expectedValue)
+    }
+  )
+
+  test('prepareRichValueForCopy uses browser-guessed timezone when no forced timezone', () => {
+    const field = {
+      date_format: 'US',
+      date_include_time: true,
+      date_force_timezone: null,
+    }
+    const result = new DateFieldType().prepareRichValueForCopy(
+      field,
+      '2026-01-10T14:30:00Z'
+    )
+    expect(result.type).toBe('date')
+    expect(result.version).toBe(1)
+    expect(result.value).toBe('2026-01-10T14:30:00Z')
+    expect(result.includeTime).toBe(true)
+    expect(typeof result.timezone).toBe('string')
+    expect(result.timezone.length).toBeGreaterThan(0)
+  })
+
+  test('prepareValueForPaste with no forced timezone preserves absolute time via rich clipboard', () => {
+    const field = {
+      date_format: 'US',
+      date_include_time: true,
+      date_force_timezone: null,
+    }
+    const richValue = {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10T14:30:00Z',
+      includeTime: true,
+      timezone: 'Europe/Rome',
+    }
+    const result = new DateFieldType().prepareValueForPaste(
+      field,
+      '01/10/2026 15:30',
+      richValue
+    )
+    expect(result).toBe('2026-01-10T14:30:00Z')
+  })
 
   test.each([
     '',

--- a/web-frontend/test/unit/database/fieldTypes.spec.js
+++ b/web-frontend/test/unit/database/fieldTypes.spec.js
@@ -707,6 +707,24 @@ const datePrepareValueForPaste = [
     field: { date_format: 'US', date_include_time: true },
     expectedValue: '2026-01-10T00:00:00Z',
   },
+  // date-only → datetime with non-UTC timezone: midnight in target timezone
+  {
+    fieldValue: '10/01/2026',
+    richValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10',
+      includeTime: false,
+      timezone: null,
+    },
+    field: {
+      date_format: 'EU',
+      date_include_time: true,
+      date_force_timezone: 'Europe/Rome',
+    },
+    expectedValue: '2026-01-09T23:00:00Z',
+  },
+  // datetime → date-only: extract calendar date in source timezone
   {
     fieldValue: '01/10/2026 14:30',
     richValue: {
@@ -715,6 +733,45 @@ const datePrepareValueForPaste = [
       value: '2026-01-10T14:30:00Z',
       includeTime: true,
       timezone: 'UTC',
+    },
+    field: { date_format: 'US' },
+    expectedValue: '2026-01-10',
+  },
+  // datetime → date when timezone shifts calendar day
+  {
+    fieldValue: '01/10/2026 23:30',
+    richValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10T23:30:00Z',
+      includeTime: true,
+      timezone: 'Europe/Rome',
+    },
+    field: { date_format: 'EU' },
+    expectedValue: '2026-01-11',
+  },
+  // datetime → date with America/New_York (UTC-5 in Jan)
+  {
+    fieldValue: '01/10/2026 22:30',
+    richValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-11T03:30:00Z',
+      includeTime: true,
+      timezone: 'America/New_York',
+    },
+    field: { date_format: 'US' },
+    expectedValue: '2026-01-10',
+  },
+  // datetime → date with null source timezone (falls back to UTC calendar date)
+  {
+    fieldValue: '01/10/2026 23:30',
+    richValue: {
+      type: 'date',
+      version: 1,
+      value: '2026-01-10T23:30:00Z',
+      includeTime: true,
+      timezone: null,
     },
     field: { date_format: 'US' },
     expectedValue: '2026-01-10',
@@ -752,7 +809,20 @@ const datePrepareValueForPaste = [
     expectedValue: '2026-01-10T14:30:00Z',
   },
 
-  // --- Group 16: Rich clipboard — invalid/garbage payloads fall back to text ---
+  // --- Group 16: Rich clipboard — invalid/garbage/locale payloads fall back to text ---
+  // Locale-formatted string as richClipboardData (ImportFileModal passes raw cell values)
+  {
+    fieldValue: '01/10/2026',
+    richValue: '01/10/2026',
+    field: { date_format: 'EU' },
+    expectedValue: '2026-10-01',
+  },
+  {
+    fieldValue: '01/10/2026',
+    richValue: '01/10/2026',
+    field: { date_format: 'US' },
+    expectedValue: '2026-01-10',
+  },
   {
     fieldValue: '03/15/2026',
     richValue: 'not-a-date',

--- a/web-frontend/test/unit/database/fieldTypes.spec.js
+++ b/web-frontend/test/unit/database/fieldTypes.spec.js
@@ -403,91 +403,172 @@ const datePrepareValueForCopy = [
 ]
 
 const datePrepareValueForPaste = [
-  // Date field with EU format
+  // --- EU format: text-only paste (external) ---
   {
     fieldValue: '04/12/2021',
-    field: {
-      date_format: 'EU',
-    },
+    field: { date_format: 'EU' },
     expectedValue: '2021-12-04',
   },
   {
     fieldValue: '04/12/2021 22:57',
-    field: {
-      date_format: 'EU',
-      date_include_time: true,
-    },
+    field: { date_format: 'EU', date_include_time: true },
     expectedValue: '2021-12-04T22:57:00Z',
   },
   {
     fieldValue: '04/12/2021 10:57 PM',
-    field: {
-      date_format: 'EU',
-      date_include_time: true,
-    },
+    field: { date_format: 'EU', date_include_time: true },
     expectedValue: '2021-12-04T22:57:00Z',
   },
   {
     fieldValue: '2021-12-04',
-    field: {
-      date_format: 'EU',
-    },
+    field: { date_format: 'EU' },
     expectedValue: '2021-12-04',
   },
   {
     fieldValue: '2021-12-04 22:57',
-    field: {
-      date_format: 'EU',
-      date_include_time: true,
-    },
+    field: { date_format: 'EU', date_include_time: true },
     expectedValue: '2021-12-04T22:57:00Z',
   },
   {
     fieldValue: '2021-12-04 10:57 PM',
-    field: {
-      date_format: 'EU',
-      date_include_time: true,
-    },
+    field: { date_format: 'EU', date_include_time: true },
     expectedValue: '2021-12-04T22:57:00Z',
   },
   {
     fieldValue: '2021-12-04T22:57:00Z',
-    field: {
-      date_format: 'EU',
-      date_include_time: true,
-    },
+    field: { date_format: 'EU', date_include_time: true },
     expectedValue: '2021-12-04T22:57:00Z',
   },
   {
-    fieldValue: '04/16/2021', // Explicit US date in EU field
-    field: {
-      date_format: 'EU',
-    },
+    fieldValue: '04/16/2021', // Unambiguous US date in EU field (day > 12)
+    field: { date_format: 'EU' },
     expectedValue: '2021-04-16',
   },
-  // Date field with US format
+
+  // --- US format: text-only paste (external) ---
   {
     fieldValue: '12/04/2021',
-    field: {
-      date_format: 'US',
-    },
-    expectedValue: '2021-04-12',
+    field: { date_format: 'US' },
+    expectedValue: '2021-12-04',
   },
   {
     fieldValue: '12/04/2021 22:57',
-    field: {
-      date_format: 'US',
-      date_include_time: true,
-    },
-    expectedValue: '2021-04-12T22:57:00Z',
+    field: { date_format: 'US', date_include_time: true },
+    expectedValue: '2021-12-04T22:57:00Z',
   },
   {
     fieldValue: '12/04/2021 10:57 PM',
-    field: {
-      date_format: 'US',
-      date_include_time: true,
-    },
-    expectedValue: '2021-04-12T22:57:00Z',
+    field: { date_format: 'US', date_include_time: true },
+    expectedValue: '2021-12-04T22:57:00Z',
+  },
+
+  // --- US format: zero-padded ambiguous dates (the core bug) ---
+  {
+    fieldValue: '01/10/2026', // Ambiguous: US reads as Jan 10
+    field: { date_format: 'US' },
+    expectedValue: '2026-01-10',
+  },
+  {
+    fieldValue: '03/05/2026', // Ambiguous: US reads as Mar 5
+    field: { date_format: 'US' },
+    expectedValue: '2026-03-05',
+  },
+  {
+    fieldValue: '09/12/2021', // Ambiguous: US reads as Sep 12
+    field: { date_format: 'US' },
+    expectedValue: '2021-09-12',
+  },
+
+  // --- EU format: zero-padded ambiguous dates ---
+  {
+    fieldValue: '10/01/2026', // Ambiguous: EU reads as Oct 1
+    field: { date_format: 'EU' },
+    expectedValue: '2026-01-10',
+  },
+  {
+    fieldValue: '05/03/2026', // Ambiguous: EU reads as May 3
+    field: { date_format: 'EU' },
+    expectedValue: '2026-03-05',
+  },
+
+  // --- Non-padded dates (external paste from typed input) ---
+  {
+    fieldValue: '1/5/2024', // Non-padded US
+    field: { date_format: 'US' },
+    expectedValue: '2024-01-05',
+  },
+  {
+    fieldValue: '5/1/2024', // Non-padded EU
+    field: { date_format: 'EU' },
+    expectedValue: '2024-01-05',
+  },
+
+  // --- Unambiguous dates (day > 12) ---
+  {
+    fieldValue: '01/15/2026', // Day > 12, must be US
+    field: { date_format: 'US' },
+    expectedValue: '2026-01-15',
+  },
+  {
+    fieldValue: '15/01/2026', // Day > 12, must be EU
+    field: { date_format: 'EU' },
+    expectedValue: '2026-01-15',
+  },
+
+  // --- ISO format ---
+  {
+    fieldValue: '2026-01-10',
+    field: { date_format: 'ISO' },
+    expectedValue: '2026-01-10',
+  },
+  {
+    fieldValue: '2026-01-10',
+    field: { date_format: 'US' },
+    expectedValue: '2026-01-10',
+  },
+
+  // --- Rich clipboard: internal paste uses ISO value ---
+  {
+    fieldValue: '10/01/2026', // Text says Oct 1 in EU
+    richValue: '2026-01-10', // ISO says Jan 10
+    field: { date_format: 'EU' },
+    expectedValue: '2026-01-10', // Rich value wins
+  },
+  {
+    fieldValue: '01/10/2026', // Text says Jan 10 in US
+    richValue: '2026-01-10', // ISO confirms Jan 10
+    field: { date_format: 'US' },
+    expectedValue: '2026-01-10',
+  },
+
+  // --- Rich clipboard: cross-format internal paste ---
+  {
+    fieldValue: '01/10/2026', // US-formatted text
+    richValue: '2026-01-10', // ISO: Jan 10
+    field: { date_format: 'EU' }, // Target is EU
+    expectedValue: '2026-01-10', // Rich value preserves correct date
+  },
+  {
+    fieldValue: '10/01/2026', // EU-formatted text
+    richValue: '2026-01-10', // ISO: Jan 10
+    field: { date_format: 'US' }, // Target is US
+    expectedValue: '2026-01-10', // Rich value preserves correct date
+  },
+
+  // --- Rich clipboard: invalid rich value falls back to text ---
+  {
+    fieldValue: '03/15/2026', // Unambiguous US date
+    richValue: 'not-a-date',
+    field: { date_format: 'US' },
+    expectedValue: '2026-03-15', // Falls back to text parsing
+  },
+
+  // --- Rich clipboard: datetime with rich value ---
+  {
+    fieldValue: '01/10/2026 14:30',
+    richValue: '2026-01-10T14:30:00Z',
+    field: { date_format: 'US', date_include_time: true },
+    expectedValue: '2026-01-10T14:30:00Z',
   },
 ]
 
@@ -815,7 +896,8 @@ describe('FieldType tests', () => {
     (value) => {
       const result = new DateFieldType().prepareValueForPaste(
         value.field,
-        value.fieldValue
+        value.fieldValue,
+        value.richValue
       )
       expect(result).toBe(value.expectedValue)
     }


### PR DESCRIPTION
Closes #5870 

* Fix silent date corruption when copy-pasting between US-format date fields — month and day were swapped for ambiguous dates (both ≤ 12)
* `prepareValueForPaste` now uses the rich clipboard ISO value (from `prepareRichValueForCopy`) when available, falling back to text parsing for external paste
*Added zero-padded format tokens (`MM/DD/YYYY`, `DD/MM/YYYY`) to `getDateFormatsOptionsForValue` so strict moment parsing matches the copy output format

### Testing

Follow steps from issue and observe correct behavior

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
