### PR TITLE
fix: Improve link URL protocol validation to prevent code execution

### DIFF
--- a/changelog/entries/unreleased/bug/fix_link_url_protocol_validation_to_prevent_code_execution.json
+++ b/changelog/entries/unreleased/bug/fix_link_url_protocol_validation_to_prevent_code_execution.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed link URL protocol validation to prevent code execution.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-08-11"
+}

--- a/web-frontend/modules/builder/utils/urlResolution.js
+++ b/web-frontend/modules/builder/utils/urlResolution.js
@@ -4,6 +4,7 @@ import {
   PAGE_PARAM_TYPE_VALIDATION_FUNCTIONS,
 } from '@baserow/modules/builder/enums'
 import { ensureString } from '@baserow/modules/core/utils/validator'
+import { getUrlScheme } from '@baserow/modules/core/utils/url'
 
 /**
  * Responsible for generating the data necessary to resolve an application builder
@@ -58,6 +59,11 @@ export default function resolveElementUrl(
   } else {
     resolvedUrl = ensureString(resolveFormula(element.navigate_to_url))
   }
+  // Browsers strip leading C0 control characters and spaces before parsing
+  // a URL, so ` javascript:` reads as relative here but still executes as
+  // a script. Strip them before anything classifies this string.
+  // eslint-disable-next-line no-control-regex
+  resolvedUrl = resolvedUrl.replace(/^[\x00-\x20]+/, '')
   resolvedUrl = prefixInternalResolvedUrl(
     resolvedUrl,
     builder,
@@ -81,17 +87,12 @@ export default function resolveElementUrl(
       resolvedUrl = `${resolvedUrl}?${queryString}`
     }
   }
-  // If the protocol is a supported one, return early.
-  const protocolRegex = /^[A-Za-z]+:/
-  if (protocolRegex.test(resolvedUrl)) {
-    for (const protocol of ALLOWED_LINK_PROTOCOLS) {
-      if (resolvedUrl.toLowerCase().startsWith(protocol)) {
-        return resolvedUrl
-      }
-    }
-
+  // Browsers ignore tab / LF / CR anywhere in a URL,
+  // so `java\tscript:` is still `javascript:`.
+  const scheme = getUrlScheme(resolvedUrl)
+  if (scheme) {
     // Disallow unsupported protocols, e.g. `javascript:`
-    return ''
+    return ALLOWED_LINK_PROTOCOLS.includes(scheme) ? resolvedUrl : ''
   }
   return resolvedUrl
 }

--- a/web-frontend/test/unit/builder/utils/urlResolution.spec.js
+++ b/web-frontend/test/unit/builder/utils/urlResolution.spec.js
@@ -1,6 +1,29 @@
 import { resolveFormula } from '@baserow/modules/core/formula'
 import resolveElementUrl from '@baserow/modules/builder/utils/urlResolution'
 
+// Control characters are built with `String.fromCharCode` so they stay visible
+// in the source instead of being invisible bytes in a string literal.
+const chr = (code) => String.fromCharCode(code)
+
+/**
+ * Resolves a custom URL element for the given literal URL.
+ */
+const resolveCustomUrl = (
+  url,
+  editorMode = 'public',
+  builder = { pages: [] }
+) =>
+  resolveElementUrl(
+    {
+      navigation_type: 'custom',
+      navigate_to_url: { formula: `'${url.replace(/'/g, "\\'")}'` },
+    },
+    builder,
+    builder.pages,
+    resolveFormula,
+    editorMode
+  )
+
 describe('resolveElementUrl tests', () => {
   test('Should return empty resolvedContext with page navigation type where page is not found.', () => {
     const element = {
@@ -114,5 +137,63 @@ describe('resolveElementUrl tests', () => {
       'preview'
     )
     expect(result).toEqual('/builder/123/preview/products/')
+  })
+})
+
+describe('resolveElementUrl protocol guard tests', () => {
+  // Browsers strip leading C0 control characters and spaces, and tab / LF / CR
+  // from anywhere in a URL, before they read the scheme. Every payload below is
+  // therefore `javascript:` or `data:` as far as the browser is concerned, and
+  // must not be handed back to an `href`.
+  test.each([
+    ['no prefix', 'javascript:alert(1)'],
+    ['leading space', ' javascript:alert(1)'],
+    ['leading NULL', chr(0) + 'javascript:alert(1)'],
+    ['leading SOH', chr(1) + 'javascript:alert(1)'],
+    ['leading TAB', chr(9) + 'javascript:alert(1)'],
+    ['leading LF', chr(10) + 'javascript:alert(1)'],
+    ['leading CR', chr(13) + 'javascript:alert(1)'],
+    ['leading US', chr(31) + 'javascript:alert(1)'],
+    ['multiple leading characters', chr(1) + '  ' + 'javascript:alert(1)'],
+    ['TAB inside the scheme', 'java' + chr(9) + 'script:alert(1)'],
+    ['LF inside the scheme', 'java' + chr(10) + 'script:alert(1)'],
+    ['uppercase scheme', 'JavaScript:alert(1)'],
+    ['data url', chr(1) + 'data:text/html,<img src=x onerror=alert(1)>'],
+  ])('Should block a disallowed protocol with %s.', (label, url) => {
+    expect(resolveCustomUrl(url)).toEqual('')
+  })
+
+  test.each([
+    ['https:', 'https://baserow.io'],
+    ['http:', 'http://baserow.io'],
+    ['mailto:', 'mailto:support@baserow.io'],
+    ['tel:', 'tel:+3312345678'],
+    ['ftpes:', 'ftpes://baserow.io'],
+    ['an uppercase scheme', 'HTTPS://baserow.io'],
+  ])('Should allow %s.', (label, url) => {
+    expect(resolveCustomUrl(url)).toEqual(url)
+  })
+
+  test('Should strip leading characters from an allowed protocol.', () => {
+    expect(resolveCustomUrl(chr(1) + ' https://baserow.io')).toEqual(
+      'https://baserow.io'
+    )
+  })
+
+  test('Should leave a relative URL untouched.', () => {
+    expect(resolveCustomUrl('/contact/')).toEqual('/contact/')
+  })
+
+  test('Should not treat general Unicode whitespace as a prefix to strip.', () => {
+    // Browsers do not strip U+00A0, so this genuinely is a relative path.
+    expect(resolveCustomUrl(chr(160) + 'javascript:alert(1)')).toEqual(
+      chr(160) + 'javascript:alert(1)'
+    )
+  })
+
+  test('Should still prefix an internal URL with leading characters in preview.', () => {
+    expect(
+      resolveCustomUrl(' /contact/', 'preview', { id: 123, pages: [] })
+    ).toEqual('/builder/123/preview/contact/')
   })
 })


### PR DESCRIPTION
# What is in this PR
This PR fixes a bug in Builder's URL protocol validation. It was allowing potential code execution for public unauthenticated users on publishes apps.

# How to test this PR
In the latest `develop`:
- Create a Database table, let's call it "my urls", with a Single line text field
- Create a Builder application
  - Add a List Rows Data Source, pointing to the "my urls" table
  - Create a Table element pointing it to your data source, then configure it:
    - Collection field type: Link
    - Navigate to: Custom URL
    - Destination URL: the field of your data source
  - Create a Form element with a single Data input
    - Wire up the form with a Create a row event
    - Point it to your "my urls" table
    - Value is the Data input field formula
- Publish the application.

In your terminal shell, run this command: `printf 'java\tscript:alert(1)' | pbcopy`. This will copy a javascript alert() script into your clipboard, while preserving the tab char.

View your published app, and in the Form, paste the contents of your clipboard. Refresh the page, and you should see a new row in your table. Click the link, and you'll see the JS is executed.

In this branch, the URL protocol validation changes ensure that `javascript:` is detected, and clicking the link does nothing.

# Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
