### PR TITLE
fix: builder and database adhoc search improvements

### DIFF
--- a/backend/src/baserow/contrib/builder/data_sources/builder_dispatch_context.py
+++ b/backend/src/baserow/contrib/builder/data_sources/builder_dispatch_context.py
@@ -201,6 +201,22 @@ class BuilderDispatchContext(DispatchContext):
 
         return self.cache["element_property_options"]
 
+    def is_adhoc_refinable(self, service) -> bool:
+        """
+        Adhoc refinements (search, filters and sortings) provided by the HTTP
+        request only apply to the data source the request targets. While that
+        data source is being dispatched, formulas (e.g. in its service
+        filters) can trigger nested dispatches of other data sources; the
+        request's refinements must not be applied to those, as e.g. the
+        searchable field ids of the requested data source's element don't
+        exist in the nested data source's table.
+
+        :param service: The service that is currently being dispatched.
+        :return: Whether adhoc refinements may be applied to this service.
+        """
+
+        return self.data_source is None or self.data_source.service_id == service.id
+
     @property
     def is_publicly_searchable(self) -> bool:
         """

--- a/backend/src/baserow/contrib/database/search/handler.py
+++ b/backend/src/baserow/contrib/database/search/handler.py
@@ -226,6 +226,14 @@ class SearchHandler:
         :return: A filtered queryset containing the rows that match the search criteria.
         """
 
+        if not fields:
+            # Without any fields to search in, only an exact row id match can
+            # produce a result.
+            filter_builder = FilterBuilder(filter_type=FILTER_TYPE_OR)
+            filter_builder.filter(Q(id__in=[]))
+            cls.add_exact_id_search(filter_builder, input_search)
+            return filter_builder.apply_to_queryset(queryset)
+
         sanitized_search = cls.escape_postgres_query(input_search)
 
         if len(sanitized_search) == 0:

--- a/backend/src/baserow/contrib/integrations/local_baserow/mixins.py
+++ b/backend/src/baserow/contrib/integrations/local_baserow/mixins.py
@@ -371,7 +371,11 @@ class LocalBaserowTableServiceFilterableMixin:
         queryset = super().get_table_queryset(service, table, dispatch_context, model)
         queryset = self.get_dispatch_filters(service, queryset, model, dispatch_context)
         dispatch_filters = dispatch_context.filters()
-        if dispatch_filters is not None and dispatch_context.is_publicly_filterable:
+        if (
+            dispatch_filters is not None
+            and dispatch_context.is_publicly_filterable
+            and dispatch_context.is_adhoc_refinable(service)
+        ):
             deserialized_filters = AdHocFilters.deserialize_dispatch_filters(
                 dispatch_filters
             )
@@ -799,7 +803,11 @@ class LocalBaserowTableServiceSortableMixin:
         queryset = super().get_table_queryset(service, table, dispatch_context, model)
 
         adhoc_sort = dispatch_context.sortings()
-        if adhoc_sort and dispatch_context.is_publicly_sortable:
+        if (
+            adhoc_sort
+            and dispatch_context.is_publicly_sortable
+            and dispatch_context.is_adhoc_refinable(service)
+        ):
             field_names = [field.strip("-") for field in adhoc_sort.split(",")]
             dispatch_context.validate_filter_search_sort_fields(
                 field_names, ServiceAdhocRefinements.SORT
@@ -951,7 +959,11 @@ class LocalBaserowTableServiceSearchableMixin:
                 service_search_query, search_mode=search_mode
             )
         adhoc_search_query = dispatch_context.search_query()
-        if adhoc_search_query is not None and dispatch_context.is_publicly_searchable:
+        if (
+            adhoc_search_query is not None
+            and dispatch_context.is_publicly_searchable
+            and dispatch_context.is_adhoc_refinable(service)
+        ):
             # This mixin's `get_queryset` method does not validate any adhoc
             # refinements, as the search query is not a field. We instead
             # restrict the fields that we search against to only those which

--- a/backend/src/baserow/core/services/dispatch_context.py
+++ b/backend/src/baserow/core/services/dispatch_context.py
@@ -80,6 +80,21 @@ class DispatchContext(RuntimeFormulaContext, ABC):
 
         return new_context
 
+    def is_adhoc_refinable(self, service: Service) -> bool:
+        """
+        Responsible for returning whether the request's adhoc refinements
+        (search, filters and sortings) may be applied when dispatching the
+        given service. By default they apply to every dispatched service,
+        but subclasses can restrict them to the service the request actually
+        targets, so that refinements don't leak into nested dispatches (e.g.
+        a data source referenced by another data source's filter formula).
+
+        :param service: The service that is currently being dispatched.
+        :return: Whether adhoc refinements may be applied to this service.
+        """
+
+        return True
+
     @property
     @abstractmethod
     def is_publicly_searchable(self) -> bool:

