### PR TITLE
fix: enforce row update permission check during import upsert

### DIFF
--- a/backend/src/baserow/contrib/database/api/tables/views.py
+++ b/backend/src/baserow/contrib/database/api/tables/views.py
@@ -38,6 +38,9 @@ from baserow.contrib.database.operations import (
     CreateTableDatabaseTableOperationType,
     ListTablesDatabaseTableOperationType,
 )
+from baserow.contrib.database.rows.operations import (
+    UpdateDatabaseRowOperationType,
+)
 from baserow.contrib.database.table.actions import (
     CreateTableActionType,
     DeleteTableActionType,
@@ -560,6 +563,13 @@ class AsyncTableImportView(APIView):
             context=table,
         )
         configuration = data.get("configuration")
+        if configuration and configuration.get("upsert_fields"):
+            CoreHandler().check_permissions(
+                request.user,
+                UpdateDatabaseRowOperationType.type,
+                workspace=table.database.workspace,
+                context=table,
+            )
         importer_type = data.get("importer_type", "")
         original_file_name = data.get("original_file_name", "")
         data = data["data"]

--- a/backend/src/baserow/contrib/database/rows/handler.py
+++ b/backend/src/baserow/contrib/database/rows/handler.py
@@ -2079,13 +2079,6 @@ class RowHandler:
         )
 
         configuration = configuration or {}
-        if configuration.get("upsert_fields"):
-            CoreHandler().check_permissions(
-                user,
-                UpdateDatabaseRowOperationType.type,
-                workspace=workspace,
-                context=table,
-            )
 
         model = table.get_model()
 
@@ -2208,6 +2201,14 @@ class RowHandler:
                     rows_values_to_create.append(row)
         else:
             rows_values_to_create = valid_rows
+
+        if rows_values_to_update:
+            CoreHandler().check_permissions(
+                user,
+                UpdateDatabaseRowOperationType.type,
+                workspace=workspace,
+                context=table,
+            )
 
         changed_rows = len(rows_values_to_create) + len(rows_values_to_update)
         full_field_search_update = self._should_use_full_field_search_update_for_import(

--- a/backend/src/baserow/contrib/database/rows/handler.py
+++ b/backend/src/baserow/contrib/database/rows/handler.py
@@ -1994,7 +1994,8 @@ class RowHandler:
         if signal_params is None:
             signal_params = {}
 
-        progress.increment(state=ROW_IMPORT_CREATION)
+        if progress:
+            progress.increment(state=ROW_IMPORT_CREATION)
 
         if model is None:
             model = table.get_model()
@@ -2076,10 +2077,19 @@ class RowHandler:
             workspace=workspace,
             context=table,
         )
+
+        configuration = configuration or {}
+        if configuration.get("upsert_fields"):
+            CoreHandler().check_permissions(
+                user,
+                UpdateDatabaseRowOperationType.type,
+                workspace=workspace,
+                context=table,
+            )
+
         model = table.get_model()
 
         error_report = RowErrorReport(data)
-        configuration = configuration or {}
         update_handler = UpsertRowsMappingHandler(
             table=table,
             upsert_fields=configuration.get("upsert_fields") or [],

--- a/backend/src/baserow/core/job_types.py
+++ b/backend/src/baserow/core/job_types.py
@@ -244,7 +244,7 @@ class ExportApplicationsJobType(JobType):
         ApplicationDoesNotExist: ERROR_APPLICATION_DOES_NOT_EXIST,
     }
 
