### PR TITLE
chore: make the assistant eval suite able to compare models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,6 @@ web-frontend/storybook-static
 
 .agent
 MEMORY.md
+
+# Local Kuma eval sweep results
+.kuma-sweep/

--- a/docs/testing/ai-assistant-evals.md
+++ b/docs/testing/ai-assistant-evals.md
@@ -43,16 +43,53 @@ All configuration is via environment variables:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `EVAL_LLM_MODEL` | `groq:openai/gpt-oss-120b` | Model string in pydantic-ai format (`provider:model`). Accepts a comma-separated list to parametrize every eval across multiple models. |
+| `EVAL_RUNS` | `1` | Runs every model/case combination this many times. Use `3` for reliability and flake-rate comparisons. |
 | `EVAL_RETRIES` | `0` | Retry each failing eval test up to N times. If a test passes on retry it's a flake (LLM non-determinism); if it fails all N retries it's a consistent bug. |
 | `GROQ_API_KEY` | — | Required when using a Groq model. |
 | `OPENAI_API_KEY` | — | Required when using an OpenAI model. |
 | `ANTHROPIC_API_KEY` | — | Required when using an Anthropic model. |
+| `<ALIAS>_BASE_URL` | — | Endpoint for a custom OpenAI-compatible provider (see below). |
+| `<ALIAS>_API_KEY` | — | Key for that provider. |
+
+### Custom OpenAI-compatible endpoints
+
+Any provider prefix that is not built in (`openai`, `groq`, `anthropic`, `ollama`,
+`google*`) is treated as an OpenAI-compatible endpoint configured **by
+convention**: the prefix is upper-cased and used to look up `<PREFIX>_BASE_URL`
+and `<PREFIX>_API_KEY`.
+
+```bash
+HETZNER_BASE_URL=https://your-hetzner-endpoint/v1
+HETZNER_API_KEY=...
+INFERCOM_BASE_URL=https://your-infercom-endpoint/v1
+INFERCOM_API_KEY=...
+
+EVAL_LLM_MODEL="groq:openai/gpt-oss-120b,hetzner:deepseek-v4-flash,hetzner:glm5.2,infercom:MiniMax-M2.7-Ultraspeed,openai:gpt-5.6-luna"
+```
+
+The model identifier after the colon is passed to the endpoint verbatim and may
+contain slashes (`infercom:vendor/some-model` works).
+
+Resolution happens in `assistant/retrying_model.py::_resolve_model`, i.e. in
+production code rather than in the eval harness. This is deliberate: sub-agents
+(`formula_agent`, the fixer, title generation) resolve their model through
+`get_model_string()` → `_resolve_model()`, so an eval-only shim would leave them
+on the default model and silently invalidate any model comparison.
+
+Aliases do **not** inherit the deprecated `UDSPY_LM_*` fallbacks, so a stray
+legacy key cannot authenticate against an unrelated endpoint. If
+`<PREFIX>_BASE_URL` is unset the prefix is passed to pydantic-ai's `infer_model`,
+which will raise for an unknown provider.
+
+Note that `BASEROW_OPENAI_BASE_URL` is **not** used by the assistant — that
+setting belongs to the generative-AI-field subsystem.
 
 ### API keys from a file
 
-The eval conftest reads API keys from the same `TEST_ENV_FILE` that
+The eval conftest reads credentials from the same `TEST_ENV_FILE` that
 `baserow/config/settings/test.py` already parses, and exposes them via
-`os.environ` so that LLM provider SDKs can find them:
+`os.environ` so that LLM provider SDKs can find them. Any variable ending in
+`_API_KEY` or `_BASE_URL` is bridged, so a new endpoint needs no code change:
 
 ```bash
 TEST_ENV_FILE=.env.testing-local just b test \
@@ -60,6 +97,14 @@ TEST_ENV_FILE=.env.testing-local just b test \
 ```
 
 Variables already present in `os.environ` take precedence.
+
+> **The path is resolved relative to `backend/`, not the repo root.**
+> `baserow/config/settings/test.py` joins `TEST_ENV_FILE` onto the backend
+> directory, so the repo-root `.env` is `TEST_ENV_FILE=../.env`. An absolute path
+> does **not** work — it is concatenated onto the relative prefix and silently
+> resolves to nothing. The failure is silent: `TEST_ENV_VARS` comes back empty,
+> no credentials are bridged, and the run fails much later with
+> `ValueError: Unknown provider: <alias>`.
 
 ### Running against multiple models
 
