### PR TITLE
fix: stop collab formulas blanking multiple select totext value

### DIFF
--- a/backend/src/baserow/contrib/database/formula/ast/function_defs.py
+++ b/backend/src/baserow/contrib/database/formula/ast/function_defs.py
@@ -2375,18 +2375,33 @@ class BaserowStringAggManyToManyValues(OneArgumentBaserowFunction):
         func_call: BaserowFunctionCall,
         arg: BaserowExpression[BaserowFormulaValidType],
     ) -> BaserowExpression[BaserowFormulaType]:
-        if getattr(arg.expression_type, "custom_string_agg_value_key", None):
-            # E.g. the multiple collaborators type aggregates `first_name`
-            # instead of `value`. Rewrite to the dedicated function so the key
-            # is bound to the call instead of mutated on this singleton. Typing
-            # re-runs whenever a formula is recompiled, so previously saved
-            # internal formulas referencing this function are rewritten too.
+        custom_value_key = getattr(
+            arg.expression_type, "custom_string_agg_value_key", None
+        )
+        if custom_value_key is None or custom_value_key == self.value_key:
+            return func_call.with_valid_type(BaserowFormulaTextType())
+        if custom_value_key == BaserowStringAggCollaboratorValues.value_key:
+            # The multiple collaborators type aggregates `first_name` instead
+            # of `value`. Rewrite to the dedicated function so the key is bound
+            # to the call instead of mutated on this singleton. Typing re-runs
+            # whenever a formula is recompiled, so previously saved internal
+            # formulas referencing this function are rewritten too.
             from baserow.contrib.database.formula.registries import (
                 formula_function_registry,
             )
 
-            return formula_function_registry.get("string_agg_collaborator_values")(arg)
-        return func_call.with_valid_type(BaserowFormulaTextType())
+            return formula_function_registry.get(
+                BaserowStringAggCollaboratorValues.type
+            )(arg)
+        # A new type declaring another custom key needs its own dedicated
+        # function def with a matching class-level `value_key` - fail loudly
+        # instead of silently aggregating the wrong key.
+        return func_call.with_invalid_type(
+            f"custom_string_agg_value_key must be either None, "
+            f"'{self.value_key}' or "
+            f"'{BaserowStringAggCollaboratorValues.value_key}', "
+            f"got '{custom_value_key}'"
+        )
 
     def to_django_expression(self, arg: Expression) -> Expression:
         return Func(
@@ -2421,14 +2436,9 @@ class BaserowStringAggCollaboratorValues(BaserowStringAggManyToManyValues):
     type = "string_agg_collaborator_values"
     arg_type = [BaserowFormulaMultipleCollaboratorsType]
     # Matches `BaserowFormulaMultipleCollaboratorsType.custom_string_agg_value_key`.
+    # The inherited `type_function` recognises the argument type's custom key as
+    # this class's `value_key` and types the call as-is.
     value_key = "first_name"
-
-    def type_function(
-        self,
-        func_call: BaserowFunctionCall,
-        arg: BaserowExpression[BaserowFormulaValidType],
-    ) -> BaserowExpression[BaserowFormulaType]:
-        return func_call.with_valid_type(BaserowFormulaTextType())
 
 
 # Deprecated, use BaserowManyToManyAgg instead. This is kept for backwards compatibility

--- a/backend/src/baserow/contrib/database/formula/ast/function_defs.py
+++ b/backend/src/baserow/contrib/database/formula/ast/function_defs.py
@@ -271,6 +271,7 @@ def register_formula_functions(registry):
     registry.register(BaserowLast())
     # ManyToMany functions
     registry.register(BaserowStringAggManyToManyValues())
+    registry.register(BaserowStringAggCollaboratorValues())
     registry.register(BaserowManyToManyCount())
     registry.register(BaserowManyToManyAgg())
 
@@ -2361,21 +2362,30 @@ class BaserowStringAggManyToManyValues(OneArgumentBaserowFunction):
         BaserowFormulaMultipleCollaboratorsType,
     ]
     aggregate = True
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Can be overridden in type_function from the arg.expression_type
-        self.value_key = "value"
+    # The key extracted from each JSON object being aggregated. This is a
+    # class-level constant on purpose: function defs are registry singletons,
+    # so per-call mutation would leak into every other formula compiled in the
+    # same process. Argument types needing a different key get their own
+    # function def (see `BaserowStringAggCollaboratorValues`), selected at
+    # typing time below.
+    value_key = "value"
 
     def type_function(
         self,
         func_call: BaserowFunctionCall,
         arg: BaserowExpression[BaserowFormulaValidType],
     ) -> BaserowExpression[BaserowFormulaType]:
-        if value_key := getattr(
-            arg.expression_type, "custom_string_agg_value_key", None
-        ):
-            self.value_key = value_key
+        if getattr(arg.expression_type, "custom_string_agg_value_key", None):
+            # E.g. the multiple collaborators type aggregates `first_name`
+            # instead of `value`. Rewrite to the dedicated function so the key
+            # is bound to the call instead of mutated on this singleton. Typing
+            # re-runs whenever a formula is recompiled, so previously saved
+            # internal formulas referencing this function are rewritten too.
+            from baserow.contrib.database.formula.registries import (
+                formula_function_registry,
+            )
+
+            return formula_function_registry.get("string_agg_collaborator_values")(arg)
         return func_call.with_valid_type(BaserowFormulaTextType())
 
     def to_django_expression(self, arg: Expression) -> Expression:
@@ -2399,6 +2409,26 @@ class BaserowStringAggManyToManyValues(OneArgumentBaserowFunction):
                 function="array_to_string",
             )
         )
+
+
+class BaserowStringAggCollaboratorValues(BaserowStringAggManyToManyValues):
+    """
+    Variant of `string_agg_many_to_many_values` for the multiple collaborators
+    type, which aggregates each collaborator's `first_name` rather than a
+    `value` key.
+    """
+
+    type = "string_agg_collaborator_values"
+    arg_type = [BaserowFormulaMultipleCollaboratorsType]
+    # Matches `BaserowFormulaMultipleCollaboratorsType.custom_string_agg_value_key`.
+    value_key = "first_name"
+
+    def type_function(
+        self,
+        func_call: BaserowFunctionCall,
+        arg: BaserowExpression[BaserowFormulaValidType],
+    ) -> BaserowExpression[BaserowFormulaType]:
+        return func_call.with_valid_type(BaserowFormulaTextType())
 
 
 # Deprecated, use BaserowManyToManyAgg instead. This is kept for backwards compatibility

--- a/backend/tests/baserow/contrib/database/formula/test_baserow_formula_results.py
+++ b/backend/tests/baserow/contrib/database/formula/test_baserow_formula_results.py
@@ -30,6 +30,7 @@ from baserow.contrib.database.formula.ast.function_defs import (
     BaserowManyToManyCount,
     BaserowMultipleSelectCount,
     BaserowMultipleSelectOptionsAgg,
+    BaserowStringAggCollaboratorValues,
     BaserowStringAggManyToManyValues,
     BaserowStringAggMultipleSelectValues,
 )
