### PR TITLE
Fix Helm chart defects and add migration resources & Application Builder domain options

### DIFF
--- a/changelog/entries/unreleased/bug/4404_fix_the_helm_chart_failing_to_render_when_ingresstls_is_set.json
+++ b/changelog/entries/unreleased/bug/4404_fix_the_helm_chart_failing_to_render_when_ingresstls_is_set.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix the Helm chart failing to render when ingress.tls is set",
+    "issue_origin": "github",
+    "issue_number": 4404,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-08-06"
+}

--- a/changelog/entries/unreleased/bug/fix_the_helm_chart_ingress_backend_service_names_the_postgre.json
+++ b/changelog/entries/unreleased/bug/fix_the_helm_chart_ingress_backend_service_names_the_postgre.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix the Helm chart ingress backend service names, the postgresql existing-secret lookup, the serviceAccount annotations, the liveness and readiness probe toggles and the pod OTEL attributes",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-08-06"
+}

--- a/changelog/entries/unreleased/bug/namespace_the_helm_chart_internal_template_helpers_so_they_n.json
+++ b/changelog/entries/unreleased/bug/namespace_the_helm_chart_internal_template_helpers_so_they_n.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Namespace the Helm chart internal template helpers so they no longer override the identically named helpers in the Redis and MinIO subcharts",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-08-07"
+}

--- a/changelog/entries/unreleased/bug/set_the_namespace_labels_and_type_on_the_helm_chart_backend_.json
+++ b/changelog/entries/unreleased/bug/set_the_namespace_labels_and_type_on_the_helm_chart_backend_.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Set the namespace, labels and type on the Helm chart backend secret so it matches the other chart resources",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-08-07"
+}

--- a/changelog/entries/unreleased/feature/add_the_helm_chart_values_migrationresources_and_globalbaser.json
+++ b/changelog/entries/unreleased/feature/add_the_helm_chart_values_migrationresources_and_globalbaser.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Add the Helm chart values migration.resources and global.baserow.applicationBuilderDomains. The ingress no longer emits a host-less rule that claimed every otherwise unmatched request; each rule now has an explicit host",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-08-07"
+}

--- a/deploy/helm/baserow/README.md
+++ b/deploy/helm/baserow/README.md
@@ -480,11 +480,12 @@ caddy:
 
 ### Ingress Configuration
 
-| Name                                              | Description                                | Value                                     |
-| ------------------------------------------------- | ------------------------------------------ | ----------------------------------------- |
-| `ingress.enabled`                                 | Enable the Ingress resource                | `true`                                    |
-| `ingress.annotations.kubernetes.io/ingress.class` | Ingress class annotation                   | `{"kubernetes.io/ingress.class":"caddy"}` |
-| `ingress.tls`                                     | TLS configuration for the Ingress resource | `[]`                                      |
+| Name                                              | Description                                                                    | Value                                     |
+| ------------------------------------------------- | ------------------------------------------------------------------------------ | ----------------------------------------- |
+| `ingress.enabled`                                 | Enable the Ingress resource                                                    | `true`                                    |
+| `ingress.className`                               | IngressClass to handle the Ingress resource, omitted from the manifest when empty | `""`                                   |
+| `ingress.annotations.kubernetes.io/ingress.class` | Ingress class annotation                                                       | `{"kubernetes.io/ingress.class":"caddy"}` |
+| `ingress.tls`                                     | TLS configuration for the Ingress resource                                     | `[]`                                      |
 
 ### Redis Configuration
 

--- a/deploy/helm/baserow/README.md
+++ b/deploy/helm/baserow/README.md
@@ -246,6 +246,7 @@ caddy:
 | `global.baserow.domain`                                            | Configure the domain for the frontend application.                                      | `cluster.local`         |
 | `global.baserow.backendDomain`                                     | Configure the domain for the backend application.                                       | `api.cluster.local`     |
 | `global.baserow.objectsDomain`                                     | Configure the domain for the external facing minio api.                                 | `objects.cluster.local` |
