### PR TITLE
fix(formula): index() only needs 2 arguments

### DIFF
--- a/backend/src/baserow/contrib/database/formula/ast/function_defs.py
+++ b/backend/src/baserow/contrib/database/formula/ast/function_defs.py
@@ -3121,7 +3121,7 @@ class BaserowIndex(BaserowFunctionDefinition):
         args: List[BaserowExpression[BaserowFormulaValidType]],
         func_call: BaserowFunctionCall[UnTyped],
     ) -> BaserowExpression[BaserowFormulaType]:
-        if len(args) not in (2, 3):
+        if len(args) != 2:
             return func_call.with_invalid_type(
                 "index requires exactly 2 arguments: an array and an index."
             )

--- a/backend/src/baserow/contrib/database/formula/ast/function_defs.py
+++ b/backend/src/baserow/contrib/database/formula/ast/function_defs.py
@@ -79,6 +79,9 @@ from baserow.contrib.database.formula.ast.tree import (
     BaserowStringLiteral,
 )
 from baserow.contrib.database.formula.expression_generator.django_expressions import (
+    ALLOWED_ARRAY_INDEX_SQL,
+    ARRAY_INDEX_SQL_BY_MODE,
+    DEFAULT_ARRAY_INDEX_SQL,
     AndExpr,
     BaserowStringAgg,
     EqualsExpr,
@@ -3069,6 +3072,9 @@ def _index_output_field(mode):
         _lookup_formula_type_from_string,
     )
 
+    if mode == "date_with_time":
+        mode = "date"
+
     try:
         return _lookup_formula_type_from_string(mode).output_field_class()
     except Exception:
@@ -3094,6 +3100,8 @@ def _unwrap_literal_value(django_expr):
 
 class BaserowIndex(BaserowFunctionDefinition):
     type = "index"
+    # A 4th argument is still parsed so internal formulas written before it was
+    # dropped keep working, but the typing step below refuses to produce one.
     num_args = NumOfArgsBetween(2, 4)
 
     @property
@@ -3104,7 +3112,7 @@ class BaserowIndex(BaserowFunctionDefinition):
             elif arg_index == 1:
                 return [BaserowFormulaNumberType]
             else:
-                return [BaserowFormulaTextType]  # mode + sql literals
+                return [BaserowFormulaTextType]  # mode literal
 
         return type_checker
 
@@ -3113,7 +3121,7 @@ class BaserowIndex(BaserowFunctionDefinition):
         args: List[BaserowExpression[BaserowFormulaValidType]],
         func_call: BaserowFunctionCall[UnTyped],
     ) -> BaserowExpression[BaserowFormulaType]:
-        if len(args) not in (2, 4):
+        if len(args) not in (2, 3):
             return func_call.with_invalid_type(
                 "index requires exactly 2 arguments: an array and an index."
             )
@@ -3128,19 +3136,12 @@ class BaserowIndex(BaserowFunctionDefinition):
 
         sub_type = arg1.expression_type.sub_type
 
-        if len(args) == 4:
-            return func_call.with_args(list(args)).with_valid_type(sub_type)
-
+        # Always regenerated so the stored mode matches the resolved sub type.
         mode_literal = BaserowStringLiteral(
             sub_type.array_index_mode, BaserowFormulaTextType()
         )
-        sql_literal = BaserowStringLiteral(
-            sub_type.array_index_sql, BaserowFormulaTextType()
-        )
 
-        return func_call.with_args(
-            [arg1, arg2, mode_literal, sql_literal]
-        ).with_valid_type(sub_type)
+        return func_call.with_args([arg1, arg2, mode_literal]).with_valid_type(sub_type)
 
     def to_django_expression_given_args(
         self,
@@ -3149,10 +3150,18 @@ class BaserowIndex(BaserowFunctionDefinition):
     ) -> "WrappedExpressionWithMetadata":
         # Fall back to text defaults if args weren't augmented at type time.
         mode = "text"
-        value_sql = "{elem} ->> 'value'"
-        if len(args) >= 4:
+        if len(args) >= 3:
             mode = _unwrap_literal_value(args[2].expression) or mode
