### PR TITLE
feat: Add option to replay guided tour

### DIFF
--- a/changelog/entries/unreleased/feature/adds_an_option_to_replay_the_guided_tour.json
+++ b/changelog/entries/unreleased/feature/adds_an_option_to_replay_the_guided_tour.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Adds an option to replay the guided tour",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-08-12"
+}

--- a/web-frontend/modules/core/assets/scss/components/guided_tour_step.scss
+++ b/web-frontend/modules/core/assets/scss/components/guided_tour_step.scss
@@ -143,6 +143,18 @@
   overflow: hidden scroll;
 }
 
+.guided-tour-step__close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  color: $palette-neutral-500;
+  font-size: 16px;
+
+  &:hover {
+    color: $palette-neutral-300;
+  }
+}
+
 .guided-tour-step__page {
   color: $palette-neutral-500;
   font-size: 11px;

--- a/web-frontend/modules/core/components/guidedTour/GuidedTour.vue
+++ b/web-frontend/modules/core/components/guidedTour/GuidedTour.vue
@@ -20,8 +20,10 @@
         :position="currentStep.position"
         :button-text="currentStep.buttonText"
         :videos="currentStep.videos"
+        :stoppable="forced"
         @previous="goto(stepIndex - 1)"
         @next="next"
+        @stop="stop"
       ></GuidedTourStep>
     </Highlight>
   </div>
@@ -49,6 +51,12 @@ export default {
           return this.authenticated
         })
         .filter((type) => {
+          if (this.forced) {
+            // A manually replayed tour must be shown even if it has already been
+            // completed, but tours that must only be seen the first time are
+            // excluded.
+            return type.showOnReplay
+          }
           return !this.completed.includes(type.getType())
         })
         .filter((type) => type.isActive(this.$route))
