### PR TITLE
fix: use array-aware sort for lookup fields in frontend sort comparison

### DIFF
--- a/changelog/entries/unreleased/bug/5893_fixed_frontend_sorting_by_lookup_fields__rows_no_longer_jump.json
+++ b/changelog/entries/unreleased/bug/5893_fixed_frontend_sorting_by_lookup_fields__rows_no_longer_jump.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed frontend sorting by lookup fields \u2014 rows no longer jump to wrong positions when created or updated in a view sorted by a lookup field.",
+    "issue_origin": "github",
+    "issue_number": 5893,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-12"
+}

--- a/web-frontend/modules/database/formula/formulaTypes.js
+++ b/web-frontend/modules/database/formula/formulaTypes.js
@@ -828,6 +828,15 @@ export class BaserowFormulaArrayType extends mix(
     }
   }
 
+  getSortTypes(field) {
+    return {
+      [DEFAULT_SORT_TYPE_KEY]: {
+        function: this.getSort.bind(this),
+        indicator: this.getSortIndicator(field),
+      },
+    }
+  }
+
   getSortIndicator(field) {
     const underlyingFieldType = this.app.$registry.get(
       'field',

--- a/web-frontend/test/unit/database/utils/row.spec.js
+++ b/web-frontend/test/unit/database/utils/row.spec.js
@@ -431,6 +431,116 @@ describe('Row utilities', () => {
       })
       expect(matchSortings).toBe(true)
     })
+
+    test('lookup (array formula) field sort correctly compares array values', () => {
+      const lookupField = {
+        id: 2,
+        name: 'Lookup',
+        type: 'formula',
+        formula_type: 'array',
+        array_formula_type: 'text',
+      }
+      const rows = [
+        {
+          id: 1,
+          order: '1.00000000000000000000',
+          field_2: [{ id: 20, value: 'Alpha' }],
+        },
+        {
+          id: 2,
+          order: '2.00000000000000000000',
+          field_2: [{ id: 20, value: 'Alpha' }],
+        },
+        {
+          id: 3,
+          order: '3.00000000000000000000',
+          field_2: [{ id: 10, value: 'Beta' }],
+        },
+      ]
+      const { matchSortings } = computeRowMatchFlags({
+        row: { id: 2, field_2: [{ id: 20, value: 'Alpha' }] },
+        view: baseView({
+          sortings: [{ field: 2, order: 'ASC', type: 'default' }],
+        }),
+        fields: [lookupField],
+        registry: store.$registry,
+        rowsInSortingGroup: rows,
+      })
+      expect(matchSortings).toBe(true)
+    })
+
+    test('lookup field sort detects row out of position', () => {
+      const lookupField = {
+        id: 2,
+        name: 'Lookup',
+        type: 'formula',
+        formula_type: 'array',
+        array_formula_type: 'text',
+      }
+      const rows = [
+        {
+          id: 1,
+          order: '1.00000000000000000000',
+          field_2: [{ id: 10, value: 'Beta' }],
+        },
+        {
+          id: 2,
+          order: '2.00000000000000000000',
+          field_2: [{ id: 20, value: 'Alpha' }],
+        },
+      ]
+      const { matchSortings } = computeRowMatchFlags({
+        row: { id: 2, field_2: [{ id: 20, value: 'Alpha' }] },
+        view: baseView({
+          sortings: [{ field: 2, order: 'ASC', type: 'default' }],
+        }),
+        fields: [lookupField],
+        registry: store.$registry,
+        rowsInSortingGroup: rows,
+      })
+      expect(matchSortings).toBe(false)
+    })
+
+    test('computeRowInsertPosition sorts lookup array values correctly', () => {
+      const lookupField = {
+        id: 2,
+        name: 'Lookup',
+        type: 'formula',
+        formula_type: 'array',
+        array_formula_type: 'text',
+      }
+      const existingRows = [
+        {
+          id: 1,
+          order: '1.00000000000000000000',
+          field_2: [{ id: 20, value: 'Alpha' }],
+        },
+        {
+          id: 3,
+          order: '3.00000000000000000000',
+          field_2: [{ id: 10, value: 'Beta' }],
+        },
+        {
+          id: 4,
+          order: '4.00000000000000000000',
+          field_2: [{ id: 30, value: 'Gamma' }],
+        },
+      ]
+      const newRow = {
+        id: 99,
+        order: '2.50000000000000000000',
+        field_2: [{ id: 20, value: 'Alpha' }],
+      }
+      const position = computeRowInsertPosition(
+        newRow,
+        existingRows,
+        [{ field: 2, order: 'ASC', type: 'default' }],
+        [lookupField],
+        store.$registry
+      )
+      expect(position.sortedIndex).toBe(1)
+      expect(position.anchorRowId).toBe(1)
+    })
   })
 
   describe('buildNewRowDefaults', () => {


### PR DESCRIPTION
## Summary

- Fixed a bug where sorting by a lookup (or any array formula) field was completely ignored in frontend sort comparisons, causing rows to jump to wrong positions on insert/update
- Root cause: `BaserowFormulaArrayType` overrode `getSort()` but not `getSortTypes()` — the sort system calls `getSortTypes()`, which fell through to the base class and returned the plain text field sort that can't compare array values
- Added `getSortTypes()` override to wire the existing array-aware sort function into the sort system
- Added tests for `computeRowMatchFlags` and `computeRowInsertPosition` with lookup field values

### Example after fix

https://github.com/user-attachments/assets/ede02726-75d7-4ea3-84bf-19b6295e24c3

## Test plan

- [ ] Create a table with a link row field and a lookup field
- [ ] Sort the view by the lookup field
- [ ] Insert a new row and set the linked record — verify no false "Row has moved" warning
- [ ] Verify the row stays in correct sorted position after clicking outside
- [ ] Verify existing sort behavior for text, single select, and multiple select fields is unchanged
- [ ] Run `just f yarn test:core test/unit/database/utils/row.spec.js` — 38 tests pass
- [ ] Run `just f yarn test:core test/unit/database/fieldTypesGetSort.spec.js` — 10 tests pass

Closes #5893 

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