-            value_sql = _unwrap_literal_value(args[3].expression) or value_sql
+
+        value_sql = None
+        if len(args) >= 4:
+            # Internal formulas predating the mode lookup carry the template
+            # itself; it is used only when a formula type still produces it.
+            legacy_sql = _unwrap_literal_value(args[3].expression)
+            if legacy_sql in ALLOWED_ARRAY_INDEX_SQL:
+                value_sql = legacy_sql
+        if value_sql is None:
+            value_sql = ARRAY_INDEX_SQL_BY_MODE.get(mode, DEFAULT_ARRAY_INDEX_SQL)
         safe_index = handle_arg_being_nan(
             args[1].expression,
             Value(None, output_field=fields.IntegerField()),

--- a/backend/src/baserow/contrib/database/formula/expression_generator/django_expressions.py
+++ b/backend/src/baserow/contrib/database/formula/expression_generator/django_expressions.py
@@ -163,6 +163,29 @@ class JSONBArrayJoinValues(Func):
         return sql, (*separator_params, *params)
 
 
+DEFAULT_ARRAY_INDEX_SQL = "{elem} ->> 'value'"
+
+ARRAY_INDEX_SQL_BY_MODE = {
+    "text": DEFAULT_ARRAY_INDEX_SQL,
+    "char": DEFAULT_ARRAY_INDEX_SQL,
+    "url": DEFAULT_ARRAY_INDEX_SQL,
+    "date_interval": DEFAULT_ARRAY_INDEX_SQL,
+    "button": "{elem} -> 'value'",
+    "link": "{elem} -> 'value'",
+    "single_select": "{elem} -> 'value'",
+    "multiple_select": "{elem} -> 'value'",
+    "multiple_collaborators": "{elem} -> 'value'",
+    "single_file": "{elem}",
+    "number": "({elem} ->> 'value')::numeric",
+    "boolean": "({elem} ->> 'value')::boolean",
+    "duration": "({elem} ->> 'value')::interval",
+    "date": "({elem} ->> 'value')::date",
+    "date_with_time": "({elem} ->> 'value')::timestamptz",
+}
+
+ALLOWED_ARRAY_INDEX_SQL = frozenset(ARRAY_INDEX_SQL_BY_MODE.values())
+
+
 class JSONBArrayGetElement(Expression):
     """
     Extract a single element from a JSONB array by 0-based index (negative
@@ -171,6 +194,7 @@ class JSONBArrayGetElement(Expression):
     *value_sql* is a SQL template with an ``{elem}`` placeholder that controls
     how the element is extracted (e.g. ``({elem} ->> 'value')::numeric``).
     Each formula type provides its own template via ``array_index_sql``.
+    Templates outside ``ALLOWED_ARRAY_INDEX_SQL`` fall back to the default.
 
     PostgreSQL's ``->`` operator natively handles negative indices and returns
     NULL for out-of-bounds, so no CASE expression is needed.
@@ -180,6 +204,8 @@ class JSONBArrayGetElement(Expression):
         super().__init__(output_field=output_field)
         self.array_expr = array_expr
         self.index_expr = index_expr
+        if value_sql not in ALLOWED_ARRAY_INDEX_SQL:
+            value_sql = DEFAULT_ARRAY_INDEX_SQL
         self.value_sql = value_sql
 
     def resolve_expression(

--- a/backend/src/baserow/contrib/database/formula/migrations/migrations.py
+++ b/backend/src/baserow/contrib/database/formula/migrations/migrations.py
@@ -8,6 +8,8 @@ from baserow.core.formula import BaserowFormulaException
 NO_FORMULAS = Q(pk__in=[])
 ALL_FORMULAS = ~NO_FORMULAS
 
+FORMULAS_USING_INDEX = Q(internal_formula__contains="index(")
+
 
 FormulaMigrationSelector = Union[Q, Callable[[QuerySet], Q]]
 
@@ -130,6 +132,16 @@ FORMULA_MIGRATIONS = FormulaMigrations(
             recalculate_field_dependencies_for=NO_FORMULAS,
             recalculate_cell_values_for=NO_FORMULAS,
             force_recreate_formula_columns_for=all_aggregate_formulas,
+        ),
+        FormulaMigration(
+            version=6,
+            # v6 drops index()'s 4th argument, so any internal formula still
+            # carrying one has to be regenerated, and its cells recomputed since
+            # the values they hold were produced by the older expression.
+            recalculate_formula_attributes_for=FORMULAS_USING_INDEX,
+            recalculate_field_dependencies_for=NO_FORMULAS,
+            recalculate_cell_values_for=FORMULAS_USING_INDEX,
+            force_recreate_formula_columns_for=NO_FORMULAS,
         ),
     ]
 )

--- a/backend/src/baserow/contrib/database/formula/types/formula_types.py
+++ b/backend/src/baserow/contrib/database/formula/types/formula_types.py
@@ -58,6 +58,7 @@ from baserow.contrib.database.formula.ast.tree import (
     BaserowStringLiteral,
 )
 from baserow.contrib.database.formula.expression_generator.django_expressions import (
+    ARRAY_INDEX_SQL_BY_MODE,
     ComparisonOperator,
     JSONArrayCompareIntervalValueExpr,
     JSONArrayCompareNumericValueExpr,
@@ -928,9 +929,12 @@ class BaserowFormulaDateType(
         return cls(**kwargs)
 
     @property
+    def array_index_mode(self) -> str:
+        return "date_with_time" if self.date_include_time else "date"
+
+    @property
     def array_index_sql(self) -> str:
-        cast = "::timestamptz" if self.date_include_time else "::date"
-        return f"({{elem}} ->> 'value'){cast}"
+        return ARRAY_INDEX_SQL_BY_MODE[self.array_index_mode]
 
     @property
     def comparable_types(self) -> List[Type["BaserowFormulaValidType"]]:

--- a/backend/tests/baserow/contrib/database/field/migrations/test_formula_migrations.py
+++ b/backend/tests/baserow/contrib/database/field/migrations/test_formula_migrations.py
@@ -6,15 +6,19 @@ from django.db.models import Q
 import pytest
 
 from baserow.contrib.database.fields.dependencies.models import FieldDependency
+from baserow.contrib.database.fields.handler import FieldHandler
 from baserow.contrib.database.fields.models import FormulaField
 from baserow.contrib.database.formula.migrations.handler import FormulaMigrationHandler
 from baserow.contrib.database.formula.migrations.migrations import (
     ALL_FORMULAS,
+    BASEROW_FORMULA_VERSION,
     FORMULA_MIGRATIONS,
+    FORMULAS_USING_INDEX,
     NO_FORMULAS,
     FormulaMigration,
     FormulaMigrations,
 )
+from baserow.contrib.database.rows.handler import RowHandler
 
 
 def assert_all_rows_are_none(data_fixture, field):
@@ -795,3 +799,74 @@ def test_can_force_recalculate_for_formulas_with_invalid_syntax_or_of_error_type
             f"{formula_of_type_number_to_recreate_col.db_column}'"
         )
         assert [r[0] for r in cursor.fetchall()] == ["numeric"]
+
+
+# v6 stopped writing index()'s 4th argument. These cover upgrading an instance
+# whose stored internal formulas still carry one of the older shapes.
+
+
+def _index_formula_on_a_file_field(data_fixture, formula, name="idx"):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    data_fixture.create_file_field(table=table, name="Files", primary=True)
+    RowHandler().create_rows(user, table, [{}])
+    field = FieldHandler().create_field(
+        user, table, "formula", name=name, formula=formula
+    )
+    return user, table, field
+
+
+@pytest.mark.django_db
+def test_v6_rewrites_a_legacy_four_argument_internal_formula(data_fixture):
+    _, _, field = _index_formula_on_a_file_field(
+        data_fixture, "index(field('Files'), 0)"
+    )
+
+    legacy = field.internal_formula[:-1] + ",'{elem}')"
+    FormulaField.objects.filter(id=field.id).update(internal_formula=legacy, version=5)
+
+    FormulaMigrationHandler.migrate_formulas_to_latest_version()
+
+    field.refresh_from_db()
+    assert "{elem}" not in field.internal_formula
+    assert field.version == BASEROW_FORMULA_VERSION
+
+
+@pytest.mark.django_db
+def test_v6_rewrites_a_legacy_two_argument_internal_formula(data_fixture):
+    """Pre-2.2.0 rows carry no mode and evaluate as text, breaking jsonb callers."""
+
+    _, _, field = _index_formula_on_a_file_field(
+        data_fixture, "get_file_visible_name(index(field('Files'),0))"
+    )
+
+    legacy = field.internal_formula.replace(",'single_file')", ")")
+    assert legacy != field.internal_formula
+    FormulaField.objects.filter(id=field.id).update(internal_formula=legacy, version=5)
+
+    FormulaMigrationHandler.migrate_formulas_to_latest_version()
+
+    field.refresh_from_db()
+    assert "'single_file'" in field.internal_formula
+    assert field.version == BASEROW_FORMULA_VERSION
+
+
+@pytest.mark.django_db
+def test_v6_selector_matches_index_formulas_only(data_fixture):
+    user, table, indexed = _index_formula_on_a_file_field(
+        data_fixture, "index(field('Files'), 0)", name="indexed"
+    )
+    shortcut = FieldHandler().create_field(
+        user, table, "formula", name="shortcut", formula="first(field('Files'))"
+    )
+    unrelated = FieldHandler().create_field(
+        user, table, "formula", name="unrelated", formula="'a' + 'b'"
+    )
+
+    matched = set(
+        FormulaField.objects.filter(FORMULAS_USING_INDEX).values_list("id", flat=True)
+    )
+
+    assert indexed.id in matched
+    assert shortcut.id in matched, "first()/last() expand to index() internally"
+    assert unrelated.id not in matched

--- a/backend/tests/baserow/contrib/database/formula/test_index_generalized.py
+++ b/backend/tests/baserow/contrib/database/formula/test_index_generalized.py
@@ -954,17 +954,25 @@ def _recalculate(field, table):
 
 
 @pytest.mark.django_db
-def test_index_rejects_a_fourth_argument(table_with_file_field):
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "index(field('Files'), 0, 'text')",
+        "index(field('Files'), 0, 'text', 'anything')",
+    ],
+    ids=["three_args", "four_args"],
+)
+def test_index_only_accepts_two_arguments(table_with_file_field, formula):
+    """The mode is written by the typing step, never taken from the formula."""
+
     user, table = table_with_file_field
 
     with pytest.raises(InvalidFormulaType):
-        _create_formula(
-            user, table, "four", "index(field('Files'), 0, 'text', 'anything')"
-        )
+        _create_formula(user, table, "extra", formula)
 
 
 @pytest.mark.django_db
-def test_index_rejects_a_fourth_argument_over_the_api(
+def test_index_only_accepts_two_arguments_over_the_api(
     table_with_file_field, api_client, data_fixture
 ):
     user, table = table_with_file_field
@@ -973,7 +981,7 @@ def test_index_rejects_a_fourth_argument_over_the_api(
     response = api_client.post(
         f"/api/database/fields/table/{table.id}/",
         {
-            "name": "four",
+            "name": "extra",
             "type": "formula",
             "formula": "index(field('Files'), 0, 'text', 'anything')",
         },
@@ -983,21 +991,6 @@ def test_index_rejects_a_fourth_argument_over_the_api(
 
     assert response.status_code == 400
     assert response.json()["error"] == "ERROR_WITH_FORMULA"
-
-
-@pytest.mark.django_db
-def test_a_supplied_third_argument_is_replaced_by_the_resolved_mode(
-    table_with_file_field,
-):
-    user, table = table_with_file_field
-
-    field = _create_formula(
-        user, table, "three", "index(field('Files'), 0, 'not-a-mode')"
-    )
-
-    assert field.formula_type != "invalid"
-    assert "not-a-mode" not in field.internal_formula
-    assert "single_file" in field.internal_formula
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/contrib/database/formula/test_index_generalized.py
+++ b/backend/tests/baserow/contrib/database/formula/test_index_generalized.py
@@ -7,11 +7,30 @@ first(arr) = index(arr, 0), last(arr) = index(arr, -1).
 from datetime import date, timedelta
 from decimal import Decimal
 
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
 import pytest
 
 from baserow.contrib.database.fields.handler import FieldHandler
+from baserow.contrib.database.fields.models import FormulaField
+from baserow.contrib.database.formula.expression_generator.django_expressions import (
+    ALLOWED_ARRAY_INDEX_SQL,
+    ARRAY_INDEX_SQL_BY_MODE,
+    DEFAULT_ARRAY_INDEX_SQL,
+)
+from baserow.contrib.database.formula.expression_generator.django_expressions import (
+    JSONBArrayGetElement as JSONBArrayGetElementExpr,
+)
+from baserow.contrib.database.formula.handler import FormulaHandler
 from baserow.contrib.database.formula.types.exceptions import InvalidFormulaType
+from baserow.contrib.database.formula.types.formula_types import (
+    BASEROW_FORMULA_TYPES,
+    BaserowFormulaDateType,
+    BaserowFormulaNumberType,
+)
 from baserow.contrib.database.rows.handler import RowHandler
+from baserow.core.formula.parser.parser import convert_string_to_string_literal_token
 
 
 def _setup_single_select(df, table):
@@ -888,3 +907,222 @@ def test_baserow_index_to_django_expression_handles_unaugmented_args():
 
     assert isinstance(result, WrappedExpressionWithMetadata)
     assert isinstance(result.expression, JSONBArrayGetElement)
+
+
+# index() takes an array and an index. A 3rd argument holding the extraction
+# mode is written by the typing step; the 4th argument older versions wrote is
+# still parsed so stored formulas keep working.
+
+
+@pytest.fixture
+def table_with_file_field(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    data_fixture.create_file_field(table=table, name="Files", primary=True)
+    RowHandler().create_rows(user, table, [{}])
+    return user, table
+
+
+def _create_formula(user, table, name, formula):
+    return FieldHandler().create_field(
+        user, table, "formula", name=name, formula=formula
+    )
+
+
+def _legacy_four_arg(internal, mode, template):
+    """Rebuild the 4-arg internal formula a pre-fix version would have stored."""
+
+    return internal.replace(
+        f"'{mode}'",
+        convert_string_to_string_literal_token(mode, True)
+        + ","
+        + convert_string_to_string_literal_token(template, True),
+    )
+
+
+def _recalculate(field, table):
+    """Recompute a field's column straight from its stored internal formula."""
+
+    reloaded = FormulaField.objects.get(id=field.id)
+    reloaded.clear_cached_properties()
+    model = table.get_model()
+    expr = FormulaHandler.baserow_expression_to_update_django_expression(
+        reloaded.cached_typed_internal_expression, model
+    )
+    model.objects_and_trash.all().update(**{field.db_column: expr})
+    return model
+
+
+@pytest.mark.django_db
+def test_index_rejects_a_fourth_argument(table_with_file_field):
+    user, table = table_with_file_field
+
+    with pytest.raises(InvalidFormulaType):
+        _create_formula(
+            user, table, "four", "index(field('Files'), 0, 'text', 'anything')"
+        )
+
+
+@pytest.mark.django_db
+def test_index_rejects_a_fourth_argument_over_the_api(
+    table_with_file_field, api_client, data_fixture
+):
+    user, table = table_with_file_field
+    jwt = data_fixture.generate_token(user)
+
+    response = api_client.post(
+        f"/api/database/fields/table/{table.id}/",
+        {
+            "name": "four",
+            "type": "formula",
+            "formula": "index(field('Files'), 0, 'text', 'anything')",
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {jwt}",
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"] == "ERROR_WITH_FORMULA"
+
+
+@pytest.mark.django_db
+def test_a_supplied_third_argument_is_replaced_by_the_resolved_mode(
+    table_with_file_field,
+):
+    user, table = table_with_file_field
+
+    field = _create_formula(
+        user, table, "three", "index(field('Files'), 0, 'not-a-mode')"
+    )
+
+    assert field.formula_type != "invalid"
+    assert "not-a-mode" not in field.internal_formula
+    assert "single_file" in field.internal_formula
+
+
+@pytest.mark.django_db
+def test_internal_formula_carries_only_the_mode(table_with_file_field):
+    user, table = table_with_file_field
+
+    field = _create_formula(user, table, "two", "index(field('Files'), 0)")
+
+    assert "single_file" in field.internal_formula
+    for template in ALLOWED_ARRAY_INDEX_SQL:
+        assert template not in field.internal_formula
+
+
+@pytest.mark.django_db
+def test_legacy_four_argument_internal_formula_still_evaluates(table_with_file_field):
+    """Rows written before the 4th argument was dropped must keep working."""
+
+    user, table = table_with_file_field
+    field = _create_formula(
+        user, table, "legacy4", "get_file_visible_name(index(field('Files'),0))"
+    )
+    expected = getattr(table.get_model().objects.first(), field.db_column)
+
+    legacy = _legacy_four_arg(field.internal_formula, "single_file", "{elem}")
+    assert legacy != field.internal_formula
+    FormulaField.objects.filter(id=field.id).update(internal_formula=legacy)
+
+    model = _recalculate(field, table)
+    assert getattr(model.objects.first(), field.db_column) == expected
+
+
+@pytest.mark.django_db
+def test_legacy_four_argument_date_row_keeps_its_time(data_fixture):
+    """Legacy rows stored mode 'date' for both casts, so the template must win."""
+
+    user = data_fixture.create_user()
+    database = data_fixture.create_database_application(user=user)
+    table_a = data_fixture.create_database_table(database=database, name="A")
+    table_b = data_fixture.create_database_table(database=database, name="B")
+    data_fixture.create_text_field(table=table_a, name="pa", primary=True)
+    data_fixture.create_text_field(table=table_b, name="pb", primary=True)
+
+    link = FieldHandler().create_field(
+        user, table_a, "link_row", name="link", link_row_table=table_b
+    )
+    target = data_fixture.create_date_field(
+        table=table_b, name="target", date_include_time=True, date_format="ISO"
+    )
+    rows_b = (
+        RowHandler()
+        .create_rows(user, table_b, [{target.db_column: "2024-01-15T13:45:00Z"}])
+        .created_rows
+    )
+    RowHandler().create_rows(user, table_a, [{link.db_column: [rows_b[0].id]}])
+    FieldHandler().create_field(
+        user, table_a, "formula", name="lk", formula="lookup('link','target')"
+    )
+    field = FieldHandler().create_field(
+        user, table_a, "formula", name="idx", formula="index(field('lk'),0)"
+    )
+
+    expected = getattr(table_a.get_model().objects.first(), field.db_column)
+    assert expected.hour == 13 and expected.minute == 45
+
+    legacy = field.internal_formula.replace(
+        "'date_with_time'",
+        "'date',"
+        + convert_string_to_string_literal_token(
+            "({elem} ->> 'value')::timestamptz", True
+        ),
+    )
+    assert legacy != field.internal_formula
+    FormulaField.objects.filter(id=field.id).update(internal_formula=legacy)
+
+    model = _recalculate(field, table_a)
+    assert getattr(model.objects.first(), field.db_column) == expected
+
+
+@pytest.mark.django_db
+def test_legacy_fourth_argument_is_ignored_when_not_a_known_template(
+    table_with_file_field,
+):
+    """Only a template a formula type still produces is used; others fall back."""
+
+    user, table = table_with_file_field
+    field = _create_formula(user, table, "stale", "index(field('Files'),0)")
+
+    stale = _legacy_four_arg(
+        field.internal_formula, "single_file", "{elem} /*stale_template*/"
+    )
+    FormulaField.objects.filter(id=field.id).update(internal_formula=stale)
+
+    with CaptureQueriesContext(connection) as ctx:
+        _recalculate(field, table)
+
+    assert not any("stale_template" in q["sql"] for q in ctx.captured_queries)
+
+
+def test_unknown_mode_falls_back_to_the_default_template():
+    assert ARRAY_INDEX_SQL_BY_MODE.get("nope", DEFAULT_ARRAY_INDEX_SQL) == (
+        DEFAULT_ARRAY_INDEX_SQL
+    )
+
+
+def test_jsonb_array_get_element_only_accepts_known_templates():
+    expr = JSONBArrayGetElementExpr(None, None, "{elem}::regclass", None)
+
+    assert expr.value_sql == DEFAULT_ARRAY_INDEX_SQL
+
+
+def test_every_formula_type_mode_maps_to_its_own_template():
+    """Locks the mode -> SQL table against drift when a new type is added."""
+
+    instances = [
+        BaserowFormulaDateType("ISO", True, "24"),
+        BaserowFormulaDateType("ISO", False, "24"),
+        BaserowFormulaNumberType(2),
+    ]
+    for cls in BASEROW_FORMULA_TYPES:
+        try:
+            instances.append(cls())
+        except TypeError:
+            continue
+
+    for instance in instances:
+        mode = instance.array_index_mode
+        assert mode in ARRAY_INDEX_SQL_BY_MODE, f"{mode} missing from the mode table"
+        assert ARRAY_INDEX_SQL_BY_MODE[mode] == instance.array_index_sql


### PR DESCRIPTION
`index()` only needs 2arguments. The 3rd and 4th are internal and not needed by users, so they are no longer accepted.