+| `global.baserow.applicationBuilderDomains`                         | Extra domains routed to the frontend, for Application Builder apps served on their own domain. | `[]`             |
 | `global.baserow.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                    | `false`                 |
 | `global.baserow.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                        | `{}`                    |
 | `global.baserow.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                              | `""`                    |
@@ -326,6 +327,7 @@ caddy:
 | `migration.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                        | `[]`      |
 | `migration.containerSecurityContext.capabilities.add`         | List of capabilities to be added                          | `[]`      |
 | `migration.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile          | `""`      |
+| `migration.resources`                                         | Set container requests and limits for different resources like CPU or memory (essential for production workloads) | `{}` |
 
 ### Baserow Backend ASGI Configuration
 

--- a/deploy/helm/baserow/charts/baserow-common/templates/deployment.yaml
+++ b/deploy/helm/baserow/charts/baserow-common/templates/deployment.yaml
@@ -53,17 +53,11 @@ spec:
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           {{- end }}
-          {{- if .Values.readinessProbe.enabled }}
-          {{- with .Values.livenessProbe }}
-          livenessProbe:
-            {{ toYaml . | nindent 12 }}
-          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe: {{- omit .Values.livenessProbe "enabled" | toYaml | nindent 12 }}
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
-          {{- with .Values.readinessProbe }}
-          readinessProbe:
-            {{ toYaml . | nindent 12 }}
-          {{- end }}
+          readinessProbe: {{- omit .Values.readinessProbe "enabled" | toYaml | nindent 12 }}
           {{- end }}
           {{- if or .Values.global.baserow.containerSecurityContext.enabled .Values.containerSecurityContext.enabled }}
           securityContext: {{- include "baserow.containerSecurityContext" . | nindent 12 }}
@@ -89,13 +83,13 @@ spec:
             - name: K8S_POD_UID
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.name
+                  fieldPath: metadata.uid
             - name: K8S_POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "k8s.container.name=$(K8S_POD_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID),k8s.namespace.name=$(K8S_POD_NAMESPACE),k8s.resource.type=container"
+              value: "k8s.container.name={{ include "baserow.fullname" . }},k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID),k8s.namespace.name=$(K8S_POD_NAMESPACE),k8s.resource.type=container"
             - name: HOST_IP
               valueFrom:
                 fieldRef:

--- a/deploy/helm/baserow/charts/baserow-common/templates/service-account.yaml
+++ b/deploy/helm/baserow/charts/baserow-common/templates/service-account.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-  {{- end }}z
+  {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/baserow/templates/_helpers.tpl
+++ b/deploy/helm/baserow/templates/_helpers.tpl
@@ -88,7 +88,7 @@ Create image url to use
 Returns the available value for certain key in an existing secret (if it exists),
 otherwise it generates a random value.
 */}}
-{{- define "getValueFromSecret" }}
+{{- define "baserow.global.getValueFromSecret" }}
 {{- $len := (default 16 .Length) | int -}}
 {{- $obj := (lookup "v1" "Secret" .Namespace .Name).data -}}
 {{- if $obj }}
@@ -109,7 +109,7 @@ Get jwt secret name
 Get jwt secret key
 */}}
 {{- define "baserow.global.jwt.secret_key" -}}
-{{- include "getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" .Values.global.baserow.backendSecret "Length" 10 "Key" "SECRET_KEY")  -}}
+{{- include "baserow.global.getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" .Values.global.baserow.backendSecret "Length" 10 "Key" "SECRET_KEY")  -}}
 {{- end }}
 
 
@@ -117,7 +117,7 @@ Get jwt secret key
 Get jwt secret key
 */}}
 {{- define "baserow.global.jwt.signing_key" -}}
-{{- include "getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" .Values.global.baserow.backendSecret "Length" 10 "Key" "BASEROW_JWT_SIGNING_KEY")  -}}
+{{- include "baserow.global.getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" .Values.global.baserow.backendSecret "Length" 10 "Key" "BASEROW_JWT_SIGNING_KEY")  -}}
 {{- end }}
 
 {{/*
@@ -144,7 +144,7 @@ Get the password for the postgresql user
 {{- define "baserow.global.postgresql.password" -}}
   {{- if .Values.postgresql.enabled -}}
   {{- if .Values.postgresql.auth.existingSecret -}}
-    {{- include "getValueFromSecret" (dict "Namespace" (include "common.names.namespace" .Subcharts.postgresql) "Name" (include "postgresql.v1.secretName" .Subcharts.postgresql) "Length" 10 "Key" (include "postgresql.v1.userPasswordKey" .Subcharts.postgresql))  -}}
+    {{- include "baserow.global.getValueFromSecret" (dict "Namespace" (include "common.names.namespace" .Subcharts.postgresql) "Name" (include "postgresql.v1.secretName" .Subcharts.postgresql) "Length" 10 "Key" (include "postgresql.v1.userPasswordKey" .Subcharts.postgresql))  -}}
   {{- else if .Values.postgresql.auth.password -}}
     {{ .Values.postgresql.auth.password }}
   {{- end -}}
@@ -163,7 +163,7 @@ Return the username for the postgres user
 {{/*
 PodSecurityContext combine the global and local PodSecurityContexts
 */}}
-{{- define "podSecurityContext" -}}
+{{- define "baserow.global.migration.podSecurityContext" -}}
 {{- if .Values.migration.securityContext.enabled }}
 {{- omit .Values.migration.securityContext "enabled" | toYaml  }}
 {{- else if .Values.global.baserow.securityContext.enabled }}
@@ -174,7 +174,7 @@ PodSecurityContext combine the global and local PodSecurityContexts
 {{/*
 ContainerSecurityContext combine the global and local ContainerSecurityContexts
 */}}
-{{- define "containerSecurityContext" -}}
+{{- define "baserow.global.migration.containerSecurityContext" -}}
 {{- if .Values.migration.containerSecurityContext.enabled }}
 {{- omit .Values.migration.containerSecurityContext "enabled" | toYaml  }}
 {{- else if .Values.global.baserow.containerSecurityContext.enabled }}

--- a/deploy/helm/baserow/templates/_helpers.tpl
+++ b/deploy/helm/baserow/templates/_helpers.tpl
@@ -144,7 +144,7 @@ Get the password for the postgresql user
 {{- define "baserow.global.postgresql.password" -}}
   {{- if .Values.postgresql.enabled -}}
   {{- if .Values.postgresql.auth.existingSecret -}}
-    {{- include "getValueFromSecret" (dict "Namespace" (include "common.names.namespace" .Subcharts.postgresq) "Name" (include "postgresql.v1.secretName" .Subcharts.postgresq) "Length" 10 "Key" (include "postgresql.v1.userPasswordKey" .Subcharts.postgresq))  -}}
+    {{- include "getValueFromSecret" (dict "Namespace" (include "common.names.namespace" .Subcharts.postgresql) "Name" (include "postgresql.v1.secretName" .Subcharts.postgresql) "Length" 10 "Key" (include "postgresql.v1.userPasswordKey" .Subcharts.postgresql))  -}}
   {{- else if .Values.postgresql.auth.password -}}
     {{ .Values.postgresql.auth.password }}
   {{- end -}}

--- a/deploy/helm/baserow/templates/ingress.yaml
+++ b/deploy/helm/baserow/templates/ingress.yaml
@@ -73,8 +73,8 @@ spec:
                 name: {{ include "baserow.global.fullname" . }}-baserow-frontend
                 port:
                   number: 80
-  {{- if .Values.ingress.tls }}
+  {{- with .Values.ingress.tls }}
   tls:
-    {{ tpl (toYaml .Values.ingress.tls | indent 4) . }}
-  {{- end -}}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{ end }}

--- a/deploy/helm/baserow/templates/ingress.yaml
+++ b/deploy/helm/baserow/templates/ingress.yaml
@@ -54,6 +54,18 @@ spec:
                 name: {{ include "baserow.fullname" (index .Subcharts "baserow-frontend") }}
                 port:
                   number: 80
+    {{- range .Values.global.baserow.applicationBuilderDomains }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "baserow.fullname" (index $.Subcharts "baserow-frontend") }}
+                port:
+                  number: 80
+    {{- end }}
     {{- if .Values.minio.enabled }}
     - host: {{ .Values.global.baserow.objectsDomain }}
       http:
@@ -66,15 +78,6 @@ spec:
                 port:
                   number: 9000
     {{- end }}
-    - http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "baserow.fullname" (index .Subcharts "baserow-frontend") }}
-                port:
-                  number: 80
   {{- with .Values.ingress.tls }}
   tls:
     {{- toYaml . | nindent 4 }}

--- a/deploy/helm/baserow/templates/ingress.yaml
+++ b/deploy/helm/baserow/templates/ingress.yaml
@@ -9,7 +9,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
   rules:
     - host: {{ .Values.global.baserow.backendDomain | default (printf "api.%s" .Values.global.baserow.domain) }}
       http:
@@ -18,28 +20,28 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ include "baserow.global.fullname" . }}-baserow-backend-asgi
+                name: {{ include "baserow.fullname" (index .Subcharts "baserow-backend-asgi") }}
                 port:
                   number: 80
           - path: /mcp/
             pathType: Prefix
             backend:
               service:
-                name: {{ include "baserow.global.fullname" . }}-baserow-backend-asgi
+                name: {{ include "baserow.fullname" (index .Subcharts "baserow-backend-asgi") }}
                 port:
                   number: 80
           - path: /assistant/
             pathType: Prefix
             backend:
               service:
-                name: {{ include "baserow.global.fullname" . }}-baserow-backend-asgi
+                name: {{ include "baserow.fullname" (index .Subcharts "baserow-backend-asgi") }}
                 port:
                   number: 80
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: {{ include "baserow.global.fullname" . }}-baserow-backend-wsgi
+                name: {{ include "baserow.fullname" (index .Subcharts "baserow-backend-wsgi") }}
                 port:
                   number: 80
     - host: {{ .Values.global.baserow.domain }}
@@ -49,7 +51,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ include "baserow.global.fullname" . }}-baserow-frontend
+                name: {{ include "baserow.fullname" (index .Subcharts "baserow-frontend") }}
                 port:
                   number: 80
     {{- if .Values.minio.enabled }}
@@ -70,7 +72,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ include "baserow.global.fullname" . }}-baserow-frontend
+                name: {{ include "baserow.fullname" (index .Subcharts "baserow-frontend") }}
                 port:
                   number: 80
   {{- with .Values.ingress.tls }}

--- a/deploy/helm/baserow/templates/migrate-hook.yaml
+++ b/deploy/helm/baserow/templates/migrate-hook.yaml
@@ -18,6 +18,9 @@ spec:
           image: {{ include "baserow.global.migration.image" . }}
           args: ["setup"]
           imagePullPolicy: Always
+          {{- with .Values.migration.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.migration.extraEnv }}
           env:
             {{- range .Values.migration.extraEnv }}

--- a/deploy/helm/baserow/templates/migrate-hook.yaml
+++ b/deploy/helm/baserow/templates/migrate-hook.yaml
@@ -11,7 +11,7 @@ spec:
   template:
     spec:
       {{- if or .Values.global.baserow.securityContext.enabled .Values.migration.securityContext.enabled }}
-      securityContext: {{- include "podSecurityContext" . | nindent 8 }}
+      securityContext: {{- include "baserow.global.migration.podSecurityContext" . | nindent 8 }}
       {{- end }}
       containers:
         - name: migrate
@@ -36,7 +36,7 @@ spec:
           priorityClassName: {{ .Values.migration.priorityClassName }}
           {{- end -}}
           {{- if or .Values.global.baserow.containerSecurityContext.enabled .Values.migration.containerSecurityContext.enabled }}
-          securityContext: {{- include "containerSecurityContext" . | nindent 12 }}
+          securityContext: {{- include "baserow.global.migration.containerSecurityContext" . | nindent 12 }}
           {{- end }}
           {{- with .Values.migration.volumeMounts }}
           volumeMounts:

--- a/deploy/helm/baserow/templates/secret.yaml
+++ b/deploy/helm/baserow/templates/secret.yaml
@@ -1,10 +1,14 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  name: {{ .Values.global.baserow.backendSecret }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: pre-install, pre-upgrade
     helm.sh/hook-weight: "2"
-  name: {{ .Values.global.baserow.backendSecret }}
+  labels:
+    {{- include "baserow.global.labels" . | nindent 4 }}
+type: Opaque
 data:
 {{- if .Values.minio.enabled }}
   AWS_ACCESS_KEY_ID: {{ include "minio.secret.userValue" .Subcharts.minio | b64enc }}

--- a/deploy/helm/baserow/templates/shared-configmap.yaml
+++ b/deploy/helm/baserow/templates/shared-configmap.yaml
@@ -11,7 +11,7 @@ metadata:
 data:
   PUBLIC_BACKEND_URL: https://{{ .Values.global.baserow.backendDomain }}
   PUBLIC_WEB_FRONTEND_URL: https://{{ .Values.global.baserow.domain }}
-  PRIVATE_BACKEND_URL: http://{{ lower .Release.Name }}-baserow-backend-wsgi
+  PRIVATE_BACKEND_URL: http://{{ include "baserow.fullname" (index .Subcharts "baserow-backend-wsgi") }}
   {{- range $key, $val := .Values.sharedConfigMap }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}

--- a/deploy/helm/baserow/values.yaml
+++ b/deploy/helm/baserow/values.yaml
@@ -22,6 +22,7 @@
 ## @param global.baserow.domain Configure the domain for the frontend application.
 ## @param global.baserow.backendDomain Configure the domain for the backend application.
 ## @param global.baserow.objectsDomain Configure the domain for the external facing minio api.
+## @param global.baserow.applicationBuilderDomains Extra domains routed to the frontend, for Application Builder apps served on their own domain.
 ## @param global.baserow.containerSecurityContext.enabled Enabled containers' Security Context
 ## @param global.baserow.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
 ## @param global.baserow.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
@@ -59,6 +60,12 @@ global:
     domain: cluster.local
     backendDomain: api.cluster.local
     objectsDomain: objects.cluster.local
+    ## Example:
+    ## applicationBuilderDomains:
+    ##   - app.mydomain.com
+    ##   - shop.mydomain.com
+    ##
+    applicationBuilderDomains: []
     assistantLLMModel: ""
 
     securityContext:
@@ -167,6 +174,16 @@ backendConfigMap:
 ## @param migration.containerSecurityContext.capabilities.drop List of capabilities to be dropped
 ## @param migration.containerSecurityContext.capabilities.add List of capabilities to be added
 ## @param migration.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
+## @param migration.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+## Example:
+## resources:
+##   requests:
+##     cpu: 2
+##     memory: 512Mi
+##   limits:
+##     cpu: 3
+##     memory: 1024Mi
+##
 
 migration:
   enabled: true
@@ -200,6 +217,7 @@ migration:
       drop: []
     seccompProfile:
       type: ""
+  resources: {}
 
 ## @section Baserow Backend ASGI Configuration
 ## Configuration for the ASGI server that serves the Baserow backend application.

--- a/deploy/helm/baserow/values.yaml
+++ b/deploy/helm/baserow/values.yaml
@@ -607,10 +607,18 @@ baserow-embeddings:
 ## @section Ingress Configuration
 ## Configuration for the Ingress resource
 ## @param ingress.enabled Enable the Ingress resource
+## @param ingress.className IngressClass to handle the Ingress resource, omitted from the manifest when empty
 ## @param ingress.annotations.kubernetes.io/ingress.class Ingress class annotation
 ## @param ingress.tls TLS configuration for the Ingress resource
+## Example:
+## tls:
+##   - hosts:
+##       - baserow.mydomain.com
+##     secretName: baserow-tls
+##
 ingress:
   enabled: true
+  className: ""
   annotations:
     kubernetes.io/ingress.class: caddy
   tls: []


### PR DESCRIPTION
## Summary

Fixes a set of Helm chart defects found while resolving #4404, and backports two chart options. All changes verified with `helm template` against chart 1.0.56.

### Bug fixes

- **`ingress.tls` rendered invalid YAML** — `toYaml | indent 4` inside an already-indented line double-indented the first sequence entry, making `helm template` fail outright whenever a TLS block was configured. Now uses the same `with`/`nindent` idiom as the `annotations` block. Fixes #4404.
- **Ingress backend service names were built by hand** as `<fullname>-baserow-<component>`, which only matches the subchart's actual service names when the release name contains "baserow". Names are now resolved through `.Subcharts`, matching how the minio host rule already does it. `PRIVATE_BACKEND_URL` in the shared configmap switched to the same helper.
- **`.Subcharts.postgresq` typo** (missing "l") made the whole chart fail to render when `postgresql.auth.existingSecret` was set.
- **Stray `z` in the component serviceAccount template** was silently appended to the last annotation value (e.g. turning an IRSA role ARN into `arn:aws:iam::123:role/xz`).
- **Liveness probe was gated on `readinessProbe.enabled`**, so `livenessProbe.enabled: true` did nothing and enabling the readiness probe injected an unrequested liveness probe. The `enabled` marker key also leaked into the rendered probe specs.
- **`K8S_POD_UID` read `metadata.name`** instead of `metadata.uid`, and `OTEL_RESOURCE_ATTRIBUTES` reported the pod name as the container name.
- **`ingress.className` was referenced but never declared** in values.yaml, so a default install rendered `ingressClassName: null`. It is now documented and omitted when empty.
- **Unprefixed template helpers leaked into subcharts** — `getValueFromSecret`, `podSecurityContext`, and `containerSecurityContext` were defined without the `baserow.` prefix. Helm's template namespace is global, so the parent's `getValueFromSecret` silently overrode the redis and minio subcharts' own definitions (the helper that preserves existing credentials across upgrades). Renamed to `baserow.global.getValueFromSecret` and `baserow.global.migration.{pod,container}SecurityContext`.
- **The backend secret lacked `namespace`, common labels, and `type`** — the only chart-owned object missing them. Metadata only; the secret's data is unchanged.

### New options

- **`migration.resources`** — the migrate Job's container was the only one in the chart with no way to set requests/limits, which makes it unschedulable on clusters with a ResourceQuota requiring them.
- **`global.baserow.applicationBuilderDomains`** — extra hosts routed to the frontend service, for Application Builder apps served on their own domains.

### Behaviour change

The ingress no longer emits a rule with no host. A host-less rule claims every otherwise-unmatched request on its ingress class, which is hostile on a shared controller such as nginx, and was redundant for the normal case since the `global.baserow.domain` rule already routes the base hostname to the frontend. Additional hostnames can be added via `global.baserow.applicationBuilderDomains`.

### Changelog

Changelog entries added for each fix and the new options under `changelog/entries/unreleased/`.

## Test plan

- [x] `helm template` renders successfully with `ingress.tls` set (previously failed)
- [x] `helm template` renders successfully with `postgresql.auth.existingSecret` set (previously failed)
- [x] Ingress backend service names match the rendered service names for release names with and without "baserow"
- [x] Verified subchart helper shadowing by replacing the parent helper with a sentinel and rendering minio's secret
- [x] Rendered output diffed before/after for defaults — identical apart from the fixed defects and randomly generated secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)