@@ -70,6 +115,76 @@ just b test ../enterprise/backend/tests/baserow_enterprise_tests/assistant/evals
 ```
 
 Each test will run once per model, with the model name shown in the test ID.
+
+For a fair reliability comparison, repeat every case equally instead of only
+retrying failures:
+
+```bash
+GROQ_API_KEY=... OPENAI_API_KEY=... EVAL_RUNS=3 \
+EVAL_LLM_MODEL="groq:openai/gpt-oss-120b,openai:<challenger>" \
+just b test ../enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/ \
+  -m eval -v --junitxml=kuma-model-comparison.xml
+```
+
+The test IDs include `run-1`, `run-2`, and `run-3`. Keep `EVAL_RETRIES=0`
+for the scored comparison. `EVAL_RETRIES` is a separate diagnostic tool that
+reruns failures and would otherwise give failing cases more attempts than
+passing ones.
+
+### Running the matrix in parallel
+
+The matrix is the cross product of cases x models x runs, so it grows fast: 76
+cases x 5 models x 3 runs is 1,140 agent runs. Use `pytest-xdist` to spread them
+across processes:
+
+```bash
+EVAL_RUNS=3 EVAL_LLM_MODEL="groq:openai/gpt-oss-120b,hetzner:deepseek-v4-flash,..." \
+just b test ../enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/ \
+  -m eval -n=8 --junitxml=kuma-model-comparison.xml
+```
+
+Each xdist worker is a separate process, so the per-test rewrite of
+`settings.BASEROW_ENTERPRISE_ASSISTANT_LLM_MODEL` (used to propagate the model to
+sub-agents) cannot race between workers.
+
+#### How workers are allocated
+
+Provider rate limits, not CPU, are the ceiling for this suite. Several workers
+hitting one endpoint produce 429s, and a 429 scored as a test failure is
+indistinguishable from a model-quality regression.
+
+So parallelism is spread along the widest axis first: **across providers, then
+across models, and only then doubled up on one model.** Passing `-n`
+automatically switches scheduling to `--dist loadgroup`, and eval tests are
+tagged so that everything in a group runs on a single worker.
+
+With four models on three providers (two of them on `hetzner`):
+
+| `-n` | Layout | Groups |
+| ---: | --- | ---: |
+| 1–3 | one worker per provider; the two `hetzner` models share one | 3 |
+| 4 | one worker per model | 4 |
+| 5 | one model gets a second worker | 5 |
+| 8 | every model gets two workers | 8 |
+| 12 | every model gets three workers | 12 |
+
+Below the provider count the layout stays at one group per provider — xdist runs
+the surplus groups sequentially, so a provider is still never hit by two workers
+at once.
+
+Pass `--dist load` to opt out; an explicit `--dist` is always respected.
+
+Two more things to watch:
+
+- **Sync the knowledge base first.** `synced_knowledge_base` is a session fixture,
+  so under `-n` every worker evaluates it at once and they can all try to sync an
+  empty KB concurrently. Run the doc evals once serially (or any command that
+  populates the KB) before the parallel run, and rely on `--reuse-db` afterwards.
+- **Do not pass `-s`.** It disables capture and interleaves output from every
+  worker into an unreadable stream.
+
+See the production baseline, release gates, and report template in
+[Kuma reliability baseline and improvement plan](kuma-reliability-report.md).
 
 ## Test files
 

--- a/enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/conftest.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/conftest.py
@@ -8,18 +8,39 @@ import pytest
 
 from baserow.config.settings.test import TEST_ENV_VARS
 
-# Expose API keys from TEST_ENV_FILE to os.environ so that LLM provider
-# SDKs (which read os.getenv() at import/construction time) can find them.
-# test.py already parses TEST_ENV_FILE via dotenv_values but deliberately
-# does NOT inject non-allowlisted keys into os.environ.  We bridge that
-# gap here for the small set of keys the eval suite needs.
-_API_KEY_NAMES = ("GROQ_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY")
-for _k in _API_KEY_NAMES:
-    if (_v := TEST_ENV_VARS.get(_k)) and not os.environ.get(_k):
+# Expose provider credentials from TEST_ENV_FILE to os.environ so that LLM
+# provider SDKs (which read os.getenv() at import/construction time) can find
+# them.  test.py already parses TEST_ENV_FILE via dotenv_values but deliberately
+# does NOT inject non-allowlisted keys into os.environ.  Matching on suffix
+# rather than an explicit list means a new OpenAI-compatible endpoint only needs
+# its <ALIAS>_BASE_URL / <ALIAS>_API_KEY pair, with no change here.
+_CREDENTIAL_SUFFIXES = ("_API_KEY", "_BASE_URL")
+for _k, _v in TEST_ENV_VARS.items():
+    if _v and _k.endswith(_CREDENTIAL_SUFFIXES) and not os.environ.get(_k):
         os.environ[_k] = _v
 
 
 _EVALS_DIR = os.path.dirname(__file__)
+
+
+def _get_eval_runs():
+    """Return stable run identifiers for repeated model reliability checks."""
+
+    runs = int(os.environ.get("EVAL_RUNS", "1"))
+    if runs < 1:
+        raise pytest.UsageError("EVAL_RUNS must be a positive integer")
+    return list(range(1, runs + 1))
+
+
+@pytest.fixture(
+    autouse=True,
+    params=_get_eval_runs(),
+    ids=lambda run: f"run-{run}",
+)
+def eval_run(request):
+    """Repeat every eval equally so pass and flake rates are comparable."""
+
+    return request.param
 
 
 def _evals_explicitly_requested(config):
@@ -38,6 +59,7 @@ def _evals_explicitly_requested(config):
     return False
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(config, items):
     """Skip eval tests unless explicitly requested (``-m eval`` or by path).
 
@@ -60,6 +82,119 @@ def pytest_collection_modifyitems(config, items):
             if item.get_closest_marker("eval"):
                 item.add_marker(pytest.mark.retry(eval_retries))
 
+    _assign_xdist_groups(config, items)
+
+
+def _provider_of(model: str) -> str:
+    """Return the provider prefix of a pydantic-ai model string."""
+
+    return model.split(":", 1)[0] if ":" in model else "openai"
+
+
+def _shards_per_model(models: list[str], workers: int) -> dict[str, int]:
+    """Decide how many xdist groups each model gets, widest axis first.
+
+    Parallelism is spread across providers, then across models, and only then
+    doubled up on a single model, because provider rate limits are the real
+    ceiling for this suite: a 429 scored as a test failure is indistinguishable
+    from a model-quality regression.
+
+    An empty result means "group by provider" — the narrowest, safest layout.
+    """
+
+    providers = {_provider_of(m) for m in models}
+    if workers <= len(providers):
+        return {}
+    if workers <= len(models):
+        return dict.fromkeys(models, 1)
+    base, extra = divmod(workers, len(models))
+    return {m: base + (1 if i < extra else 0) for i, m in enumerate(models)}
+
+
+def _group_name(model: str, occurrence: int, shards: dict[str, int]) -> str:
+    """Return the ``xdist_group`` for one test of *model*."""
+
+    if not shards:
+        return _provider_of(model)
+    count = shards.get(model, 1)
+    return model if count <= 1 else f"{model}#{occurrence % count}"
+
+
+def _worker_count(config) -> int:
+    """Number of xdist workers, as seen from the controller *or* a worker.
+
+    Workers are not launched with ``-n``, so ``numprocesses`` is unset there;
+    they learn the count from ``workerinput``. Both sides must agree or they
+    compute different groups for the same test.
+    """
+
+    workerinput = getattr(config, "workerinput", None)
+    if workerinput:
+        return int(workerinput.get("workercount", 1))
+    workers = getattr(config.option, "numprocesses", None)
+    return workers if isinstance(workers, int) else 1
+
+
+def _assign_xdist_groups(config, items) -> None:
+    """Tag eval items so ``--dist loadgroup`` schedules them per the policy above.
+
+    Assignment happens here rather than on the ``eval_model`` parameter because
+    splitting one model across several workers means splitting *its items*, which
+    is only possible once the full collection is known.
+
+    This must run in the workers too: xdist reads the marker there, when it
+    suffixes node ids with the group name.
+    """
+
+    workers = _worker_count(config)
+    if workers < 2:
+        return
+
+    by_model: dict[str, list] = {}
+    for item in items:
+        callspec = getattr(item, "callspec", None)
+        model = callspec.params.get("eval_model") if callspec else None
+        if model:
+            by_model.setdefault(model, []).append(item)
+
+    if not by_model:
+        return
+
+    shards = _shards_per_model(list(by_model), workers)
+    for model, model_items in by_model.items():
+        for occurrence, item in enumerate(model_items):
+            item.add_marker(
+                pytest.mark.xdist_group(name=_group_name(model, occurrence, shards))
+            )
+
+
+def pytest_configure(config):
+    """Default to loadgroup scheduling so the grouping policy is honoured."""
+
+    if getattr(config.option, "numprocesses", None) and config.option.dist in (
+        "no",
+        "load",
+    ):
+        config.option.dist = "loadgroup"
+
+
+def pytest_xdist_make_scheduler(config, log):
+    """Force group-aware scheduling for parallel runs.
+
+    Setting ``config.option.dist`` alone is not reliable: xdist derives its
+    default from ``-n`` at its own point in startup, so depending on hook order
+    the flip can be overwritten and every worker ends up serving every provider.
+    """
+
+    if not getattr(config.option, "numprocesses", None):
+        return None
+    if config.option.dist not in ("no", "load", "loadgroup"):
+        return None
+
+    from xdist.scheduler import LoadGroupScheduling
+
+    return LoadGroupScheduling(config, log)
+
 
 def pytest_generate_tests(metafunc):
     """Auto-parametrize tests that use the ``eval_model`` fixture."""
@@ -73,7 +208,7 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture(scope="session")
-def synced_knowledge_base(django_db_blocker):
+def synced_knowledge_base(django_db_setup, django_db_blocker):
     """
     Sync the knowledge base once per pytest session if not already populated.
 

--- a/enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/eval_utils.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/eval_utils.py
@@ -17,6 +17,8 @@ from pydantic_ai.usage import UsageLimits
 from baserow_enterprise.assistant.agents import main_agent
 from baserow_enterprise.assistant.assistant import _get_workspace_license_type
 from baserow_enterprise.assistant.deps import AssistantDeps, ToolHelpers
+from baserow_enterprise.assistant.model_profiles import ORCHESTRATOR, get_model_settings
+from baserow_enterprise.assistant.retrying_model import RetryingModel
 from baserow_enterprise.assistant.tools.registries import assistant_tool_registry
 from baserow_enterprise.assistant.types import (
     ApplicationUIContext,
@@ -206,6 +208,11 @@ def create_eval_assistant(user, workspace, max_iters=15, model=None):
     # so store in "/" format (e.g. "groq/openai/gpt-oss-120b").
     settings.BASEROW_ENTERPRISE_ASSISTANT_LLM_MODEL = model.replace(":", "/", 1)
 
+    # A shared, generous ceiling keeps a slow endpoint from scoring as a wrong
+    # answer. Latency stays comparable because it is measured, not capped.
+    if eval_timeout := os.environ.get("EVAL_LLM_TIMEOUT"):
+        settings.BASEROW_ENTERPRISE_ASSISTANT_LLM_TIMEOUT = float(eval_timeout)
+
     deps = AssistantDeps(
         user=user,
         workspace=workspace,
@@ -223,7 +230,15 @@ def create_eval_assistant(user, workspace, max_iters=15, model=None):
     deps.explain_manifest = explain_manifest
     usage_limits = UsageLimits(request_limit=max_iters)
 
-    return main_agent, deps, tracker, model, usage_limits, toolset
+    # Hand back the same wrapper production uses. Passing the bare string would
+    # let pydantic-ai infer the provider itself, which both skips the retry layer
+    # and rejects custom OpenAI-compatible aliases outright.  The profile is
+    # attached to the model because eval tests call run_sync() without
+    # model_settings, so otherwise they would silently run on library defaults
+    # rather than the settings production uses.
+    eval_model = RetryingModel(model, settings=get_model_settings(model, ORCHESTRATOR))
+
+    return main_agent, deps, tracker, eval_model, usage_limits, toolset
 
 
 def get_tool_call_sequence(result) -> list[str]:

--- a/enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/test_eval_automation_workflows.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/test_eval_automation_workflows.py
@@ -72,17 +72,34 @@ def _run_agent(
     )
 
 
+def _rejected_tool_call_ids(history) -> set:
+    """Tool call ids whose arguments failed validation and were retried."""
+
+    return {
+        e["tool_call_id"]
+        for e in history
+        if e.get("type") == "RetryPromptPart" and e.get("tool_call_id")
+    }
+
+
 def _get_create_workflows_args(result) -> list[dict]:
     """Return the parsed ``args`` dicts of every ``create_workflows`` tool call
-    the agent made (assistant-side entries have ``args``)."""
+    the agent made (assistant-side entries have ``args``).
+
+    Calls whose arguments were rejected are dropped. Callers read index 0, so
+    keeping a retried attempt would score the abandoned call and fail a run
+    whose final state is correct.
+    """
 
     history = format_message_history(result)
+    rejected = _rejected_tool_call_ids(history)
     return [
         e["args"]
         for e in history
         if e["role"] == "assistant"
         and e.get("tool_name") == "create_workflows"
         and "args" in e
+        and e.get("tool_call_id") not in rejected
     ]
 
 

--- a/enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/test_eval_builder.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/test_eval_builder.py
@@ -152,11 +152,15 @@ def _filter_tool_calls(result, tool_names=None):
     return [e for e in calls if e.get("tool_name") in tool_names]
 
 
+# setup_page is the composite tool the assistant is told to prefer for whole
+# pages, and it carries the same "elements" payload, so omitting it makes these
+# checks blind to everything a well-behaved agent creates.
 _ELEMENT_CREATION_TOOLS = {
     "create_display_elements",
     "create_layout_elements",
     "create_form_elements",
     "create_collection_elements",
+    "setup_page",
 }
 
 
@@ -272,7 +276,14 @@ def test_agent_creates_landing_page(data_fixture, eval_model):
 
     all_el_args = _collect_element_args(result)
     heading_args = [e for e in all_el_args if e.get("type") == "heading"]
-    button_args = [e for e in all_el_args if e.get("type") == "button"]
+    # A link rendered as a button is the only construct that can target a URL,
+    # so it counts as a button here.
+    button_args = [
+        e
+        for e in all_el_args
+        if e.get("type") == "button"
+        or (e.get("type") == "link" and e.get("link_variant") == "button")
+    ]
     heading_texts = [str(e.get("value", "")).lower() for e in heading_args]
     button_texts = [
         str(e.get("value", "") or e.get("label", "")).lower() for e in button_args

--- a/enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/test_eval_builder_proactive.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/test_eval_builder_proactive.py
@@ -246,10 +246,11 @@ def test_agent_creates_app_when_table_exists(data_fixture, eval_model):
 
     pages = Page.objects.filter(builder=builder, shared=False)
 
-    # Collect data source table_ids from args
+    # setup_page carries the same data_sources/elements payload, so it has to be
+    # read too or these checks miss everything the composite tool created.
     ds_table_ids = []
-    for call in ds_calls:
-        for ds in call.get("args", {}).get("data_sources", []):
+    for call in ds_calls + setup_page_calls:
+        for ds in call.get("args", {}).get("data_sources", []) or []:
             if ds.get("table_id"):
                 ds_table_ids.append(ds["table_id"])
 
@@ -259,6 +260,7 @@ def test_agent_creates_app_when_table_exists(data_fixture, eval_model):
         "create_collection_elements",
         "create_layout_elements",
         "create_form_elements",
+        "setup_page",
     }
     el_calls = [
         e

--- a/enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/test_eval_database_tables.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/test_eval_database_tables.py
@@ -62,6 +62,18 @@ PROMPT_CREATE_RELATED_TABLES_WITH_SAMPLE_ROWS = (
     "Price, and a link to the Authors table."
 )
 
+PROMPT_CREATES_COMPLETE_DATABASE_FROM_DESCRIPTION = (
+    "Create a database including tables, fields, example rows, and example views "
+    "matching this description: Sales and marketing database"
+)
+
+PROMPT_REPAIRS_EXISTING_FORMULA = (
+    "Fix the existing Access Summary formula in the Access Records table so it "
+    "combines the Authorising Role and Authorising Group multiple-select fields. "
+    "Show whichever side exists when one is empty; when both exist, join them "
+    "with ' - '. Look at the table and save a working formula."
+)
+
 # -- View creation prompts --------------------------------------------------
 
 PROMPT_CREATE_GRID_VIEW = (
@@ -571,6 +583,140 @@ def test_agent_creates_database_from_description(data_fixture, eval_model):
             sum(1 for f in books_fields if isinstance(f, (TextField, LongTextField)))
             >= 2,
             hint=f"books text fields: {[f.name for f in books_fields if isinstance(f, (TextField, LongTextField))]}",
+        )
+
+
+@pytest.mark.eval
+@pytest.mark.django_db(transaction=True)
+def test_agent_creates_complete_database_from_production_prompt(
+    data_fixture, eval_model
+):
+    """A common onboarding prompt should complete the whole database journey."""
+
+    from baserow.contrib.database.models import Database
+
+    user = data_fixture.create_user()
+    workspace = data_fixture.create_workspace(user=user)
+
+    agent, deps, tracker, model, usage_limits, toolset = create_eval_assistant(
+        user, workspace, max_iters=30, model=eval_model
+    )
+    ui_context = build_database_ui_context(user, workspace)
+
+    result = _run_agent(
+        agent,
+        deps,
+        tracker,
+        model,
+        usage_limits,
+        toolset,
+        question=PROMPT_CREATES_COMPLETE_DATABASE_FROM_DESCRIPTION,
+        ui_context=ui_context,
+    )
+
+    print_message_history(result)
+    err_count, err_hint = count_tool_errors(result)
+
+    databases = list(Database.objects.filter(workspace=workspace))
+    tables = list(Table.objects.filter(database__in=databases))
+    views = list(View.objects.filter(table__in=tables))
+    non_default_views = [view for view in views if view.name.lower() != "grid"]
+    sample_row_count = sum(table.get_model().objects.count() for table in tables)
+
+    with EvalChecklist("creates complete sales and marketing database") as checks:
+        checks.check("no tool errors", err_count == 0, hint=err_hint)
+        checks.check(
+            "exactly one database created",
+            len(databases) == 1,
+            hint=f"got: {[database.name for database in databases]}",
+        )
+        checks.check(
+            "at least two tables created",
+            len(tables) >= 2,
+            hint=f"got: {[table.name for table in tables]}",
+        )
+        checks.check(
+            "tables include additional fields",
+            bool(tables) and all(table.field_set.count() >= 2 for table in tables),
+            hint=f"field counts: {[(table.name, table.field_set.count()) for table in tables]}",
+        )
+        checks.check(
+            "sample rows created",
+            sample_row_count >= len(tables),
+            hint=f"got {sample_row_count} rows across {len(tables)} tables",
+        )
+        checks.check(
+            "example view created",
+            len(non_default_views) >= 1,
+            hint=f"views: {[(view.table.name, view.name) for view in views]}",
+        )
+
+
+@pytest.mark.eval
+@pytest.mark.django_db(transaction=True)
+def test_agent_repairs_and_saves_existing_formula(data_fixture, eval_model):
+    """A formula complaint should use the validated formula tool and persist it."""
+
+    user = data_fixture.create_user()
+    workspace = data_fixture.create_workspace(user=user)
+    database = data_fixture.create_database_application(
+        workspace=workspace, name="Access Management"
+    )
+    table = data_fixture.create_database_table(
+        user=user, database=database, name="Access Records"
+    )
+    data_fixture.create_text_field(table=table, name="System", primary=True)
+    data_fixture.create_multiple_select_field(table=table, name="Authorising Role")
+    data_fixture.create_multiple_select_field(table=table, name="Authorising Group")
+    formula_field = data_fixture.create_formula_field(
+        table=table,
+        name="Access Summary",
+        formula="'pending'",
+        formula_type="text",
+    )
+
+    agent, deps, tracker, model, usage_limits, toolset = create_eval_assistant(
+        user, workspace, max_iters=20, model=eval_model
+    )
+    ui_context = build_database_ui_context(user, workspace, database, table)
+
+    result = _run_agent(
+        agent,
+        deps,
+        tracker,
+        model,
+        usage_limits,
+        toolset,
+        question=PROMPT_REPAIRS_EXISTING_FORMULA,
+        ui_context=ui_context,
+    )
+
+    print_message_history(result)
+    err_count, err_hint = count_tool_errors(result)
+    formula_field.refresh_from_db()
+    formula = formula_field.formula
+
+    with EvalChecklist("repairs existing access summary formula") as checks:
+        checks.check("no tool errors", err_count == 0, hint=err_hint)
+        checks.check(
+            "formula was updated",
+            formula != "'pending'",
+            hint=f"formula: {formula}",
+        )
+        checks.check(
+            "formula is valid",
+            formula_field.cached_formula_type.is_valid,
+            hint=f"formula type: {formula_field.formula_type}, formula: {formula}",
+        )
+        checks.check(
+            "formula uses Authorising Role",
+            "Authorising Role" in formula,
+            hint=f"formula: {formula}",
+        )
+        checks.check(
+            "formula uses Authorising Group",
+            "Authorising Group" in formula,
+            hint=f"formula: {formula}",
         )
 
 

--- a/enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/test_eval_search_user_docs.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/test_eval_search_user_docs.py
@@ -1,3 +1,5 @@
+import unicodedata
+
 from django.conf import settings
 
 import pytest
@@ -5,6 +7,7 @@ import pytest
 from .eval_utils import (
     EvalChecklist,
     build_database_ui_context,
+    count_tool_errors,
     create_eval_assistant,
     format_message_history,
     print_message_history,
@@ -202,6 +205,111 @@ SEARCH_DOCS_CASES = [
 ]
 
 
+# These questions are anonymized examples from recurring production prompt
+# families. Unlike the broad retrieval cases above, each case has a factual
+# answer contract: authoritative sources are mandatory, every required concept
+# group must match, and known hallucinations must be absent.
+PRODUCTION_QUESTION_CASES = [
+    pytest.param(
+        "How do I invite users to my workspace?",
+        ["working-with-collaborators"],
+        [["member"], ["invite"], ["admin"]],
+        [],
+        id="production-invite-workspace-users",
+    ),
+    pytest.param(
+        "How do I create a form?",
+        ["guide-to-creating-forms-in-baserow"],
+        [
+            ["form view"],
+            ["add view", "create view", "view dropdown"],
+            ["share", "public"],
+        ],
+        [],
+        id="production-create-form",
+    ),
+    pytest.param(
+        "How do I delete a workspace?",
+        ["delete-a-workspace"],
+        [["delete workspace"], ["admin"], ["workspace name", "dropdown"]],
+        [
+            "can't delete a workspace",
+            "can’t delete a workspace",
+            "cannot delete a workspace",
+            "workspaces are permanent",
+        ],
+        id="production-delete-workspace",
+    ),
+    pytest.param(
+        "Wo finde ich Tutorials mit funktionierenden Links?",
+        ["user-docs", "docs/tutorials", "docs/index"],
+        [["https://baserow.io/user-docs/", "https://baserow.io/docs/"]],
+        [".md"],
+        id="production-working-tutorial-links",
+    ),
+    pytest.param(
+        "How do I connect a Baserow database to a JavaScript and HTML file?",
+        ["database-api", "personal-api-tokens"],
+        [
+            ["database token"],
+            ["authorization"],
+            [
+                "do not expose",
+                "don't expose",
+                "never expose",
+                "server-side",
+                "backend proxy",
+            ],
+        ],
+        [],
+        id="production-connect-database-to-javascript",
+    ),
+    pytest.param(
+        (
+            "What formula can I use to generate the application name from "
+            "Provider, State, and License Type?"
+        ),
+        ["understanding-formulas", "formula"],
+        [["concat"], ["provider"], ["state"], ["license type"]],
+        [],
+        id="production-generate-name-formula",
+    ),
+    pytest.param(
+        "Why can I not group by a column that is a formula?",
+        ["group-rows-in-baserow"],
+        [["formula"], ["group"], ["result type", "groupable", "group-able"]],
+        ["formula fields cannot be grouped"],
+        id="production-group-by-formula",
+    ),
+    pytest.param(
+        "Can I create a dashboard?",
+        ["create-a-dashboard", "dashboards-overview"],
+        [["dashboard"], ["create new"], ["summary", "widget"]],
+        [],
+        id="production-create-dashboard",
+    ),
+    pytest.param(
+        "How can I download the entire database while preserving links?",
+        ["export-workspaces"],
+        [
+            ["export data"],
+            ["zip"],
+            ["relationship", "link"],
+            ["structure", "configuration"],
+        ],
+        ["relationships are not preserved", "links are not preserved"],
+        id="production-export-database-with-links",
+    ),
+]
+
+
+def _normalize_answer_text(value):
+    """Normalize model typography so punctuation cannot create false failures."""
+
+    normalized = unicodedata.normalize("NFKC", value).lower()
+    return normalized.translate(str.maketrans("‐‑‒–—−", "------"))
+
+
 def _run_agent(
     agent, deps, tracker, model, usage_limits, toolset, question, ui_context
 ):
@@ -261,8 +369,10 @@ def test_search_user_docs(
         if e.get("tool_name") == "search_user_docs" and e["role"] == "assistant"
     ]
     sources = deps.sources
-    answer = result.output.lower()
-    keyword_match = any(kw.lower() in answer for kw in expected_keywords)
+    answer = _normalize_answer_text(result.output)
+    keyword_match = any(
+        _normalize_answer_text(keyword) in answer for keyword in expected_keywords
+    )
 
     # Source URL matching is non-fatal — URLs change and the retrieval may
     # return valid alternative sources.  Print a warning but don't score it.
@@ -293,3 +403,89 @@ def test_search_user_docs(
             keyword_match,
             hint=f"answer (first 300 chars): {result.output[:300]}",
         )
+
+
+@pytest.mark.eval
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "question,expected_source_patterns,required_concept_groups,forbidden_claims",
+    PRODUCTION_QUESTION_CASES,
+)
+def test_production_question_accuracy(
+    data_fixture,
+    eval_model,
+    question,
+    expected_source_patterns,
+    required_concept_groups,
+    forbidden_claims,
+):
+    """Kuma should answer recurring product questions from authoritative docs."""
+
+    user = data_fixture.create_user()
+    workspace = data_fixture.create_workspace(user=user)
+    database = data_fixture.create_database_application(workspace=workspace)
+
+    agent, deps, tracker, model, usage_limits, toolset = create_eval_assistant(
+        user, workspace, max_iters=10, model=eval_model
+    )
+    ui_context = build_database_ui_context(user, workspace, database)
+    result = _run_agent(
+        agent,
+        deps,
+        tracker,
+        model,
+        usage_limits,
+        toolset,
+        question=question,
+        ui_context=ui_context,
+    )
+
+    print_message_history(result)
+
+    history = format_message_history(result)
+    tool_names = [
+        entry.get("tool_name")
+        for entry in history
+        if entry.get("tool_name") is not None
+    ]
+    sources = deps.sources
+    answer = _normalize_answer_text(result.output)
+    source_match = any(
+        any(pattern.lower() in url.lower() for pattern in expected_source_patterns)
+        for url in sources
+    )
+    missing_groups = [
+        alternatives
+        for alternatives in required_concept_groups
+        if not any(
+            _normalize_answer_text(alternative) in answer
+            for alternative in alternatives
+        )
+    ]
+    present_forbidden_claims = [
+        claim for claim in forbidden_claims if _normalize_answer_text(claim) in answer
+    ]
+    error_count, error_hint = count_tool_errors(result)
+
+    with EvalChecklist("production product question accuracy") as checks:
+        checks.check(
+            "called search_user_docs",
+            "search_user_docs" in tool_names,
+            hint=f"tools called: {tool_names}",
+        )
+        checks.check(
+            "returned an authoritative source",
+            source_match,
+            hint=(f"expected one of {expected_source_patterns}; returned: {sources}"),
+        )
+        checks.check(
+            "included every required factual concept",
+            not missing_groups,
+            hint=f"missing concept groups: {missing_groups}; answer: {result.output[:500]}",
+        )
+        checks.check(
+            "did not include a known hallucination",
+            not present_forbidden_claims,
+            hint=f"forbidden claims found: {present_forbidden_claims}",
+        )
+        checks.check("had no tool validation errors", error_count == 0, error_hint)

--- a/enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/test_provider_grouping.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/test_provider_grouping.py
@@ -1,0 +1,223 @@
+"""
+Guards the xdist worker-allocation policy used by the eval matrix.
+
+Parallelism is spread across providers first, then models, then within a model.
+If this breaks, several workers hit one provider at once and the resulting 429s
+are indistinguishable from a model-quality regression in the scored comparison.
+"""
+
+import pytest
+
+from . import conftest as eval_conftest
+from .conftest import _group_name, _provider_of, _shards_per_model
+
+# Four models on three providers: hetzner carries two.
+MODELS = [
+    "groq:openai/gpt-oss-120b",
+    "hetzner:deepseek-v4-flash",
+    "hetzner:glm5.2",
+    "openai:gpt-5.6-luna",
+]
+
+
+def groups_for(models: list[str], workers: int, per_model: int = 6) -> dict[str, set]:
+    """Return {model: set of group names} for *per_model* items of each model."""
+
+    shards = _shards_per_model(models, workers)
+    return {m: {_group_name(m, i, shards) for i in range(per_model)} for m in models}
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("groq:openai/gpt-oss-120b", "groq"),
+        ("hetzner:deepseek-v4-flash", "hetzner"),
+        ("infercom:vendor/some-model", "infercom"),
+        ("gpt-4o", "openai"),
+    ],
+)
+def test_provider_of(model, expected):
+    assert _provider_of(model) == expected
+
+
+def test_workers_at_or_below_provider_count_group_by_provider():
+    # 3 workers, 3 providers -> one worker per provider, hetzner's two models share.
+    groups = groups_for(MODELS, workers=3)
+
+    assert groups["hetzner:deepseek-v4-flash"] == {"hetzner"}
+    assert groups["hetzner:glm5.2"] == {"hetzner"}
+    assert groups["groq:openai/gpt-oss-120b"] == {"groq"}
+    assert len(set().union(*groups.values())) == 3
+
+
+def test_fewer_workers_than_providers_still_groups_by_provider():
+    groups = groups_for(MODELS, workers=2)
+
+    assert len(set().union(*groups.values())) == 3
+
+
+def test_workers_matching_model_count_give_one_worker_per_model():
+    # 4 workers, 4 models -> hetzner's two models split onto their own workers.
+    groups = groups_for(MODELS, workers=4)
+
+    assert groups["hetzner:deepseek-v4-flash"] == {"hetzner:deepseek-v4-flash"}
+    assert groups["hetzner:glm5.2"] == {"hetzner:glm5.2"}
+    assert len(set().union(*groups.values())) == 4
+
+
+def test_one_extra_worker_doubles_up_a_single_model():
+    # 5 workers, 4 models -> exactly one model gets a second worker.
+    groups = groups_for(MODELS, workers=5)
+
+    sizes = sorted(len(g) for g in groups.values())
+    assert sizes == [1, 1, 1, 2]
+    assert len(set().union(*groups.values())) == 5
+
+
+def test_double_the_models_gives_every_model_two_workers():
+    groups = groups_for(MODELS, workers=8)
+
+    assert all(len(g) == 2 for g in groups.values())
+    assert len(set().union(*groups.values())) == 8
+
+
+@pytest.mark.parametrize(
+    "workers,expected_groups",
+    # Below the provider count the layout stays at one group per provider; xdist
+    # runs the surplus groups sequentially, so per-provider concurrency is still 1.
+    [(1, 3), (2, 3), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (12, 12)],
+)
+def test_group_count_follows_the_waterfall(workers, expected_groups):
+    groups = groups_for(MODELS, workers=workers, per_model=12)
+
+    assert len(set().union(*groups.values())) == expected_groups
+
+
+@pytest.mark.parametrize("workers", [1, 2, 3])
+def test_scarce_workers_never_split_a_provider(workers):
+    groups = groups_for(MODELS, workers=workers)
+
+    per_provider: dict[str, set] = {}
+    for model, names in groups.items():
+        per_provider.setdefault(_provider_of(model), set()).update(names)
+
+    assert all(len(names) == 1 for names in per_provider.values())
+
+
+def test_single_provider_still_spreads_across_its_models():
+    models = ["hetzner:a", "hetzner:b", "hetzner:c"]
+
+    assert len(set().union(*groups_for(models, workers=1).values())) == 1
+    assert len(set().union(*groups_for(models, workers=3).values())) == 3
+
+
+class _StubConfig:
+    def __init__(
+        self, numprocesses, dist: str = "load", workercount: int | None = None
+    ):
+        self.option = type("opt", (), {"numprocesses": numprocesses, "dist": dist})()
+        if workercount is not None:
+            self.workerinput = {"workercount": workercount}
+
+
+class _StubItem:
+    def __init__(self, model: str | None):
+        self.callspec = (
+            type("cs", (), {"params": {"eval_model": model}})() if model else None
+        )
+        self.markers: list = []
+
+    def add_marker(self, marker):
+        self.markers.append(marker)
+
+    @property
+    def groups(self) -> list[str]:
+        return [m.kwargs["name"] for m in self.markers if m.name == "xdist_group"]
+
+
+def _items(models: list[str], per_model: int) -> list[_StubItem]:
+    return [_StubItem(m) for m in models for _ in range(per_model)]
+
+
+def test_items_are_tagged_at_collection_time():
+    items = _items(MODELS, per_model=3)
+
+    eval_conftest._assign_xdist_groups(_StubConfig(numprocesses=4), items)
+
+    assert all(len(i.groups) == 1 for i in items)
+    assert {i.groups[0] for i in items} == set(MODELS)
+
+
+def test_a_model_split_across_workers_uses_distinct_groups():
+    items = _items(MODELS, per_model=4)
+
+    eval_conftest._assign_xdist_groups(_StubConfig(numprocesses=8), items)
+
+    hetzner = [i for i in items if i.callspec.params["eval_model"] == "hetzner:glm5.2"]
+    assert len({i.groups[0] for i in hetzner}) == 2
+
+
+def test_serial_runs_are_left_ungrouped():
+    items = _items(MODELS, per_model=2)
+
+    eval_conftest._assign_xdist_groups(_StubConfig(numprocesses=None), items)
+
+    assert all(i.groups == [] for i in items)
+
+
+def test_non_eval_items_are_ignored():
+    items = [_StubItem(None), _StubItem(None)]
+
+    eval_conftest._assign_xdist_groups(_StubConfig(numprocesses=4), items)
+
+    assert all(i.groups == [] for i in items)
+
+
+def test_parallel_run_switches_to_loadgroup():
+    config = _StubConfig(numprocesses=4)
+
+    eval_conftest.pytest_configure(config)
+
+    assert config.option.dist == "loadgroup"
+
+
+def test_serial_run_keeps_default_scheduling():
+    config = _StubConfig(numprocesses=None)
+
+    eval_conftest.pytest_configure(config)
+
+    assert config.option.dist == "load"
+
+
+def test_explicit_dist_choice_is_respected():
+    config = _StubConfig(numprocesses=4, dist="loadfile")
+
+    eval_conftest.pytest_configure(config)
+
+    assert config.option.dist == "loadfile"
+
+
+def test_worker_sees_the_count_via_workerinput():
+    # xdist workers are not launched with -n, so numprocesses is unset there.
+    # They must still derive the same group layout as the controller.
+    config = _StubConfig(numprocesses=None, workercount=4)
+
+    assert eval_conftest._worker_count(config) == 4
+
+
+def test_workers_group_items_identically_to_the_controller():
+    controller_items = _items(MODELS, per_model=4)
+    worker_items = _items(MODELS, per_model=4)
+
+    eval_conftest._assign_xdist_groups(_StubConfig(numprocesses=8), controller_items)
+    eval_conftest._assign_xdist_groups(
+        _StubConfig(numprocesses=None, workercount=8), worker_items
+    )
+
+    assert [i.groups for i in controller_items] == [i.groups for i in worker_items]
+
+
+def test_worker_without_workerinput_falls_back_to_serial():
+    config = _StubConfig(numprocesses=None)
+
+    assert eval_conftest._worker_count(config) == 1


### PR DESCRIPTION
Comparing models on this suite was not possible, and where it did run it was not trustworthy.

Custom OpenAI-compatible endpoints could not be addressed at all. The harness passed a bare model string, so pydantic-ai inferred the provider itself — which both rejected those endpoints and meant every eval ever run silently skipped the retry layer production uses.

Several checks then scored the wrong thing: the automation evals read the tool call validation had *rejected* rather than the one that succeeded, and the builder evals ignored the composite tool the assistant is told to prefer. Correct runs were failing.

Parallelism is spread across providers before models, because a rate-limited request scored as a failure is indistinguishable from a model getting the answer wrong.

Stacked on #5898 — review that first.