@@ -58,7 +66,9 @@ export default {
       return this.activeGuidedTours.length > 0
     },
     allSteps() {
-      return this.activeGuidedTours.flatMap((type) => type.steps)
+      return this.activeGuidedTours
+        .flatMap((type) => type.steps)
+        .filter((step) => !this.forced || step.showOnReplay)
     },
     currentStep() {
       return this.allSteps[this.stepIndex]
@@ -66,12 +76,23 @@ export default {
     ...mapGetters({
       authenticated: 'auth/isAuthenticated',
       completed: 'auth/getCompletedGuidedTour',
+      forced: 'guidedTour/isForced',
     }),
   },
   watch: {
     started(value) {
-      if (value) {
+      // A forced start is handled by the `forced` watcher, which can't be done here
+      // because the tour could already be started when it changes.
+      if (value && !this.forced) {
         this.show()
+      }
+    },
+    forced(value) {
+      if (value) {
+        this.stepIndex = 0
+        if (this.started) {
+          this.show()
+        }
       }
     },
     activeGuidedTours(value) {
@@ -110,7 +131,22 @@ export default {
       await this.$nextTick()
       this.$refs.highlight.show(step.selectors)
     },
+    async stop() {
+      const step = this.allSteps[this.stepIndex]
+      await step.afterShow()
+
+      this.$refs.highlight.hide()
+      this.stepIndex = 0
+      await this.$store.dispatch('guidedTour/stop')
+    },
     async finish() {
+      if (this.forced) {
+        // A manually restarted tour must not save the completed state because it has
+        // typically already been completed, and it must be possible to restart it
+        // again.
+        return await this.stop()
+      }
+
       const step = this.allSteps[this.stepIndex]
       await step.afterShow()
 

--- a/web-frontend/modules/core/components/guidedTour/GuidedTourStep.vue
+++ b/web-frontend/modules/core/components/guidedTour/GuidedTourStep.vue
@@ -1,6 +1,14 @@
 <template>
   <div :class="`guided-tour-step guided-tour-step--${position}`">
     <div v-auto-overflow-scroll class="guided-tour-step__body">
+      <a
+        v-if="stoppable"
+        class="guided-tour-step__close"
+        :title="$t('guidedTourStep.stopTour')"
+        @click="$emit('stop')"
+      >
+        <i class="iconoir-cancel"></i>
+      </a>
       <div class="guided-tour-step__page">
         {{ $t('guidedTourStep.step', { step, totalSteps }) }}
       </div>
@@ -117,8 +125,13 @@ export default {
       required: false,
       default: () => [],
     },
+    stoppable: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
-  emits: ['next', 'previous'],
+  emits: ['next', 'previous', 'stop'],
   data() {
     return {
       thumbnailFailed: false,

--- a/web-frontend/modules/core/components/guidedTour/GuidedTourStep.vue
+++ b/web-frontend/modules/core/components/guidedTour/GuidedTourStep.vue
@@ -3,9 +3,11 @@
     <div v-auto-overflow-scroll class="guided-tour-step__body">
       <a
         v-if="stoppable"
+        href="#"
         class="guided-tour-step__close"
         :title="$t('guidedTourStep.stopTour')"
-        @click="$emit('stop')"
+        :aria-label="$t('guidedTourStep.stopTour')"
+        @click.prevent="$emit('stop')"
       >
         <i class="iconoir-cancel"></i>
       </a>

--- a/web-frontend/modules/core/components/sidebar/SidebarUserContext.vue
+++ b/web-frontend/modules/core/components/sidebar/SidebarUserContext.vue
@@ -99,7 +99,7 @@
 
         <li class="context__menu-item">
           <a class="context__menu-item-link" @click="replayGuidedTour()">
-            <i class="context__menu-item-icon iconoir-help-square"></i>
+            <i class="context__menu-item-icon iconoir-help-circle"></i>
             {{ $t('sidebar.replayGuidedTour') }}
           </a>
         </li>

--- a/web-frontend/modules/core/components/sidebar/SidebarUserContext.vue
+++ b/web-frontend/modules/core/components/sidebar/SidebarUserContext.vue
@@ -97,6 +97,13 @@
           <SettingsModal ref="settingsModal"></SettingsModal>
         </li>
 
+        <li class="context__menu-item">
+          <a class="context__menu-item-link" @click="replayGuidedTour()">
+            <i class="context__menu-item-icon iconoir-help-square"></i>
+            {{ $t('sidebar.replayGuidedTour') }}
+          </a>
+        </li>
+
         <component
           :is="component"
           v-for="(component, index) in sidebarUserContextComponents"
@@ -229,6 +236,11 @@ export default {
         await pageFinished(this.nuxtApp)
         await nextTick()
       } catch {}
+    },
+    async replayGuidedTour() {
+      this.hide()
+      await this.$nextTick()
+      await this.$store.dispatch('guidedTour/forceStart')
     },
     hasUnreadNotifications(workspaceId) {
       return this.$store.getters['notification/workspaceHasUnread'](workspaceId)

--- a/web-frontend/modules/core/guidedTourTypes.js
+++ b/web-frontend/modules/core/guidedTourTypes.js
@@ -20,7 +20,17 @@ export class GuidedTourType extends Registerable {
 
   /**
    * Hook that is called when whole onboarding completes, and this one was included.
+   */
   completed() {}
+
+  /**
+   * Indicates whether this tour must be included when the user manually replays the
+   * guided tour. Tours that must only be seen the first time, like one-off
+   * announcements, can return false here.
+   */
+  get showOnReplay() {
+    return true
+  }
 
   /**
    * Should return true if the guided tour should is active and should be shown. This
@@ -100,6 +110,14 @@ export class GuidedTourStep {
 
   get highlightPadding() {
     return this._highlightPadding
+  }
+
+  /**
+   * Indicates whether this step must be included when the user manually replays the
+   * guided tour. Steps that must only be seen the first time can return false here.
+   */
+  get showOnReplay() {
+    return true
   }
 
   /**

--- a/web-frontend/modules/core/locales/en.json
+++ b/web-frontend/modules/core/locales/en.json
@@ -65,6 +65,7 @@
     "dashboard": "Dashboard",
     "trash": "Trash",
     "settings": "My settings",
+    "replayGuidedTour": "Replay guided tour",
     "notifications": "Notifications",
     "adminSettings": "Admin settings",
     "general": "General",
@@ -1199,7 +1200,8 @@
     "gotIt": "Got it",
     "next": "Next",
     "back": "Back",
-    "watchVideo": "Watch video"
+    "watchVideo": "Watch video",
+    "stopTour": "Stop tour"
   },
   "guidedTourVideoModal": {
     "previous": "Previous video",

--- a/web-frontend/modules/core/plugins/store.js
+++ b/web-frontend/modules/core/plugins/store.js
@@ -16,6 +16,7 @@ import routeMountedStoreModule from '../store/routeMounted'
 import integrationStoreModule from '../store/integration'
 import presenceStoreModule from '../store/presence'
 import aiProviderStoreModule from '../store/aiProvider'
+import guidedTourStoreModule from '../store/guidedTour'
 
 export default defineNuxtPlugin({
   name: 'create-store',
@@ -38,6 +39,7 @@ export default defineNuxtPlugin({
         integration: integrationStoreModule,
         presence: presenceStoreModule,
         aiProvider: aiProviderStoreModule,
+        guidedTour: guidedTourStoreModule,
       },
     })
     nuxtApp.vueApp.use(store)

--- a/web-frontend/modules/core/store/guidedTour.js
+++ b/web-frontend/modules/core/store/guidedTour.js
@@ -1,0 +1,35 @@
+export const state = () => ({
+  // Indicates whether the user manually started the guided tour, ignoring the
+  // completed state of the tours. Nothing is saved to the backend when a forced
+  // tour finishes, and the user can stop it at any time.
+  forced: false,
+})
+
+export const mutations = {
+  SET_FORCED(state, forced) {
+    state.forced = forced
+  },
+}
+
+export const actions = {
+  forceStart({ commit }) {
+    commit('SET_FORCED', true)
+  },
+  stop({ commit }) {
+    commit('SET_FORCED', false)
+  },
+}
+
+export const getters = {
+  isForced(state) {
+    return state.forced
+  },
+}
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations,
+}

--- a/web-frontend/test/unit/core/components/guidedTour/guidedTour.spec.js
+++ b/web-frontend/test/unit/core/components/guidedTour/guidedTour.spec.js
@@ -1,0 +1,221 @@
+import flushPromises from 'flush-promises'
+import GuidedTour from '@baserow/modules/core/components/guidedTour/GuidedTour'
+import {
+  GuidedTourType,
+  GuidedTourStep,
+} from '@baserow/modules/core/guidedTourTypes'
+import { TestApp } from '@baserow/test/helpers/testApp'
+
+class TestGuidedTourStep extends GuidedTourStep {
+  constructor(app, content, { showOnReplay = true } = {}) {
+    super(app, 'Title', content)
+    this._showOnReplay = showOnReplay
+  }
+
+  get selectors() {
+    return []
+  }
+
+  get position() {
+    return 'center'
+  }
+
+  get showOnReplay() {
+    return this._showOnReplay
+  }
+}
+
+class MainTestGuidedTourType extends GuidedTourType {
+  static getType() {
+    return 'test_main'
+  }
+
+  get steps() {
+    return [
+      new TestGuidedTourStep(this.app, 'main step 1'),
+      new TestGuidedTourStep(this.app, 'main step 2 first time only', {
+        showOnReplay: false,
+      }),
+      new TestGuidedTourStep(this.app, 'main step 3'),
+    ]
+  }
+
+  get order() {
+    return 1
+  }
+
+  isActive() {
+    return true
+  }
+}
+
+class FirstTimeOnlyTestGuidedTourType extends GuidedTourType {
+  static getType() {
+    return 'test_first_time_only'
+  }
+
+  get showOnReplay() {
+    return false
+  }
+
+  get steps() {
+    return [new TestGuidedTourStep(this.app, 'first time only tour step')]
+  }
+
+  get order() {
+    return 2
+  }
+
+  isActive() {
+    return true
+  }
+}
+
+describe('GuidedTour component', () => {
+  let testApp = null
+  let store = null
+  const originalResizeObserver = globalThis.ResizeObserver
+
+  beforeAll(() => {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  })
+
+  afterAll(() => {
+    globalThis.ResizeObserver = originalResizeObserver
+  })
+
+  beforeEach(() => {
+    testApp = new TestApp()
+    store = testApp.store
+
+    // Replace the real guided tours with predictable test tours so the assertions
+    // don't depend on their steps.
+    const registry = testApp.getRegistry()
+    Object.keys(registry.getAll('guidedTour')).forEach((type) =>
+      registry.unregister('guidedTour', type)
+    )
+    const context = { app: testApp.getApp() }
+    registry.register('guidedTour', new MainTestGuidedTourType(context))
+    registry.register(
+      'guidedTour',
+      new FirstTimeOnlyTestGuidedTourType(context)
+    )
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  const authenticate = (completedGuidedTours) => {
+    store.dispatch('auth/forceSetUserData', {
+      user: {
+        id: 256,
+        completed_guided_tours: completedGuidedTours,
+      },
+      access_token:
+        `eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImpvaG5AZXhhb` +
+        `XBsZS5jb20iLCJpYXQiOjE2NjAyOTEwODYsImV4cCI6MTY2MDI5NDY4NiwianRpIjo` +
+        `iNDZmNzUwZWUtMTJhMS00N2UzLWJiNzQtMDIwYWM4Njg3YWMzIiwidXNlcl9pZCI6M` +
+        `iwidXNlcl9wcm9maWxlX2lkIjpbMl0sIm9yaWdfaWF0IjoxNjYwMjkxMDg2fQ.RQ-M` +
+        `NQdDR9zTi8CbbQkRrwNsyDa5CldQI83Uid1l9So`,
+    })
+  }
+
+  const visibleStepContent = (wrapper) =>
+    wrapper.find('.guided-tour-step__description').text()
+
+  const clickNext = async (wrapper) => {
+    await wrapper.find('.guided-tour-step__foot button').trigger('click')
+    await flushPromises()
+  }
+
+  test('tours start automatically the first time and save the completed state', async () => {
+    authenticate([])
+    testApp.mock.onPatch('/user/account/').reply(200, {})
+
+    const wrapper = await testApp.mount(GuidedTour, {})
+
+    expect(wrapper.find('.guided-tour-step').exists()).toBe(true)
+    // Automatically started tours cannot be stopped.
+    expect(wrapper.find('.guided-tour-step__close').exists()).toBe(false)
+
+    // All steps of both tours are included, in order.
+    for (const content of [
+      'main step 1',
+      'main step 2 first time only',
+      'main step 3',
+      'first time only tour step',
+    ]) {
+      expect(visibleStepContent(wrapper)).toBe(content)
+      await clickNext(wrapper)
+    }
+
+    expect(wrapper.find('.guided-tour-step').exists()).toBe(false)
+    expect(testApp.mock.history.patch.length).toBe(1)
+    expect(JSON.parse(testApp.mock.history.patch[0].data)).toEqual({
+      completed_guided_tours: ['test_main', 'test_first_time_only'],
+    })
+  })
+
+  test('completed tours do not start automatically', async () => {
+    authenticate(['test_main', 'test_first_time_only'])
+
+    const wrapper = await testApp.mount(GuidedTour, {})
+
+    expect(wrapper.find('.guided-tour-step').exists()).toBe(false)
+  })
+
+  test(
+    'replaying includes completed tours, skips first time only tours and ' +
+      'steps, and does not save',
+    async () => {
+      authenticate(['test_main', 'test_first_time_only'])
+
+      const wrapper = await testApp.mount(GuidedTour, {})
+      await store.dispatch('guidedTour/forceStart')
+      await flushPromises()
+
+      expect(wrapper.find('.guided-tour-step').exists()).toBe(true)
+      // Manually replayed tours can be stopped.
+      expect(wrapper.find('.guided-tour-step__close').exists()).toBe(true)
+
+      // The `test_first_time_only` tour and the second step of the `test_main`
+      // tour are excluded because of their `showOnReplay` value.
+      for (const content of ['main step 1', 'main step 3']) {
+        expect(visibleStepContent(wrapper)).toBe(content)
+        await clickNext(wrapper)
+      }
+
+      expect(wrapper.find('.guided-tour-step').exists()).toBe(false)
+      expect(store.getters['guidedTour/isForced']).toBe(false)
+      // Finishing a replayed tour must not persist anything.
+      expect(testApp.mock.history.patch.length).toBe(0)
+    }
+  )
+
+  test('a replayed tour can be stopped and replayed again', async () => {
+    authenticate(['test_main', 'test_first_time_only'])
+
+    const wrapper = await testApp.mount(GuidedTour, {})
+    await store.dispatch('guidedTour/forceStart')
+    await flushPromises()
+
+    await wrapper.find('.guided-tour-step__close').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('.guided-tour-step').exists()).toBe(false)
+    expect(store.getters['guidedTour/isForced']).toBe(false)
+    expect(testApp.mock.history.patch.length).toBe(0)
+
+    // Replaying again restarts from the first step.
+    await store.dispatch('guidedTour/forceStart')
+    await flushPromises()
+
+    expect(wrapper.find('.guided-tour-step').exists()).toBe(true)
+    expect(visibleStepContent(wrapper)).toBe('main step 1')
+  })
+})

--- a/web-frontend/test/unit/core/components/guidedTour/guidedTourStep.spec.js
+++ b/web-frontend/test/unit/core/components/guidedTour/guidedTourStep.spec.js
@@ -25,6 +25,19 @@ describe('GuidedTourStep component', () => {
     })
   }
 
+  test('no close button is shown if the step is not stoppable', async () => {
+    const wrapper = await mountComponent()
+    expect(wrapper.find('.guided-tour-step__close').exists()).toBe(false)
+  })
+
+  test('clicking the close button of a stoppable step emits stop', async () => {
+    const wrapper = await mountComponent({ props: { stoppable: true } })
+
+    await wrapper.find('.guided-tour-step__close').trigger('click')
+
+    expect(wrapper.emitted('stop')).toHaveLength(1)
+  })
+
   test('no video is shown if the step has none', async () => {
     const wrapper = await mountComponent()
     expect(wrapper.find('.guided-tour-step__video').exists()).toBe(false)


### PR DESCRIPTION
Related to SaaS PR: https://github.com/baserow/baserow-saas/pull/2. <- this one must be reviewed as well.

### What is in this PR

This PR introduces a button in the sidebar user context menu to replay the guided tour. If clicked, it will check which page the user is on (database, automation, etc) and will replay the correct tour. In replay mode, it's possible to stop the guided tour.

I've introduced the `showOnReplay` method for the cloud version. Here we have a step that shows the free trial started to the user, but that one should always be excluded.

<img width="521" height="387" alt="image" src="https://github.com/user-attachments/assets/1a23098f-9287-4b08-aac7-06a8559b90fb" />


### How to test this PR

- Confirm that sidebar + database tour starts if the button is clicked while looking at a table.
- Confirm that sidebar + application tour starts if the button is clicked while looking at an application page.
- Confirm that sidebar + automation tour starts if the button is clicked while looking at an automation workflow.
- Confirm that it's possible to stop the guided tour, if started manually.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