--- a/backend/tests/baserow/contrib/builder/api/data_sources/test_data_source_views.py
+++ b/backend/tests/baserow/contrib/builder/api/data_sources/test_data_source_views.py
@@ -1545,6 +1545,89 @@ def test_dispatch_data_source_with_adhoc_search(api_client, data_fixture):
     }
 
 
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.search.tasks.schedule_update_search_data.delay",
+    "baserow.contrib.database.search.tasks.update_search_data.delay",
+)
+def test_dispatch_data_source_with_adhoc_search_and_filter_referencing_other_data_source(
+    api_client, data_fixture
+):
+    """
+    The adhoc refinements of the request (search, filters, sortings) must only
+    be applied to the data source the request targets. When that data source's
+    filter formula references another data source, the nested dispatch used to
+    apply the adhoc search too, and because the element's searchable field ids
+    don't exist in the referenced table, the full-text search crashed with an
+    `IndexError`.
+    """
+
+    with transaction.atomic():
+        user, token = data_fixture.create_user_and_token()
+        members_table, _, _ = data_fixture.build_table(
+            user=user,
+            columns=[("Email", "text")],
+            rows=[["a@x.com"]],
+        )
+        clients_table, _, _ = data_fixture.build_table(
+            user=user,
+            columns=[("Client name", "text"), ("Tenant", "text")],
+            rows=[["Acme", "a@x.com"], ["Globex", "b@x.com"]],
+        )
+    email_field = members_table.field_set.get(name="Email")
+    client_name_field = clients_table.field_set.get(name="Client name")
+    tenant_field = clients_table.field_set.get(name="Tenant")
+
+    builder = data_fixture.create_builder_application(user=user)
+    integration = data_fixture.create_local_baserow_integration(
+        user=user, application=builder
+    )
+    page = data_fixture.create_builder_page(user=user, builder=builder)
+
+    members_data_source = data_fixture.create_builder_local_baserow_get_row_data_source(
+        user=user,
+        page=page,
+        integration=integration,
+        table=members_table,
+        row_id="1",
+    )
+    clients_data_source = (
+        data_fixture.create_builder_local_baserow_list_rows_data_source(
+            user=user, page=page, integration=integration, table=clients_table
+        )
+    )
+    data_fixture.create_local_baserow_table_service_filter(
+        service=clients_data_source.service,
+        field=tenant_field,
+        value=f"get('data_source.{members_data_source.id}.field_{email_field.id}')",
+        value_is_formula=True,
+        order=0,
+    )
+    element = data_fixture.create_builder_table_element(
+        page=page, data_source=clients_data_source
+    )
+    element.property_options.create(
+        schema_property=client_name_field.db_column, searchable=True
+    )
+
+    url = reverse(
+        "api:builder:data_source:dispatch",
+        kwargs={"data_source_id": clients_data_source.id},
+    )
+
+    response = api_client.post(
+        f"{url}?search_query=Acme",
+        {"metadata": {"data_source": {"element": element.id}}},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_200_OK, response.json()
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0][client_name_field.name] == "Acme"
+
+
 @pytest.mark.django_db
 def test_dispatch_data_source_with_element_from_different_page(
     api_client, data_fixture

--- a/backend/tests/baserow/contrib/builder/data_sources/test_dispatch_context.py
+++ b/backend/tests/baserow/contrib/builder/data_sources/test_dispatch_context.py
@@ -107,6 +107,29 @@ def test_dispatch_context_search_query():
 
 
 @pytest.mark.django_db
+def test_dispatch_context_is_adhoc_refinable(data_fixture):
+    user = data_fixture.create_user()
+    builder = data_fixture.create_builder_application(user=user)
+    page = data_fixture.create_builder_page(user=user, builder=builder)
+    data_source = data_fixture.create_builder_local_baserow_list_rows_data_source(
+        user=user, page=page
+    )
+    other_data_source = data_fixture.create_builder_local_baserow_list_rows_data_source(
+        user=user, page=page
+    )
+    request = HttpRequest()
+
+    # Without a targeted data source, any service is adhoc refinable.
+    dispatch_context = BuilderDispatchContext(request, page)
+    assert dispatch_context.is_adhoc_refinable(data_source.service) is True
+
+    # With a targeted data source, only its own service is adhoc refinable.
+    dispatch_context = BuilderDispatchContext(request, page, data_source=data_source)
+    assert dispatch_context.is_adhoc_refinable(data_source.service) is True
+    assert dispatch_context.is_adhoc_refinable(other_data_source.service) is False
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize("collection_element_type", collection_element_types())
 def test_dispatch_context_is_publicly_searchable(collection_element_type, data_fixture):
     user = data_fixture.create_user()

--- a/backend/tests/baserow/contrib/database/api/views/gallery/test_gallery_view_views.py
+++ b/backend/tests/baserow/contrib/database/api/views/gallery/test_gallery_view_views.py
@@ -12,7 +12,11 @@ from rest_framework.status import (
 
 from baserow.contrib.database.api.constants import PUBLIC_PLACEHOLDER_ENTITY_ID
 from baserow.contrib.database.rows.handler import RowHandler
-from baserow.contrib.database.search.handler import ALL_SEARCH_MODES, SearchHandler
+from baserow.contrib.database.search.handler import (
+    ALL_SEARCH_MODES,
+    SearchHandler,
+    SearchMode,
+)
 
 
 @pytest.mark.django_db
@@ -642,6 +646,50 @@ def test_list_rows_search(api_client, data_fixture, search_mode):
     assert response_json["count"] == 2
     assert response_json["results"][0]["id"] == matching_row1.id
     assert response_json["results"][1]["id"] == matching_row2.id
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize("search_mode", ALL_SEARCH_MODES)
+def test_list_rows_search_with_all_fields_hidden(api_client, data_fixture, search_mode):
+    """
+    A gallery view allows hiding every field, including the primary one. A
+    search request must not error when there are no visible fields left to
+    search in; it used to crash with an `IndexError` in full-text mode.
+    """
+
+    user, token = data_fixture.create_user_and_token(
+        email="test@test.nl", password="password", first_name="Test1"
+    )
+    table = data_fixture.create_database_table(user=user)
+    text_field = data_fixture.create_text_field(
+        table=table, order=0, name="Name", text_default="", primary=True
+    )
+    gallery = data_fixture.create_gallery_view(table=table, public=True)
+    data_fixture.create_gallery_view_field_option(gallery, text_field, hidden=True)
+
+    model = gallery.table.get_model()
+    model.objects.create(**{f"field_{text_field.id}": "Bob Smith"})
+
+    SearchHandler.update_search_data(table)
+
+    url = reverse("api:database:views:gallery:list", kwargs={"view_id": gallery.id})
+    response = api_client.get(
+        url,
+        {"search": "Bob", "search_mode": search_mode},
+        **{"HTTP_AUTHORIZATION": f"JWT {token}"},
+    )
+    assert response.status_code == HTTP_200_OK, response.json()
+
+    public_url = reverse(
+        "api:database:views:gallery:public_rows", kwargs={"slug": gallery.slug}
+    )
+    response = api_client.get(public_url, {"search": "Bob", "search_mode": search_mode})
+    assert response.status_code == HTTP_200_OK, response.json()
+    if search_mode == SearchMode.FT_WITH_COUNT:
+        # With no searchable fields, a full-text search can't match anything.
+        # Compat mode ignores the search entirely in this situation, which is
+        # its pre-existing behaviour.
+        assert response.json()["results"] == []
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/contrib/database/search/test_search_handler.py
+++ b/backend/tests/baserow/contrib/database/search/test_search_handler.py
@@ -32,6 +32,25 @@ def test_escape_query():
     assert SearchHandler.escape_query("  Full text search  ") == "Full text search"
 
 
+@pytest.mark.django_db(transaction=True)
+def test_full_text_search_in_table_without_fields(data_fixture):
+    user = data_fixture.create_user()
+    table, _, rows = data_fixture.build_table(
+        user=user, columns=[("Name", "text")], rows=[["Peter"], ["Afonso"]]
+    )
+    model = table.get_model()
+
+    # With no fields to search in, a textual query can't match anything.
+    result = SearchHandler.full_text_search_in_table(model.objects.all(), "Peter", [])
+    assert list(result) == []
+
+    # An exact row id match is still returned.
+    result = SearchHandler.full_text_search_in_table(
+        model.objects.all(), str(rows[1].id), []
+    )
+    assert [row.id for row in result] == [rows[1].id]
+
+
 @pytest.mark.django_db
 def test_get_default_search_mode_for_table_with_workspace_search_data(data_fixture):
     table = data_fixture.create_database_table()

--- a/changelog/entries/unreleased/bug/fixed_500_error_when_searching_a_view_with_all_fields_hidden.json
+++ b/changelog/entries/unreleased/bug/fixed_500_error_when_searching_a_view_with_all_fields_hidden.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed an error when searching rows of a view that has all of its fields hidden, for example a publicly shared gallery view.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-13"
+}

--- a/changelog/entries/unreleased/bug/fixed_application_builder_search_crashing_when_a_data_source.json
+++ b/changelog/entries/unreleased/bug/fixed_application_builder_search_crashing_when_a_data_source.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed Application Builder search not working when the data source is filtered using a value from another data source.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-08-13"
+}


### PR DESCRIPTION
### What is in this PR

This PR fixes a bug in the `database` module, and in how our search queries are applied to our services.

1. In `database`: when we apply a search query on the filter builder, if we have *no fields* to use, then handle this correctly. At the moment this can cause issues:
    - Setup a gallery view
    - Hide all of its fields
    - Create a public gallery view, and apply a search
    - In `develop` / production: it'll throw a 500 (see Sentry 140461437)
    - In this branch: it'll be correctly handled
2. Install the workspace export shared below. When you use our adhoc search against a collection element, and have a specific field flagged as "searchable", we will attempt to apply that field on *all* services configured. This won't work if one or more services point to a table *without* that field.

For (2) in `develop` you'll see:

<img width="342" height="226" alt="Screenshot 2026-08-13 at 11 35 37" src="https://github.com/user-attachments/assets/5d7a2f7f-b051-4dca-8be9-dcca33edc5ab" />

With the fix, it'll just show no results.



### How to test this PR

- For point 1: follow the steps above.
- For point 2: install [demo.zip](https://github.com/user-attachments/files/31025305/demo.zip)

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