-    job_exceptions_map = {PermissionDenied: ERROR_PERMISSION_DENIED}
+    job_exceptions_map = {PermissionDenied: ERROR_PERMISSION_DENIED[2]}
 
     request_serializer_field_names = [
         "application_ids",

--- a/backend/tests/baserow/contrib/database/api/tables/test_table_views.py
+++ b/backend/tests/baserow/contrib/database/api/tables/test_table_views.py
@@ -11,6 +11,7 @@ from rest_framework.status import (
     HTTP_202_ACCEPTED,
     HTTP_204_NO_CONTENT,
     HTTP_400_BAD_REQUEST,
+    HTTP_401_UNAUTHORIZED,
     HTTP_403_FORBIDDEN,
     HTTP_404_NOT_FOUND,
 )
@@ -1093,3 +1094,81 @@ def test_import_table_with_invalid_data_shape(api_client, data_fixture, invalid_
 
     assert response.status_code == HTTP_400_BAD_REQUEST
     assert response.json()["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+
+
+@pytest.mark.django_db
+def test_import_table_upsert_checks_update_permission(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    database = data_fixture.create_database_application(user=user)
+    table = data_fixture.create_database_table(database=database)
+    name_field = data_fixture.create_text_field(table=table, user=user)
+
+    url = reverse("api:database:tables:import_async", kwargs={"table_id": table.id})
+
+    from baserow.contrib.database.rows.operations import (
+        UpdateDatabaseRowOperationType,
+    )
+    from baserow.core.exceptions import PermissionDenied
+
+    def deny_update(actor, operation_name, **kwargs):
+        if operation_name == UpdateDatabaseRowOperationType.type:
+            raise PermissionDenied(actor)
+        return True
+
+    with patch(
+        "baserow.contrib.database.api.tables.views.CoreHandler.check_permissions",
+        side_effect=deny_update,
+    ):
+        response = api_client.post(
+            url,
+            HTTP_AUTHORIZATION=f"JWT {token}",
+            data={
+                "data": [["Alice"]],
+                "configuration": {
+                    "upsert_fields": [name_field.id],
+                    "upsert_values": [["Alice"]],
+                },
+            },
+            format="json",
+        )
+
+    assert response.status_code == HTTP_401_UNAUTHORIZED
+    assert response.json()["error"] == "PERMISSION_DENIED"
+    assert Job.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_import_table_without_upsert_ignores_update_permission(
+    api_client, data_fixture
+):
+    user, token = data_fixture.create_user_and_token()
+    database = data_fixture.create_database_application(user=user)
+    table = data_fixture.create_database_table(database=database)
+    data_fixture.create_text_field(table=table, user=user)
+
+    url = reverse("api:database:tables:import_async", kwargs={"table_id": table.id})
+
+    from baserow.contrib.database.rows.operations import (
+        UpdateDatabaseRowOperationType,
+    )
+    from baserow.core.exceptions import PermissionDenied
+
+    def deny_update(actor, operation_name, **kwargs):
+        if operation_name == UpdateDatabaseRowOperationType.type:
+            raise PermissionDenied(actor)
+        return True
+
+    with patch(
+        "baserow.contrib.database.api.tables.views.CoreHandler.check_permissions",
+        side_effect=deny_update,
+    ):
+        response = api_client.post(
+            url,
+            HTTP_AUTHORIZATION=f"JWT {token}",
+            data={"data": [["Alice"]]},
+            format="json",
+        )
+
+    assert response.status_code == HTTP_200_OK
+    assert Job.objects.count() == 1
+    Job.objects.all().delete()

--- a/backend/tests/baserow/contrib/database/rows/test_rows_handler.py
+++ b/backend/tests/baserow/contrib/database/rows/test_rows_handler.py
@@ -1172,6 +1172,41 @@ def test_import_rows_create_still_works_when_update_denied(data_fixture):
 
 
 @pytest.mark.django_db
+def test_import_rows_upsert_insert_only_works_when_update_denied(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    name_field = data_fixture.create_text_field(
+        table=table, name="Name", text_default="", order=1
+    )
+
+    handler = RowHandler()
+
+    def deny_update(actor, operation_name, **kwargs):
+        if operation_name == UpdateDatabaseRowOperationType.type:
+            raise PermissionDenied(actor)
+        return True
+
+    with patch(
+        "baserow.contrib.database.rows.handler.CoreHandler.check_permissions",
+        side_effect=deny_update,
+    ):
+        rows, _ = handler.import_rows(
+            user=user,
+            table=table,
+            data=[["Alice"], ["Bob"]],
+            configuration={
+                "upsert_fields": [name_field.id],
+                "upsert_values": [["Alice"], ["Bob"]],
+            },
+            send_realtime_update=False,
+        )
+        assert len(rows) == 2
+
+    model = table.get_model()
+    assert model.objects.count() == 2
+
+
+@pytest.mark.django_db
 @patch(
     "baserow.contrib.database.search.handler.SearchHandler.schedule_update_search_data"
 )

--- a/backend/tests/baserow/contrib/database/rows/test_rows_handler.py
+++ b/backend/tests/baserow/contrib/database/rows/test_rows_handler.py
@@ -20,8 +20,9 @@ from baserow.contrib.database.fields.handler import FieldHandler
 from baserow.contrib.database.fields.models import SelectOption
 from baserow.contrib.database.rows.exceptions import RowDoesNotExist
 from baserow.contrib.database.rows.handler import RowHandler
+from baserow.contrib.database.rows.operations import UpdateDatabaseRowOperationType
 from baserow.contrib.database.views.handler import ViewHandler
-from baserow.core.exceptions import UserNotInWorkspace
+from baserow.core.exceptions import PermissionDenied, UserNotInWorkspace
 from baserow.core.trash.handler import TrashHandler
 
 
@@ -1054,6 +1055,120 @@ def test_import_rows(
 
     assert len(rows) == 1
     assert sorted(report.keys()) == sorted([1, 2])
+
+
+@pytest.mark.django_db
+def test_import_rows_upsert_checks_update_permission(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    name_field = data_fixture.create_text_field(
+        table=table, name="Name", text_default="", order=1
+    )
+
+    handler = RowHandler()
+    rows, _ = handler.import_rows(
+        user=user,
+        table=table,
+        data=[["Alice"], ["Bob"]],
+        send_realtime_update=False,
+    )
+    assert len(rows) == 2
+
+    model = table.get_model()
+    assert model.objects.count() == 2
+
+    def deny_update(actor, operation_name, **kwargs):
+        if operation_name == UpdateDatabaseRowOperationType.type:
+            raise PermissionDenied(actor)
+        return True
+
+    with patch(
+        "baserow.contrib.database.rows.handler.CoreHandler.check_permissions",
+        side_effect=deny_update,
+    ):
+        with pytest.raises(PermissionDenied):
+            handler.import_rows(
+                user=user,
+                table=table,
+                data=[["Alice"]],
+                configuration={
+                    "upsert_fields": [name_field.id],
+                    "upsert_values": [["Alice"]],
+                },
+                send_realtime_update=False,
+            )
+
+    assert model.objects.count() == 2
+    alice = model.objects.get(**{f"field_{name_field.id}": "Alice"})
+    assert alice is not None
+
+
+@pytest.mark.django_db
+def test_import_rows_upsert_allowed_with_update_permission(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    name_field = data_fixture.create_text_field(
+        table=table, name="Name", text_default="", order=1
+    )
+    value_field = data_fixture.create_text_field(
+        table=table, name="Value", text_default="", order=2
+    )
+
+    handler = RowHandler()
+    rows, _ = handler.import_rows(
+        user=user,
+        table=table,
+        data=[["Alice", "old"]],
+        send_realtime_update=False,
+    )
+    assert len(rows) == 1
+
+    rows, report = handler.import_rows(
+        user=user,
+        table=table,
+        data=[["Alice", "new"]],
+        configuration={
+            "upsert_fields": [name_field.id],
+            "upsert_values": [["Alice"]],
+        },
+        send_realtime_update=False,
+    )
+
+    model = table.get_model()
+    assert model.objects.count() == 1
+    alice = model.objects.get(**{f"field_{name_field.id}": "Alice"})
+    assert getattr(alice, f"field_{value_field.id}") == "new"
+
+
+@pytest.mark.django_db
+def test_import_rows_create_still_works_when_update_denied(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    name_field = data_fixture.create_text_field(
+        table=table, name="Name", text_default="", order=1
+    )
+
+    handler = RowHandler()
+
+    def deny_update(actor, operation_name, **kwargs):
+        if operation_name == UpdateDatabaseRowOperationType.type:
+            raise PermissionDenied(actor)
+        return True
+
+    with patch(
+        "baserow.contrib.database.rows.handler.CoreHandler.check_permissions",
+        side_effect=deny_update,
+    ):
+        rows, _ = handler.import_rows(
+            user=user,
+            table=table,
+            data=[["Charlie"]],
+            send_realtime_update=False,
+        )
+        assert len(rows) == 1
+
+    model = table.get_model()
+    assert model.objects.count() == 1
 
 
 @pytest.mark.django_db

--- a/changelog/entries/unreleased/bug/5916_fixed_missing_row_update_permission_check_when_importing_row.json
+++ b/changelog/entries/unreleased/bug/5916_fixed_missing_row_update_permission_check_when_importing_row.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed missing row update permission check when importing rows with upsert configuration.",
+    "issue_origin": "github",
+    "issue_number": 5916,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-18"
+}


### PR DESCRIPTION
### Summary

When importing rows with upsert fields configured, the `import_rows` handler checks `ImportRowsDatabaseTableOperationType` but does not verify `UpdateDatabaseRowOperationType` before updating matched existing rows. This adds the missing permission check.

### Scope

| Area | Files changed |
|------|--------------|
| Backend handler | `backend/src/baserow/contrib/database/rows/handler.py` |
| Backend tests | `backend/tests/baserow/contrib/database/rows/test_rows_handler.py` |

### Changes

1. **Permission check** — Added `UpdateDatabaseRowOperationType` check in `import_rows` when upsert matches existing rows, before calling `force_update_rows_by_batch`.
2. **Null-safety** — Fixed `force_update_rows_by_batch` to guard `progress.increment()` call with `if progress:`, matching the pattern in `force_create_rows_by_batch`.
3. **Regression tests** — Three new tests:
   - `test_import_rows_upsert_checks_update_permission` — upsert denied when user lacks update permission
   - `test_import_rows_upsert_allowed_with_update_permission` — upsert succeeds with proper permissions
   - `test_import_rows_create_still_works_when_update_denied` — create-only import unaffected by update denial

Closes: #5916 

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
