### PR TITLE
resolve flaky ratingElement e2e test and missing ffmpeg on retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -709,6 +709,16 @@ jobs:
           cd e2e-tests
           yarn install
 
+      # The browsers come from the runner's system Chrome
+      # (PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1), but video recording on retry
+      # (video: "on-first-retry") still needs Playwright's bundled ffmpeg.
+      - name: Install Playwright ffmpeg
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 0
+        run: |
+          cd e2e-tests
+          npx playwright install ffmpeg
+
       - name: Verify Google Chrome
         run: google-chrome --version
 

--- a/e2e-tests/tests/builder/elements/ratingElement.spec.ts
+++ b/e2e-tests/tests/builder/elements/ratingElement.spec.ts
@@ -7,12 +7,12 @@ test.describe("Builder page heading element test suite", () => {
     element1 = await createBuilderElement(
       builderPagePage.builderPage,
       "rating",
-      { value: "'A Rate'" }
+      { value: "'A Rate'" },
     );
     element2 = await createBuilderElement(
       builderPagePage.builderPage,
       "rating_input",
-      { value: "'B Rate'" }
+      { value: "'B Rate'" },
     );
     await builderPagePage.goto();
   });
@@ -21,7 +21,7 @@ test.describe("Builder page heading element test suite", () => {
     const builderElementModal = await builderPagePage.openAddElementModal();
     await builderElementModal.addElementByName("Rating");
     await expect(
-      page.locator("a").filter({ hasText: "Star" }).first()
+      page.locator("a").filter({ hasText: "Star" }).first(),
     ).toBeVisible();
   });
 
@@ -34,7 +34,7 @@ test.describe("Builder page heading element test suite", () => {
     await builderElementModal.addElementByName("Rating input");
 
     await expect(
-      page.locator('[data-test-id="rating-form-value"]')
+      page.locator('[data-test-id="rating-form-value"]'),
     ).toBeVisible();
 
     await page.evaluate(() => {
@@ -42,9 +42,11 @@ test.describe("Builder page heading element test suite", () => {
       if (node) node.remove();
     });
 
+    // Subscribe before clicking: the Preview handler calls window.open()
+    // synchronously, so the "page" event can fire before click() resolves.
+    const newPagePromise = context.waitForEvent("page");
     await page.getByRole("button", { name: "Preview" }).click();
-
-    const newPage = await context.waitForEvent("page");
+    const newPage = await newPagePromise;
 
     await newPage.waitForLoadState();
 


### PR DESCRIPTION
### What is in this PR

Fixes two issues behind the recurring e2e failures on shard 1 (e.g. [this run](https://github.com/baserow/baserow/actions/runs/31681476313/job/94388156163)):                                                                                                 
                                                                                                                                                                                                                                                                
1. **Flaky `ratingElement.spec.ts` popup race** — the test clicked Preview and only then called `context.waitForEvent("page")`. The Preview handler calls `window.open()` synchronously, so the page event could fire before the listener existed, timing out after 30s roughly half the time. The promise is now created before the click (standard Playwright popup pattern).                                                                                                                                                                                          
                                                                                                                                                                                                                                                                
  2. **Retry 1 always crashed on missing ffmpeg** — `video: "on-first-retry"` needs Playwright's bundled ffmpeg, but the CI job sets `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` and never installed it, so every first retry died with `Executable doesn't exist at .../ffmpeg-1010/ffmpeg-linux`, silently reducing the retry budget from 3 to 2. Added an `npx playwright install ffmpeg` step to the e2e job.

### Checklist

- [ ] ~A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`~
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
