### PR TITLE
feat: show URL iframe placeholder in editor

### DIFF
--- a/changelog/entries/unreleased/bug/5876_clarify_in_the_application_builder_editor_when_iframe_url_co.json
+++ b/changelog/entries/unreleased/bug/5876_clarify_in_the_application_builder_editor_when_iframe_url_co.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Clarify in the Application Builder editor when IFrame URL content is only shown in preview and published applications.",
+    "issue_origin": "github",
+    "issue_number": 5876,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-08-11"
+}

--- a/changelog/entries/unreleased/bug/5876_clarify_in_the_application_builder_editor_when_iframe_url_co.json
+++ b/changelog/entries/unreleased/bug/5876_clarify_in_the_application_builder_editor_when_iframe_url_co.json
@@ -1,5 +1,5 @@
 {
-    "type": "bug",
+    "type": "feature",
     "message": "Clarify in the Application Builder editor when IFrame URL content is only shown in preview and published applications.",
     "issue_origin": "github",
     "issue_number": 5876,

--- a/web-frontend/modules/builder/components/elements/components/IFrameElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/IFrameElement.vue
@@ -16,6 +16,13 @@
           : $t('iframeElementForm.missingValue')
       }}
     </p>
+    <p
+      v-else-if="shouldShowEditorURLPlaceholder"
+      class="iframe-element__empty iframe-element__editor-placeholder"
+      :style="{ height: `${element.height}px` }"
+    >
+      {{ $t('iframeElementForm.editorPreviewPlaceholder') }}
+    </p>
     <template v-else>
       <client-only
         ><iframe
@@ -71,6 +78,13 @@ export default {
     },
     resolvedEmbed() {
       return ensureString(this.resolveFormula(this.element.embed))
+    },
+    shouldShowEditorURLPlaceholder() {
+      return (
+        this.element.source_type === IFRAME_SOURCE_TYPES.URL &&
+        Boolean(this.resolvedURL) &&
+        (this.isEditMode || this.applicationContext.mode === 'editing')
+      )
     },
     sandboxPermissions() {
       if (this.isEditMode) {

--- a/web-frontend/modules/builder/locales/en.json
+++ b/web-frontend/modules/builder/locales/en.json
@@ -334,6 +334,7 @@
   "iframeElementForm": {
     "missingValue": "Missing IFrame source...",
     "emptyValue": "Empty IFrame source...",
+    "editorPreviewPlaceholder": "This iframe isn't displayed in the editor.\nUse Preview to check how it appears in your application.",
     "sourceTypeLabel": "Source type",
     "urlLabel": "URL",
     "urlPlaceholder": "Link to the external resource to be embedded",

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/iframe_element.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/iframe_element.scss
@@ -10,6 +10,15 @@
   padding: 16px;
 }
 
+.iframe-element__editor-placeholder {
+  align-items: center;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  text-align: center;
+  white-space: pre-line;
+}
+
 .iframe-element__placeholder {
   width: 100%;
   display: flex;

--- a/web-frontend/test/unit/builder/components/elements/components/IFrameElement.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/IFrameElement.spec.js
@@ -42,13 +42,34 @@ describe('IFrameElement', () => {
     expect(wrapper.find('iframe').element).toMatchSnapshot()
   })
 
-  test('fully sandboxes external URLs in editing mode', async () => {
+  test('shows an editor placeholder for resolved external URLs', async () => {
     const wrapper = await mountComponent('editing', {
       source_type: 'url',
       url: { formula: '"https://example.com"' },
     })
 
-    expect(wrapper.find('iframe').element).toMatchSnapshot()
+    const placeholder = wrapper.find('.iframe-element__editor-placeholder')
+
+    expect(wrapper.find('iframe').exists()).toBe(false)
+    expect(placeholder.attributes('style')).toBe('height: 300px;')
+    expect(placeholder.text()).toBe(
+      'iframeElementForm.editorPreviewPlaceholder'
+    )
+  })
+
+  test('keeps the existing empty state for unresolved external URLs', async () => {
+    const wrapper = await mountComponent('editing', {
+      source_type: 'url',
+      url: { formula: '""' },
+    })
+
+    expect(wrapper.find('iframe').exists()).toBe(false)
+    expect(wrapper.find('.iframe-element__editor-placeholder').exists()).toBe(
+      false
+    )
+    expect(wrapper.find('.iframe-element__empty').text()).toBe(
+      'iframeElementForm.emptyValue'
+    )
   })
 
   test('does not sandbox user-provided content in preview mode', async () => {
@@ -81,17 +102,20 @@ describe('IFrameElement', () => {
     }
   )
 
-  test('keeps trusted URLs sandboxed in editing mode', async () => {
+  test('shows an editor placeholder for trusted URLs in editing mode', async () => {
     const wrapper = await mountComponent('editing', {
       source_type: 'url',
       url: { formula: '"https://example.com"' },
       allow_same_origin: true,
     })
 
-    expect(wrapper.find('iframe').attributes('sandbox')).toBe('')
+    expect(wrapper.find('iframe').exists()).toBe(false)
+    expect(wrapper.find('.iframe-element__editor-placeholder').exists()).toBe(
+      true
+    )
   })
 
-  test('keeps trusted URLs sandboxed when the editor force-renders them in public mode', async () => {
+  test('shows an editor placeholder when the editor force-renders URLs in public mode', async () => {
     const wrapper = await mountComponent(
       'public',
       {
@@ -102,8 +126,9 @@ describe('IFrameElement', () => {
       'editing'
     )
 
-    expect(wrapper.find('iframe').attributes('sandbox')).toBe(
-      'allow-scripts allow-forms allow-popups'
+    expect(wrapper.find('iframe').exists()).toBe(false)
+    expect(wrapper.find('.iframe-element__editor-placeholder').exists()).toBe(
+      true
     )
   })
 

--- a/web-frontend/test/unit/builder/components/elements/components/__snapshots__/IFrameElement.spec.js.snap
+++ b/web-frontend/test/unit/builder/components/elements/components/__snapshots__/IFrameElement.spec.js.snap
@@ -35,13 +35,3 @@ exports[`IFrameElement > does not sandbox user-provided content in preview mode 
   srcdoc="<script>window.parent.document.cookie</script>"
 />
 `;
-
-exports[`IFrameElement > fully sandboxes external URLs in editing mode 1`] = `
-<iframe
-  class="iframe-element__iframe"
-  height="300"
-  sandbox=""
-  src="https://example.com"
-  style="pointer-events: none;"
-/>
-`;


### PR DESCRIPTION
### What is in this PR

Closes #5876.

- Replaces resolved URL IFrames with an editor-only placeholder that explains where to verify their rendered content.
- Keeps empty URL states and HTML Embed sources unchanged.
- Keeps Preview and published-application sandbox behavior unchanged.

### How to test this PR

1. Create or edit an Application Builder IFrame element with source type **URL** and a valid external URL.
2. In the editor, verify that the URL is not loaded and that the placeholder is shown. Confirm that “Use Preview…” starts on a new line.
3. Clear the URL and verify that the existing empty-source state is still shown.
4. Switch the source type to **Embed** and verify that it still behaves as before in the editor.
5. Open Preview or a published application and verify that the URL IFrame renders as before.
6. For a trusted external URL, enable **Allow the iframe to access its own site data** and confirm it remains a placeholder in the editor while rendering in Preview/public mode.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
