### PR TITLE
feat: Added videos to the guided tour

### DIFF
--- a/changelog/entries/unreleased/feature/adds_baserow_academy_videos_to_the_guided_tour.json
+++ b/changelog/entries/unreleased/feature/adds_baserow_academy_videos_to_the_guided_tour.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Adds Baserow academy videos to the guided tour",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-08-10"
+}

--- a/web-frontend/modules/automation/guidedTourTypes.js
+++ b/web-frontend/modules/automation/guidedTourTypes.js
@@ -19,6 +19,10 @@ class WelcomeGuidedTourStep extends GuidedTourStep {
   get position() {
     return 'center'
   }
+
+  get videos() {
+    return ['lHfMax7BC5E']
+  }
 }
 
 class GraphGuidedTourStep extends GuidedTourStep {
@@ -40,6 +44,10 @@ class GraphGuidedTourStep extends GuidedTourStep {
 
   get highlightPadding() {
     return 0
+  }
+
+  get videos() {
+    return ['vaAXEfx-n5U', 'tqa6_5BrVvY', 'p5DwN1CSVPc', 'lbmFNGVIylY']
   }
 }
 
@@ -77,6 +85,10 @@ class TestRunGuidedTourStep extends GuidedTourStep {
   get position() {
     return 'bottom-right'
   }
+
+  get videos() {
+    return ['A06Oeyxx12M']
+  }
 }
 
 class PublishGuidedTourStep extends GuidedTourStep {
@@ -94,6 +106,10 @@ class PublishGuidedTourStep extends GuidedTourStep {
 
   get position() {
     return 'bottom-right'
+  }
+
+  get videos() {
+    return ['A06Oeyxx12M']
   }
 }
 

--- a/web-frontend/modules/builder/guidedTourTypes.js
+++ b/web-frontend/modules/builder/guidedTourTypes.js
@@ -19,6 +19,10 @@ class ElementsGuidedTourStep extends GuidedTourStep {
   get position() {
     return 'bottom-left'
   }
+
+  get videos() {
+    return ['LemdgnR9Sak', 'SVWSeqf_YMg', 'I6ITCnA6fCY']
+  }
 }
 
 class DataGuidedTourStep extends GuidedTourStep {
@@ -37,6 +41,10 @@ class DataGuidedTourStep extends GuidedTourStep {
   get position() {
     return 'bottom-left'
   }
+
+  get videos() {
+    return ['Tw6PrSdLUhg']
+  }
 }
 
 class PreviewGuidedTourStep extends GuidedTourStep {
@@ -54,6 +62,10 @@ class PreviewGuidedTourStep extends GuidedTourStep {
 
   get position() {
     return 'right-top'
+  }
+
+  get videos() {
+    return ['sW0v-U3z9oQ', 'k027ccEMzAY']
   }
 }
 
@@ -96,6 +108,10 @@ class SidePanelPublishGuidedTourStep extends GuidedTourStep {
   get position() {
     return 'left-top'
   }
+
+  get videos() {
+    return ['EuagnEJgK4w', 'kaLF5o9lj00']
+  }
 }
 
 class PreviewPublishGuidedTourStep extends GuidedTourStep {
@@ -116,6 +132,10 @@ class PreviewPublishGuidedTourStep extends GuidedTourStep {
 
   get position() {
     return 'left-top'
+  }
+
+  get videos() {
+    return ['a92GF1pX2X8']
   }
 }
 

--- a/web-frontend/modules/core/assets/scss/components/all.scss
+++ b/web-frontend/modules/core/assets/scss/components/all.scss
@@ -209,6 +209,7 @@
 @import 'template_import_item';
 @import 'highlight';
 @import 'guided_tour_step';
+@import 'guided_tour_video_modal';
 @import 'mcp_endpoint';
 @import 'code_editor';
 @import 'sample_data_modal';

--- a/web-frontend/modules/core/assets/scss/components/guided_tour_step.scss
+++ b/web-frontend/modules/core/assets/scss/components/guided_tour_step.scss
@@ -183,6 +183,63 @@
   }
 }
 
+.guided-tour-step__video {
+  margin-top: 16px;
+}
+
+.guided-tour-step__video-thumbnail {
+  position: relative;
+  display: block;
+  height: 100px;
+  overflow: hidden;
+  background-color: $palette-neutral-1100;
+
+  @include rounded($rounded);
+
+  img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  i {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba($palette-neutral-1300, 0.4);
+    color: $white;
+    font-size: 32px;
+
+    @include absolute(0, 0, 0, 0);
+  }
+
+  &:hover i {
+    background-color: rgba($palette-neutral-1300, 0.2);
+  }
+}
+
+.guided-tour-step__video-loading {
+  @include loading(18px, $palette-neutral-500);
+
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin: -9px 0 0 -9px;
+}
+
+.guided-tour-step__academy {
+  display: block;
+  margin-top: 8px;
+  color: $palette-neutral-500;
+  font-size: 11px;
+  line-height: 16px;
+
+  &:hover {
+    color: $palette-neutral-300;
+  }
+}
+
 .guided-tour-step__foot {
   flex-grow: 0;
   flex-shrink: 0;

--- a/web-frontend/modules/core/assets/scss/components/guided_tour_video_modal.scss
+++ b/web-frontend/modules/core/assets/scss/components/guided_tour_video_modal.scss
@@ -1,0 +1,125 @@
+.guided-tour-video-modal__wrapper {
+  z-index: $z-index-guided-tour-video-modal;
+  background-color: rgba($palette-neutral-1300, 0.85);
+}
+
+.guided-tour-video-modal {
+  overflow: hidden;
+  user-select: none;
+
+  @include absolute(0, 0, 0, 0);
+}
+
+.guided-tour-video-modal__close {
+  color: $white;
+
+  @include center-text(32px, 20px);
+  @include absolute(17px, 17px, auto, auto);
+  @include rounded($rounded);
+
+  &:hover {
+    background-color: rgba($white, 0.15);
+  }
+}
+
+.guided-tour-video-modal__body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  @include absolute($guided-tour-video-head, 0, $guided-tour-video-foot, 0);
+}
+
+.guided-tour-video-modal__player {
+  width: min(
+    1100px,
+    70vw,
+    calc((100vh - #{$guided-tour-video-chrome}) * 16 / 9)
+  );
+  aspect-ratio: 16 / 9;
+
+  iframe {
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
+}
+
+.guided-tour-video-modal__nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: $guided-tour-video-nav-width;
+  color: $palette-neutral-500;
+  font-size: 60px;
+
+  @include absolute(0, auto, 0, auto);
+
+  &:hover {
+    color: $white;
+    text-decoration: none;
+  }
+
+  &.guided-tour-video-modal__nav--previous {
+    left: 0;
+  }
+
+  &.guided-tour-video-modal__nav--next {
+    right: 0;
+  }
+
+  &.guided-tour-video-modal__nav--disabled {
+    opacity: 0.3;
+    pointer-events: none;
+  }
+}
+
+.guided-tour-video-modal__foot {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: $guided-tour-video-foot;
+
+  @include absolute(auto, 0, 0, 0);
+}
+
+.guided-tour-video-modal__thumbnails {
+  display: flex;
+  gap: 12px;
+  margin: 0;
+  padding: 0 12px;
+  list-style: none;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.guided-tour-video-modal__thumbnail {
+  display: block;
+  overflow: hidden;
+  border: solid 2px transparent;
+
+  @include rounded($rounded);
+
+  img {
+    display: block;
+    width: 160px;
+    height: 90px;
+    object-fit: cover;
+  }
+
+  &.guided-tour-video-modal__thumbnail--active {
+    border-color: $white;
+  }
+}
+
+.guided-tour-video-modal__academy {
+  color: $palette-neutral-400;
+  font-size: 11px;
+  line-height: 16px;
+
+  &:hover {
+    color: $white;
+  }
+}

--- a/web-frontend/modules/core/assets/scss/variables.scss
+++ b/web-frontend/modules/core/assets/scss/variables.scss
@@ -31,6 +31,7 @@ $z-index-toasts: 10 !default;
 $z-index-guided-tour-container: 99 !default;
 $z-index-highlight-overlay: 100 !default;
 $z-index-guided-tour-step: 101 !default;
+$z-index-guided-tour-video-modal: 102 !default;
 
 // normalize overrides
 $base-font-family: $text-font-stack !default;
@@ -61,6 +62,13 @@ $api-docs-breakpoint: 1100px !default;
 $file-field-modal-head-height: 62px !default;
 $file-field-modal-body-nav-width: 120px !default;
 $file-field-modal-foot-height: 108px !default;
+
+$guided-tour-video-nav-width: 100px !default;
+$guided-tour-video-head: 62px !default;
+$guided-tour-video-foot: 158px !default;
+
+// The vertical space that's not available to the video itself.
+$guided-tour-video-chrome: $guided-tour-video-head + $guided-tour-video-foot;
 
 $onboarding-breakpoint: 920px !default;
 

--- a/web-frontend/modules/core/components/guidedTour/GuidedTour.vue
+++ b/web-frontend/modules/core/components/guidedTour/GuidedTour.vue
@@ -19,6 +19,7 @@
         :last="stepIndex >= allSteps.length - 1"
         :position="currentStep.position"
         :button-text="currentStep.buttonText"
+        :videos="currentStep.videos"
         @previous="goto(stepIndex - 1)"
         @next="next"
       ></GuidedTourStep>

--- a/web-frontend/modules/core/components/guidedTour/GuidedTourStep.vue
+++ b/web-frontend/modules/core/components/guidedTour/GuidedTourStep.vue
@@ -10,6 +10,34 @@
       <div class="guided-tour-step__description">
         <MarkdownIt :content="content" />
       </div>
+      <div
+        v-if="videos.length > 0 && !thumbnailFailed"
+        class="guided-tour-step__video"
+      >
+        <a
+          class="guided-tour-step__video-thumbnail"
+          @click="$refs.videoModal.show(0)"
+        >
+          <img
+            v-show="thumbnailLoaded"
+            :key="videos[0]"
+            :src="thumbnailUrl"
+            :alt="$t('guidedTourStep.watchVideo')"
+            @load="thumbnailLoaded = true"
+            @error="thumbnailFailed = true"
+          />
+          <i v-if="thumbnailLoaded" class="iconoir-play"></i>
+          <div v-else class="guided-tour-step__video-loading"></div>
+        </a>
+        <a
+          class="guided-tour-step__academy"
+          :href="academyUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          >{{ $t('academy.learnMore') }}</a
+        >
+        <GuidedTourVideoModal ref="videoModal" :videos="videos" />
+      </div>
     </div>
     <div class="guided-tour-step__foot">
       <div class="flex justify-content-space-between align-items-center">
@@ -30,8 +58,13 @@
 </template>
 
 <script>
+import GuidedTourVideoModal from '@baserow/modules/core/components/guidedTour/GuidedTourVideoModal'
+import { BASEROW_ACADEMY_URL } from '@baserow/modules/core/utils/academy'
+import { getYouTubeThumbnailUrl } from '@baserow/modules/core/utils/youtube'
+
 export default {
   name: 'GuidedTourStep',
+  components: { GuidedTourVideoModal },
   props: {
     position: {
       required: true,
@@ -79,8 +112,33 @@ export default {
       required: false,
       default: null,
     },
+    videos: {
+      type: Array,
+      required: false,
+      default: () => [],
+    },
   },
   emits: ['next', 'previous'],
+  data() {
+    return {
+      thumbnailFailed: false,
+      thumbnailLoaded: false,
+    }
+  },
+  computed: {
+    academyUrl() {
+      return BASEROW_ACADEMY_URL
+    },
+    thumbnailUrl() {
+      return getYouTubeThumbnailUrl(this.videos[0])
+    },
+  },
+  watch: {
+    thumbnailUrl() {
+      this.thumbnailFailed = false
+      this.thumbnailLoaded = false
+    },
+  },
   async mounted() {
     const updatePosition = () => {
       const rect = this.$el.getBoundingClientRect()

--- a/web-frontend/modules/core/components/guidedTour/GuidedTourVideoModal.vue
+++ b/web-frontend/modules/core/components/guidedTour/GuidedTourVideoModal.vue
@@ -1,0 +1,192 @@
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      ref="modalEl"
+      v-bind="$attrs"
+      class="modal__wrapper guided-tour-video-modal__wrapper"
+      @click.stop="outside()"
+    >
+      <div class="guided-tour-video-modal">
+        <a
+          class="guided-tour-video-modal__close"
+          :title="$t('guidedTourVideoModal.close')"
+          @click="hide()"
+        >
+          <i class="iconoir-cancel"></i>
+        </a>
+        <div class="guided-tour-video-modal__body">
+          <a
+            v-if="hasMultiple"
+            class="guided-tour-video-modal__nav guided-tour-video-modal__nav--previous"
+            :class="{
+              'guided-tour-video-modal__nav--disabled': selected === 0,
+            }"
+            :title="$t('guidedTourVideoModal.previous')"
+            @click="previous()"
+          >
+            <i class="iconoir-nav-arrow-left"></i>
+          </a>
+          <div ref="playerEl" class="guided-tour-video-modal__player">
+            <div ref="player"></div>
+          </div>
+          <a
+            v-if="hasMultiple"
+            class="guided-tour-video-modal__nav guided-tour-video-modal__nav--next"
+            :class="{
+              'guided-tour-video-modal__nav--disabled':
+                selected === videos.length - 1,
+            }"
+            :title="$t('guidedTourVideoModal.next')"
+            @click="next()"
+          >
+            <i class="iconoir-nav-arrow-right"></i>
+          </a>
+        </div>
+        <div class="guided-tour-video-modal__foot">
+          <ul v-if="hasMultiple" class="guided-tour-video-modal__thumbnails">
+            <li v-for="(video, index) in videos" :key="video">
+              <a
+                class="guided-tour-video-modal__thumbnail"
+                :class="{
+                  'guided-tour-video-modal__thumbnail--active':
+                    index === selected,
+                }"
+                @click="select(index)"
+              >
+                <img :src="getThumbnailUrl(video)" alt="" />
+              </a>
+            </li>
+          </ul>
+          <a
+            class="guided-tour-video-modal__academy"
+            :href="academyUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            >{{ $t('academy.learnMore') }}</a
+          >
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script>
+import baseModal from '@baserow/modules/core/mixins/baseModal'
+import {
+  isElement,
+  doesAncestorMatchPredicate,
+} from '@baserow/modules/core/utils/dom'
+import { BASEROW_ACADEMY_URL } from '@baserow/modules/core/utils/academy'
+import {
+  createYouTubePlayer,
+  getYouTubeThumbnailUrl,
+} from '@baserow/modules/core/utils/youtube'
+
+export default {
+  name: 'GuidedTourVideoModal',
+  mixins: [baseModal],
+  inheritAttrs: false,
+  props: {
+    videos: {
+      type: Array,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      selected: 0,
+      player: null,
+    }
+  },
+  computed: {
+    academyUrl() {
+      return BASEROW_ACADEMY_URL
+    },
+    hasMultiple() {
+      return this.videos.length > 1
+    },
+  },
+  beforeUnmount() {
+    this.player?.destroy()
+    this.player = null
+  },
+  methods: {
+    getThumbnailUrl(videoId) {
+      return getYouTubeThumbnailUrl(videoId)
+    },
+    async show(index = 0) {
+      this.selected = index
+      baseModal.methods.show.call(this)
+      await this.$nextTick()
+
+      try {
+        this.player = await createYouTubePlayer(
+          this.$refs.player,
+          this.videos[this.selected],
+          () => this.next()
+        )
+      } catch (error) {
+        // Without internet access the API can't be loaded. There is nothing to play
+        // then, so the modal closes again.
+        this.hide()
+      }
+    },
+    hide(emit = true) {
+      // The player must be destroyed, otherwise the video keeps playing in the
+      // background.
+      this.player?.destroy()
+      this.player = null
+      baseModal.methods.hide.call(this, emit)
+    },
+    select(index) {
+      this.selected = index
+      // `loadVideoById` immediately starts playing the new video.
+      this.player?.loadVideoById(this.videos[index])
+    },
+    // The videos are deliberately not wrapping around because the last one
+    // automatically calls `next` when it finished, and that would loop forever.
+    next() {
+      if (this.selected < this.videos.length - 1) {
+        this.select(this.selected + 1)
+      }
+    },
+    previous() {
+      if (this.selected > 0) {
+        this.select(this.selected - 1)
+      }
+    },
+    keyup(event) {
+      if (event.key === 'ArrowLeft') {
+        this.previous()
+      }
+      if (event.key === 'ArrowRight') {
+        this.next()
+      }
+      return baseModal.methods.keyup.call(this, event)
+    },
+    outside() {
+      // The `downElement` of the mixin is used instead of the click target because
+      // hiding on `mousedown` would remove the modal while the browser is still
+      // completing the gesture, making it select all the text of the page below.
+      const target = this.downElement
+
+      // Anything outside of the video closes the modal, except the anchors because
+      // their own click event must still fire.
+      const isChildOfAnchor = doesAncestorMatchPredicate(
+        target,
+        (element) => element.tagName === 'A',
+        this.$refs.modalEl
+      )
+
+      if (
+        this.canClose &&
+        !isChildOfAnchor &&
+        !isElement(this.$refs.playerEl, target)
+      ) {
+        this.hide()
+      }
+    },
+  },
+}
+</script>

--- a/web-frontend/modules/core/guidedTourTypes.js
+++ b/web-frontend/modules/core/guidedTourTypes.js
@@ -103,6 +103,15 @@ export class GuidedTourStep {
   }
 
   /**
+   * Can optionally contain Baserow academy YouTube video ids related to this step. The
+   * first one is shown as a thumbnail in the step, and clicking it plays all of them in
+   * the given order.
+   */
+  get videos() {
+    return []
+  }
+
+  /**
    * Hook that is called before the step is shown. This can be used to open a context
    * menu, for example.
    */
@@ -162,6 +171,10 @@ class ControlCenterGuidedTourStep extends GuidedTourStep {
   get position() {
     return 'right-top'
   }
+
+  get videos() {
+    return ['aXZzQRRTt9c']
+  }
 }
 
 class CreateNewGuidedTourStep extends GuidedTourStep {
@@ -181,6 +194,10 @@ class CreateNewGuidedTourStep extends GuidedTourStep {
 
   get position() {
     return 'right-bottom'
+  }
+
+  get videos() {
+    return ['KNK1rgK3bJY']
   }
 }
 

--- a/web-frontend/modules/core/locales/en.json
+++ b/web-frontend/modules/core/locales/en.json
@@ -1188,11 +1188,20 @@
   "userSourceType": {
     "userCountSummary": "{count} users ({lastUpdated})"
   },
+  "academy": {
+    "learnMore": "Learn more at the Baserow academy"
+  },
   "guidedTourStep": {
     "step": "{step} of {totalSteps}",
     "gotIt": "Got it",
     "next": "Next",
-    "back": "Back"
+    "back": "Back",
+    "watchVideo": "Watch video"
+  },
+  "guidedTourVideoModal": {
+    "previous": "Previous video",
+    "next": "Next video",
+    "close": "Close"
   },
   "welcomeGuidedTourStep": {
     "title": "Welcome to Baserow",

--- a/web-frontend/modules/core/utils/academy.js
+++ b/web-frontend/modules/core/utils/academy.js
@@ -1,0 +1,1 @@
+export const BASEROW_ACADEMY_URL = 'https://academy.baserow.io/'

--- a/web-frontend/modules/core/utils/youtube.js
+++ b/web-frontend/modules/core/utils/youtube.js
@@ -1,0 +1,68 @@
+// The `nocookie` domain doesn't set any tracking cookies until the visitor actually
+// starts playing a video.
+const PLAYER_HOST = 'https://www.youtube-nocookie.com'
+const IFRAME_API_URL = 'https://www.youtube.com/iframe_api'
+
+let iframeApiPromise = null
+
+/**
+ * The `mqdefault` thumbnail is used because it's the largest one that YouTube
+ * guarantees to exist for every video.
+ */
+export function getYouTubeThumbnailUrl(videoId) {
+  return `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`
+}
+
+/**
+ * Lazily loads the YouTube iframe player API and resolves with the global `YT` object.
+ * The script is only requested once, no matter how many players are created. Rejects if
+ * the script can't be loaded, which is the case in an installation without internet
+ * access.
+ */
+export function loadYouTubeIframeApi() {
+  if (iframeApiPromise === null) {
+    iframeApiPromise = new Promise((resolve, reject) => {
+      if (window.YT?.Player) {
+        return resolve(window.YT)
+      }
+
+      // The API calls this global function when it's done loading. Another script could
+      // already have registered one, so it must be kept intact.
+      const existing = window.onYouTubeIframeAPIReady
+      window.onYouTubeIframeAPIReady = () => {
+        existing?.()
+        resolve(window.YT)
+      }
+
+      const script = document.createElement('script')
+      script.src = IFRAME_API_URL
+      script.onerror = () => {
+        iframeApiPromise = null
+        reject(new Error('Could not load the YouTube iframe API.'))
+      }
+      document.head.appendChild(script)
+    })
+  }
+  return iframeApiPromise
+}
+
+/**
+ * Creates a player that immediately starts playing and calls `onEnded` when the video
+ * has finished.
+ */
+export async function createYouTubePlayer(element, videoId, onEnded) {
+  const YT = await loadYouTubeIframeApi()
+  return new YT.Player(element, {
+    host: PLAYER_HOST,
+    videoId,
+    playerVars: { autoplay: 1, rel: 0, modestbranding: 1 },
+    events: {
+      onReady: (event) => event.target.playVideo(),
+      onStateChange: (event) => {
+        if (event.data === YT.PlayerState.ENDED) {
+          onEnded()
+        }
+      },
+    },
+  })
+}

--- a/web-frontend/modules/database/guidedTourTypes.js
+++ b/web-frontend/modules/database/guidedTourTypes.js
@@ -26,6 +26,10 @@ class FiltersSortGroupGuidedTourStep extends GuidedTourStep {
   get position() {
     return 'bottom-left'
   }
+
+  get videos() {
+    return ['GHnspwPL5ZI', 'SC8PWV0bKDA', 'qZLO_SRKFb4']
+  }
 }
 
 class AddFieldGuidedTourStep extends GuidedTourStep {
@@ -43,6 +47,10 @@ class AddFieldGuidedTourStep extends GuidedTourStep {
 
   get position() {
     return 'bottom-right'
+  }
+
+  get videos() {
+    return ['bn3AD2gjja4']
   }
 }
 
@@ -62,6 +70,10 @@ class CreateViewGuidedTourStep extends GuidedTourStep {
   get position() {
     return 'bottom-left'
   }
+
+  get videos() {
+    return ['gKdwv4zQ3Lk', 'xwL8y-bZcNs', 'h5MT1_Nh6xM', 'h0WXU5ij5i0']
+  }
 }
 
 class CreateFormViewGuidedTourStep extends GuidedTourStep {
@@ -79,6 +91,10 @@ class CreateFormViewGuidedTourStep extends GuidedTourStep {
 
   get position() {
     return 'bottom-left'
+  }
+
+  get videos() {
+    return ['wMyhKjVfC2A']
   }
 
   async beforeShow() {
@@ -108,6 +124,10 @@ class ViewOptionGuidedTourStep extends GuidedTourStep {
     return 'bottom-left'
   }
 
+  get videos() {
+    return ['I4C8208TgYo']
+  }
+
   async beforeShow() {
     this.app.$bus.$emit('open-table-view-context')
     await nextTick()
@@ -133,6 +153,10 @@ class TablesGuidedTourStep extends GuidedTourStep {
 
   get position() {
     return 'right-bottom'
+  }
+
+  get videos() {
+    return ['ASi4H11uXNA']
   }
 }
 

--- a/web-frontend/test/unit/core/components/guidedTour/guidedTourStep.spec.js
+++ b/web-frontend/test/unit/core/components/guidedTour/guidedTourStep.spec.js
@@ -1,0 +1,110 @@
+import GuidedTourStep from '@baserow/modules/core/components/guidedTour/GuidedTourStep'
+import { TestApp } from '@baserow/test/helpers/testApp'
+
+describe('GuidedTourStep component', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+  })
+
+  afterEach(() => {
+    testApp.afterEach()
+  })
+
+  const mountComponent = ({ props = {} } = {}) => {
+    return testApp.mount(GuidedTourStep, {
+      props: {
+        position: 'center',
+        step: 1,
+        totalSteps: 2,
+        title: 'Title',
+        content: 'Content',
+        ...props,
+      },
+    })
+  }
+
+  test('no video is shown if the step has none', async () => {
+    const wrapper = await mountComponent()
+    expect(wrapper.find('.guided-tour-step__video').exists()).toBe(false)
+  })
+
+  test('the thumbnail of the first video is shown', async () => {
+    const wrapper = await mountComponent({
+      props: { videos: ['abc', 'def'] },
+    })
+    expect(
+      wrapper.find('.guided-tour-step__video-thumbnail img').attributes().src
+    ).toBe('https://img.youtube.com/vi/abc/mqdefault.jpg')
+    expect(wrapper.find('.guided-tour-step__academy').attributes().href).toBe(
+      'https://academy.baserow.io/'
+    )
+  })
+
+  test('the video is hidden if the thumbnail can not be loaded', async () => {
+    const wrapper = await mountComponent({ props: { videos: ['abc'] } })
+
+    await wrapper
+      .find('.guided-tour-step__video-thumbnail img')
+      .trigger('error')
+
+    expect(wrapper.find('.guided-tour-step__video').exists()).toBe(false)
+  })
+
+  test('the video is shown again after moving to another step', async () => {
+    const wrapper = await mountComponent({ props: { videos: ['abc'] } })
+
+    await wrapper
+      .find('.guided-tour-step__video-thumbnail img')
+      .trigger('error')
+    await wrapper.setProps({ videos: ['def'] })
+
+    expect(
+      wrapper.find('.guided-tour-step__video-thumbnail img').attributes().src
+    ).toBe('https://img.youtube.com/vi/def/mqdefault.jpg')
+  })
+
+  test('the thumbnail is hidden until it has loaded', async () => {
+    const wrapper = await mountComponent({ props: { videos: ['abc'] } })
+    const image = () => wrapper.find('.guided-tour-step__video-thumbnail img')
+    const isVisible = () => image().element.style.display !== 'none'
+
+    expect(isVisible()).toBe(false)
+    expect(wrapper.find('.guided-tour-step__video-loading').exists()).toBe(true)
+
+    await image().trigger('load')
+
+    expect(isVisible()).toBe(true)
+    expect(wrapper.find('.guided-tour-step__video-loading').exists()).toBe(
+      false
+    )
+  })
+
+  test('the thumbnail of the previous step is not shown while loading', async () => {
+    const wrapper = await mountComponent({ props: { videos: ['abc'] } })
+    await wrapper.find('.guided-tour-step__video-thumbnail img').trigger('load')
+
+    await wrapper.setProps({ videos: ['def'] })
+
+    const image = wrapper.find('.guided-tour-step__video-thumbnail img')
+    expect(image.element.style.display).toBe('none')
+    expect(wrapper.find('.guided-tour-step__video-loading').exists()).toBe(true)
+  })
+
+  test('the thumbnail stays visible when the step is rendered again', async () => {
+    const wrapper = await mountComponent({ props: { videos: ['abc'] } })
+    await wrapper.find('.guided-tour-step__video-thumbnail img').trigger('load')
+
+    // The step getters build a new array on every render, so the same videos arrive
+    // as a new instance. That must not put the thumbnail back into loading state
+    // because the image element is not replaced and would never load again.
+    await wrapper.setProps({ videos: ['abc'] })
+
+    const image = wrapper.find('.guided-tour-step__video-thumbnail img')
+    expect(image.element.style.display).not.toBe('none')
+    expect(wrapper.find('.guided-tour-step__video-loading').exists()).toBe(
+      false
+    )
+  })
+})

--- a/web-frontend/test/unit/core/components/guidedTour/guidedTourVideoModal.spec.js
+++ b/web-frontend/test/unit/core/components/guidedTour/guidedTourVideoModal.spec.js
@@ -1,0 +1,138 @@
+import GuidedTourVideoModal from '@baserow/modules/core/components/guidedTour/GuidedTourVideoModal'
+import { TestApp } from '@baserow/test/helpers/testApp'
+
+const player = {
+  loadVideoById: vi.fn(),
+  destroy: vi.fn(),
+}
+let endVideo = null
+
+vi.mock('@baserow/modules/core/utils/youtube', async (importOriginal) => ({
+  ...(await importOriginal()),
+  createYouTubePlayer: vi.fn((element, videoId, onEnded) => {
+    endVideo = onEnded
+    return Promise.resolve(player)
+  }),
+}))
+
+describe('GuidedTourVideoModal component', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+    player.loadVideoById.mockClear()
+    player.destroy.mockClear()
+  })
+
+  afterEach(() => {
+    testApp.afterEach()
+  })
+
+  const mountAndShow = async (videos) => {
+    const wrapper = await testApp.mount(GuidedTourVideoModal, {
+      props: { videos },
+    })
+    await wrapper.vm.show(0)
+    await wrapper.vm.$nextTick()
+    return wrapper
+  }
+
+  const thumbnails = (wrapper) =>
+    wrapper.findAll('.guided-tour-video-modal__thumbnail')
+
+  test('no navigation is shown with a single video', async () => {
+    const wrapper = await mountAndShow(['abc'])
+    expect(wrapper.find('.guided-tour-video-modal__nav').exists()).toBe(false)
+    expect(thumbnails(wrapper).length).toBe(0)
+  })
+
+  test('the next button plays the next video', async () => {
+    const wrapper = await mountAndShow(['abc', 'def'])
+
+    await wrapper.find('.guided-tour-video-modal__nav--next').trigger('click')
+
+    expect(player.loadVideoById).toHaveBeenCalledWith('def')
+    expect(
+      thumbnails(wrapper)[1].classes(
+        'guided-tour-video-modal__thumbnail--active'
+      )
+    ).toBe(true)
+  })
+
+  test('the navigation does not wrap around', async () => {
+    const wrapper = await mountAndShow(['abc', 'def'])
+
+    expect(
+      wrapper
+        .find('.guided-tour-video-modal__nav--previous')
+        .classes('guided-tour-video-modal__nav--disabled')
+    ).toBe(true)
+
+    await wrapper.find('.guided-tour-video-modal__nav--next').trigger('click')
+
+    expect(
+      wrapper
+        .find('.guided-tour-video-modal__nav--next')
+        .classes('guided-tour-video-modal__nav--disabled')
+    ).toBe(true)
+  })
+
+  test('a finished video automatically starts the next one', async () => {
+    const wrapper = await mountAndShow(['abc', 'def'])
+
+    endVideo()
+    await wrapper.vm.$nextTick()
+
+    expect(player.loadVideoById).toHaveBeenCalledWith('def')
+
+    // The last video must not restart the first one.
+    endVideo()
+    expect(player.loadVideoById).toHaveBeenCalledTimes(1)
+  })
+
+  test('closing destroys the player so the video stops playing', async () => {
+    const wrapper = await mountAndShow(['abc'])
+
+    await wrapper.find('.guided-tour-video-modal__close').trigger('click')
+
+    expect(player.destroy).toHaveBeenCalled()
+  })
+
+  // The modal must only hide on `click` because hiding on `mousedown` makes the
+  // browser select the text of the page below.
+  const clickOn = async (wrapper, selector) => {
+    const element = wrapper.find(selector)
+    await element.trigger('mousedown')
+    await element.trigger('click')
+  }
+
+  test('clicking next to the video closes the modal', async () => {
+    const wrapper = await mountAndShow(['abc'])
+
+    await clickOn(wrapper, '.guided-tour-video-modal__body')
+
+    expect(player.destroy).toHaveBeenCalled()
+  })
+
+  test('clicks do not reach the page, keeping open context menus open', async () => {
+    const wrapper = await mountAndShow(['abc', 'def'])
+    const onBodyClick = vi.fn()
+    document.body.addEventListener('click', onBodyClick)
+
+    await clickOn(wrapper, '.guided-tour-video-modal__close')
+    await clickOn(wrapper, '.guided-tour-video-modal__nav--next')
+    await clickOn(wrapper, '.guided-tour-video-modal__body')
+
+    document.body.removeEventListener('click', onBodyClick)
+    expect(onBodyClick).not.toHaveBeenCalled()
+  })
+
+  test('clicking the video or a button does not close the modal', async () => {
+    const wrapper = await mountAndShow(['abc', 'def'])
+
+    await clickOn(wrapper, '.guided-tour-video-modal__player')
+    await clickOn(wrapper, '.guided-tour-video-modal__nav--next')
+
+    expect(player.destroy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
### What is in this PR

This PR adds Youtube videos from the Baserow academy to some of the guided tour steps. If the step has a video, then a thumbnail will be visible where the user can see an extra explanation on how to use that part of the tool. Clicking on the thumbnail opens a modal where the video can be seen.

<img width="1177" height="529" alt="image" src="https://github.com/user-attachments/assets/19850061-ea19-4a93-9dbe-64e8f0f4de75" />

<img width="1701" height="814" alt="image" src="https://github.com/user-attachments/assets/0c34ee40-225e-409a-9c61-7a9522e04484" />


### How to test this PR

- Confirm that each the steps with videos have matching videos related to the subject.
- Confirm that if a step has multiple videos that there are then thumbnails in the modal.
- Clicking on the "Learn more about the Baserow academy" should open Baserow academy.
- If there is no internet connection (airgapped environment), then the video should not be visible.
- If the internet connection is slow, then a loading animation should be shown for the thumbnail.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