@@ -1154,6 +1155,7 @@ def test_aggregate_functions_never_allow_non_many_inputs(data_fixture, api_clien
         BaserowManyToManyAgg.type,
         BaserowManyToManyCount.type,
         BaserowStringAggManyToManyValues.type,
+        BaserowStringAggCollaboratorValues.type,
     }
     custom_cases = {
         BaserowAggJoin.type: [
@@ -1260,6 +1262,7 @@ def test_aggregate_functions_can_be_referenced_by_other_formulas(
         BaserowStringAggMultipleSelectValues.type,
         # Multiple collaborators formulas
         BaserowStringAggManyToManyValues.type,
+        BaserowStringAggCollaboratorValues.type,
     }
 
     for formula_func in formula_function_registry.get_all():

--- a/changelog/entries/unreleased/bug/fixes_multiple_select_formulas_showing_blank_text_after_usin.json
+++ b/changelog/entries/unreleased/bug/fixes_multiple_select_formulas_showing_blank_text_after_usin.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixes multiple select formulas showing blank text after using a collaborators field in a formula",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-13"
+}

--- a/enterprise/backend/tests/baserow_enterprise_tests/assistant/test_assistant_database_table_tools.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/assistant/test_assistant_database_table_tools.py
@@ -583,6 +583,7 @@ def test_generate_formula_documentation_completeness(data_fixture):
         "jsonb_extract_path_text",
         "array_agg_no_nesting",
         "string_agg_many_to_many_values",
+        "string_agg_collaborator_values",
         "many_to_many_agg",
         "many_to_many_count",
         "array_length",

--- a/premium/backend/tests/baserow_premium_tests/api/fields/test_generate_formula_prompt.py
+++ b/premium/backend/tests/baserow_premium_tests/api/fields/test_generate_formula_prompt.py
@@ -21,6 +21,7 @@ def test_if_prompt_contains_all_formula_functions():
         "jsonb_extract_path_text",
         "array_agg_no_nesting",
         "string_agg_many_to_many_values",
+        "string_agg_collaborator_values",
         "many_to_many_agg",
         "many_to_many_count",
         "array_length",


### PR DESCRIPTION
## What

Fixes a formula bug where `totext()` (or any text coercion, e.g. `concat()`) over a **multiple select** field could return blank values for every row.

I discovered this [in my AB undo/redo PR](https://github.com/baserow/baserow/pull/5691) - if `test_durations` aren't updated, you can end up in a state where the tests below are grouped together, and block CI from passing. It's *quite* difficult to debug.

## Why

`BaserowStringAggManyToManyValues` — the registered formula function that stringifies multi-value fields — is a **registry singleton**, but stored its extraction key as mutable instance state. Typing any formula that stringifies a **multiple collaborators** field switched that key to `first_name`, permanently, for the whole Python process:

```python
def type_function(self, func_call, arg):
    if value_key := getattr(arg.expression_type, "custom_string_agg_value_key", None):
        self.value_key = value_key  # mutates the shared singleton, never reset
```

Every multiple select `totext()` compiled afterwards in that process then generated `jsonb_extract_path_text(elem, 'first_name')` — a key that doesn’t exist on select option objects — so `string_agg` aggregated nothing and the `when_empty` wrapper produced `''` for every row. Silently: the SQL is valid, nothing errors.

In production this poisons long-lived gunicorn/Celery workers: once a worker compiles any collaborators-text formula, every multiple select text formula it computes afterwards writes blank values. A table containing *both* formula kinds is broken deterministically on every row write. Latent since collaborators became usable in formulas (January 2025).

In CI it surfaced as an “unrelated” deterministic failure of `test_can_use_formula_on_lookup_of_multiple_select_fields[totext(...)]` whenever pytest-split happened to schedule `test_multiple_collaborators_field_type_values_can_be_stringified` earlier in the same xdist worker.

## How

Simply resetting the key per call is not enough: a single row-insert types **all** of a table’s formula fields first, then generates SQL for all of them, so one shared slot cannot serve two types in one statement.

Instead, the variation is bound to the call at typing time, following the existing pattern for type-dependent aggregations:

- `value_key` becomes an immutable **class attribute** (`"value"`); nothing mutates the singleton anymore.
- `type_function` rewrites collaborator calls to a new dedicated internal function, `string_agg_collaborator_values`, whose class-level `value_key` is `"first_name"`.
- Typing re-runs whenever a stored formula is recompiled, so existing saved formulas are rewritten transparently — no migration needed.
- The new internal function is added to the AI-prompt/documentation exception lists that enumerate the registry.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
    - Why: because it's not just a CI issue, it technically can happen in production too.
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
