### PR TITLE
fix: sanitize PostgreSQL data sync error messages

### DIFF
--- a/backend/src/baserow/contrib/database/data_sync/postgresql_data_sync_type.py
+++ b/backend/src/baserow/contrib/database/data_sync/postgresql_data_sync_type.py
@@ -189,13 +189,13 @@ class PostgreSQLDataSyncType(DataSyncType):
             cursor = connection.cursor()
             yield cursor
         except psycopg.OperationalError:
-            logger.exception("PostgreSQL data sync connection error")
+            logger.warning("PostgreSQL data sync connection error", exc_info=True)
             raise SyncError(
                 "Could not connect to the PostgreSQL database. Please verify "
                 "the hostname, port, credentials, and SSL mode."
             )
         except psycopg.Error:
-            logger.exception("PostgreSQL data sync query error")
+            logger.warning("PostgreSQL data sync query error", exc_info=True)
             raise SyncError(
                 "A database error occurred while synchronizing. Please verify "
                 "the table name and column configuration."

--- a/backend/src/baserow/contrib/database/data_sync/postgresql_data_sync_type.py
+++ b/backend/src/baserow/contrib/database/data_sync/postgresql_data_sync_type.py
@@ -4,6 +4,8 @@ from typing import Any, Dict, List, Optional
 from django.conf import settings
 from django.db import DEFAULT_DB_ALIAS
 
+from loguru import logger
+
 from baserow.contrib.database.fields.models import (
     NUMBER_MAX_DECIMAL_PLACES,
     BooleanField,
@@ -186,8 +188,18 @@ class PostgreSQLDataSyncType(DataSyncType):
             )
             cursor = connection.cursor()
             yield cursor
-        except psycopg.Error as e:
-            raise SyncError(str(e))
+        except psycopg.OperationalError:
+            logger.exception("PostgreSQL data sync connection error")
+            raise SyncError(
+                "Could not connect to the PostgreSQL database. Please verify "
+                "the hostname, port, credentials, and SSL mode."
+            )
+        except psycopg.Error:
+            logger.exception("PostgreSQL data sync query error")
+            raise SyncError(
+                "A database error occurred while synchronizing. Please verify "
+                "the table name and column configuration."
+            )
         finally:
             if cursor:
                 cursor.close()

--- a/backend/tests/baserow/contrib/database/data_sync/test_data_sync_postgresql.py
+++ b/backend/tests/baserow/contrib/database/data_sync/test_data_sync_postgresql.py
@@ -579,7 +579,10 @@ def test_postgresql_data_sync_connection_error(data_fixture):
         )
         handler.sync_data_sync_table(user=user, data_sync=data_sync)
 
-    assert "failed" in str(e.value)
+    error_message = str(e.value)
+    assert "Could not connect" in error_message
+    assert "NOT_EXISTING_USER" not in error_message
+    assert default_database["HOST"] not in error_message
 
 
 @pytest.mark.django_db(transaction=True)

--- a/enterprise/backend/src/baserow_enterprise/data_sync/data_sync_types.py
+++ b/enterprise/backend/src/baserow_enterprise/data_sync/data_sync_types.py
@@ -1,6 +1,8 @@
 from itertools import chain
 from typing import List
 
+from loguru import logger
+
 from baserow.contrib.database.data_sync.data_sync_types import (
     PostgreSQLDataSyncType as BaserowPostgreSQLDataSyncType,
 )
@@ -47,8 +49,18 @@ class PostgreSQLDataSyncType(BaserowPostgreSQLDataSyncType):
                 if fetch_all:
                     returning = cursor.fetchall()
                 cursor.connection.commit()
-            except psycopg.Error as e:
-                raise SyncError(f"Database error: {str(e)}")
+            except psycopg.OperationalError:
+                logger.exception("PostgreSQL data sync connection error")
+                raise SyncError(
+                    "Could not connect to the PostgreSQL database. Please "
+                    "verify the hostname, port, credentials, and SSL mode."
+                )
+            except psycopg.Error:
+                logger.exception("PostgreSQL data sync query error")
+                raise SyncError(
+                    "A database error occurred while synchronizing. Please "
+                    "verify the table name and column configuration."
+                )
 
         return returning
 

--- a/enterprise/backend/src/baserow_enterprise/data_sync/data_sync_types.py
+++ b/enterprise/backend/src/baserow_enterprise/data_sync/data_sync_types.py
@@ -50,13 +50,13 @@ class PostgreSQLDataSyncType(BaserowPostgreSQLDataSyncType):
                     returning = cursor.fetchall()
                 cursor.connection.commit()
             except psycopg.OperationalError:
-                logger.exception("PostgreSQL data sync connection error")
+                logger.warning("PostgreSQL data sync connection error", exc_info=True)
                 raise SyncError(
                     "Could not connect to the PostgreSQL database. Please "
                     "verify the hostname, port, credentials, and SSL mode."
                 )
             except psycopg.Error:
-                logger.exception("PostgreSQL data sync query error")
+                logger.warning("PostgreSQL data sync query error", exc_info=True)
                 raise SyncError(
                     "A database error occurred while synchronizing. Please "
                     "verify the table name and column configuration."

--- a/enterprise/backend/tests/baserow_enterprise_tests/data_sync/test_realtime_push_two_way_sync_strategy.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/data_sync/test_realtime_push_two_way_sync_strategy.py
@@ -257,8 +257,9 @@ def test_two_way_sync_is_notified_after_retries(
     assert notification.data["table_name"] == data_sync.table.name
     assert notification.data["table_id"] == data_sync.table.id
     assert notification.data["database_id"] == data_sync.table.database_id
-    assert notification.data["error"].startswith(
-        """Database error: relation "public.test_table" does not exist"""
+    assert notification.data["error"] == (
+        "A database error occurred while synchronizing. Please "
+        "verify the table name and column configuration."
     )
 
     mock_task_context.retry.assert_not_called()


### PR DESCRIPTION
## Summary

PostgreSQL data sync error handlers currently pass raw `psycopg` exception strings to `SyncError`. These strings can contain hostnames, ports, usernames, and protocol details that aid reconnaissance. This PR replaces them with generic, actionable messages.

## Scope

| Area | Change |
|------|--------|
| `data_sync/postgresql_data_sync_type.py` | Split `psycopg.Error` into `OperationalError` (connection) and generic (query) with sanitized messages |
| `enterprise/.../data_sync_types.py` | Same sanitization for enterprise PostgreSQL data sync |
| `test_data_sync_postgresql.py` | Regression test: error message contains no hostname or username |

## Test plan

- [x] PostgreSQL data sync connection error says "Could not connect" without leaking hostname/username
