### PR TITLE
fix: filter write-only data sync fields from workspace exports

### DIFF
--- a/backend/src/baserow/contrib/database/application_types.py
+++ b/backend/src/baserow/contrib/database/application_types.py
@@ -187,7 +187,9 @@ class DatabaseApplicationType(ApplicationType):
             if hasattr(table, "data_sync"):
                 data_sync = table.data_sync.specific
                 data_sync_type = data_sync_type_registry.get_by_model(data_sync)
-                serialized_data_sync = data_sync_type.export_serialized(data_sync)
+                serialized_data_sync = data_sync_type.export_serialized(
+                    data_sync, import_export_config
+                )
 
             if hasattr(table, "field_rules"):
                 field_rules_handler = FieldRuleHandler(table)

--- a/backend/src/baserow/contrib/database/data_sync/postgresql_data_sync_type.py
+++ b/backend/src/baserow/contrib/database/data_sync/postgresql_data_sync_type.py
@@ -134,6 +134,7 @@ class PostgreSQLDataSyncType(DataSyncType):
         "postgresql_table",
         "postgresql_sslmode",
     ]
+    sensitive_fields = ["postgresql_password"]
     request_serializer_field_names = [
         "postgresql_host",
         "postgresql_username",

--- a/backend/src/baserow/contrib/database/data_sync/registries.py
+++ b/backend/src/baserow/contrib/database/data_sync/registries.py
@@ -125,6 +125,12 @@ class DataSyncType(
     Example: {"postgresql_password": ["postgresql_host", "postgresql_port"]}
     """
 
+    sensitive_fields: List[str] = []
+    """
+    Fields that contain secrets (passwords, tokens, API keys) and must be excluded
+    from workspace exports.
+    """
+
     def prepare_values(self, user: AbstractUser, values: Dict) -> Dict:
         """
         A hook that can validate or changes the provided values.
@@ -242,15 +248,27 @@ class DataSyncType(
             "A two-way data sync must implement the `delete_rows` method."
         )
 
-    def export_serialized(self, instance: "DataSync"):
+    def export_serialized(
+        self,
+        instance: "DataSync",
+        import_export_config: Optional[ImportExportConfig] = None,
+    ):
         """
         Exports the data sync properties and the `allowed_fields` to the serialized
         format.
         """
 
+        exclude_sensitive = getattr(
+            import_export_config, "exclude_sensitive_data", True
+        )
+
         properties = instance.synced_properties.filter(field__trashed=False)
         type_specific = {
-            field: getattr(instance, field)
+            field: (
+                None
+                if exclude_sensitive and field in self.sensitive_fields
+                else getattr(instance, field)
+            )
             for field in BASE_DATA_SYNC_ALLOWED_FIELDS + self.allowed_fields
         }
         last_sync_iso = instance.last_sync.isoformat() if instance.last_sync else None
@@ -286,11 +304,14 @@ class DataSyncType(
         original_id = serialized_copy.pop("id")
         properties = serialized_copy.pop("properties", [])
         serialized_copy.pop("type")
-        type_properties = {
-            field: serialized_copy.get(field)
-            for field in BASE_DATA_SYNC_ALLOWED_FIELDS + self.allowed_fields
-            if field in serialized_copy
-        }
+        type_properties = {}
+        for field in BASE_DATA_SYNC_ALLOWED_FIELDS + self.allowed_fields:
+            if field not in serialized_copy:
+                continue
+            value = serialized_copy.get(field)
+            if value is None and field in self.sensitive_fields:
+                value = ""
+            type_properties[field] = value
         data_sync = self.model_class.objects.create(
             table=table,
             last_sync=serialized_copy["last_sync"],

--- a/backend/src/baserow/contrib/database/table/handler.py
+++ b/backend/src/baserow/contrib/database/table/handler.py
@@ -766,6 +766,7 @@ class TableHandler:
             include_permission_data=True,
             reduce_disk_space_usage=False,
             is_duplicate=True,
+            exclude_sensitive_data=False,
         )
 
         serialized_tables = database_type.export_tables_serialized([table], config)

--- a/backend/tests/baserow/contrib/database/data_sync/test_data_sync_export_sensitive_fields.py
+++ b/backend/tests/baserow/contrib/database/data_sync/test_data_sync_export_sensitive_fields.py
@@ -1,0 +1,126 @@
+import pytest
+
+from baserow.contrib.database.data_sync.models import PostgreSQLDataSync
+from baserow.contrib.database.data_sync.registries import data_sync_type_registry
+from baserow.core.registries import ImportExportConfig
+
+
+@pytest.mark.django_db
+def test_export_serialized_excludes_sensitive_fields(data_fixture):
+    user = data_fixture.create_user()
+    database = data_fixture.create_database_application(user=user)
+    table = data_fixture.create_database_table(database=database, user=user)
+
+    data_sync = PostgreSQLDataSync.objects.create(
+        table=table,
+        postgresql_host="db.example.com",
+        postgresql_username="admin",
+        postgresql_password="super-secret-password",
+        postgresql_port=5432,
+        postgresql_database="mydb",
+        postgresql_schema="public",
+        postgresql_table="users",
+        postgresql_sslmode="prefer",
+    )
+
+    data_sync_type = data_sync_type_registry.get("postgresql")
+    config = ImportExportConfig(include_permission_data=True)
+
+    serialized = data_sync_type.export_serialized(data_sync, config)
+
+    assert serialized["postgresql_host"] == "db.example.com"
+    assert serialized["postgresql_username"] == "admin"
+    assert serialized["postgresql_database"] == "mydb"
+    assert serialized["postgresql_password"] is None
+
+
+@pytest.mark.django_db
+def test_export_serialized_includes_sensitive_fields_when_not_excluded(data_fixture):
+    user = data_fixture.create_user()
+    database = data_fixture.create_database_application(user=user)
+    table = data_fixture.create_database_table(database=database, user=user)
+
+    data_sync = PostgreSQLDataSync.objects.create(
+        table=table,
+        postgresql_host="db.example.com",
+        postgresql_username="admin",
+        postgresql_password="super-secret-password",
+        postgresql_port=5432,
+        postgresql_database="mydb",
+        postgresql_schema="public",
+        postgresql_table="users",
+        postgresql_sslmode="prefer",
+    )
+
+    data_sync_type = data_sync_type_registry.get("postgresql")
+    config = ImportExportConfig(
+        include_permission_data=True, exclude_sensitive_data=False
+    )
+
+    serialized = data_sync_type.export_serialized(data_sync, config)
+
+    assert serialized["postgresql_password"] == "super-secret-password"
+
+
+@pytest.mark.django_db
+def test_export_serialized_without_config_excludes_sensitive_fields(data_fixture):
+    user = data_fixture.create_user()
+    database = data_fixture.create_database_application(user=user)
+    table = data_fixture.create_database_table(database=database, user=user)
+
+    data_sync = PostgreSQLDataSync.objects.create(
+        table=table,
+        postgresql_host="db.example.com",
+        postgresql_username="admin",
+        postgresql_password="super-secret-password",
+        postgresql_port=5432,
+        postgresql_database="mydb",
+        postgresql_schema="public",
+        postgresql_table="users",
+        postgresql_sslmode="prefer",
+    )
+
+    data_sync_type = data_sync_type_registry.get("postgresql")
+
+    serialized = data_sync_type.export_serialized(data_sync)
+
+    assert serialized["postgresql_password"] is None
+
+
+@pytest.mark.django_db
+def test_import_serialized_handles_null_password(data_fixture):
+    user = data_fixture.create_user()
+    database = data_fixture.create_database_application(user=user)
+    table = data_fixture.create_database_table(database=database, user=user)
+    field = data_fixture.create_text_field(table=table)
+
+    data_sync = PostgreSQLDataSync.objects.create(
+        table=table,
+        postgresql_host="db.example.com",
+        postgresql_username="admin",
+        postgresql_password="super-secret-password",
+        postgresql_port=5432,
+        postgresql_database="mydb",
+        postgresql_schema="public",
+        postgresql_table="users",
+        postgresql_sslmode="prefer",
+    )
+    data_sync.synced_properties.create(key="id", field=field)
+
+    data_sync_type = data_sync_type_registry.get("postgresql")
+    config = ImportExportConfig(include_permission_data=True)
+
+    serialized = data_sync_type.export_serialized(data_sync, config)
+    assert serialized["postgresql_password"] is None
+
+    import_table = data_fixture.create_database_table(database=database, user=user)
+    import_field = data_fixture.create_text_field(table=import_table)
+
+    id_mapping = {"database_fields": {field.id: import_field.id}}
+    imported = data_sync_type.import_serialized(
+        import_table, serialized, id_mapping, config
+    )
+
+    assert imported.postgresql_host == "db.example.com"
+    assert imported.postgresql_password == ""
+    assert imported.postgresql_username == "admin"

--- a/changelog/entries/unreleased/bug/5918_writeonly_data_sync_fields_are_excluded_from_workspace_expor.json
+++ b/changelog/entries/unreleased/bug/5918_writeonly_data_sync_fields_are_excluded_from_workspace_expor.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Write-only data sync fields are excluded from workspace exports",
+    "issue_origin": "github",
+    "issue_number": 5918,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-18"
+}

--- a/enterprise/backend/src/baserow_enterprise/data_sync/github_issues_data_sync.py
+++ b/enterprise/backend/src/baserow_enterprise/data_sync/github_issues_data_sync.py
@@ -157,6 +157,7 @@ class GitHubIssuesDataSyncType(DataSyncType):
         "github_issues_repo",
         "github_issues_api_token",
     ]
+    sensitive_fields = ["github_issues_api_token"]
     request_serializer_field_names = [
         "github_issues_owner",
         "github_issues_repo",

--- a/enterprise/backend/src/baserow_enterprise/data_sync/gitlab_issues_data_sync.py
+++ b/enterprise/backend/src/baserow_enterprise/data_sync/gitlab_issues_data_sync.py
@@ -205,6 +205,7 @@ class GitLabIssuesDataSyncType(DataSyncType):
         "gitlab_project_id",
         "gitlab_access_token",
     ]
+    sensitive_fields = ["gitlab_access_token"]
     request_serializer_field_names = [
         "gitlab_url",
         "gitlab_project_id",

--- a/enterprise/backend/src/baserow_enterprise/data_sync/hubspot_contacts_data_sync.py
+++ b/enterprise/backend/src/baserow_enterprise/data_sync/hubspot_contacts_data_sync.py
@@ -183,6 +183,7 @@ class HubspotContactsDataSyncType(DataSyncType):
     allowed_fields = [
         "hubspot_access_token",
     ]
+    sensitive_fields = ["hubspot_access_token"]
     request_serializer_field_names = [
         "hubspot_access_token",
     ]

--- a/enterprise/backend/src/baserow_enterprise/data_sync/jira_issues_data_sync.py
+++ b/enterprise/backend/src/baserow_enterprise/data_sync/jira_issues_data_sync.py
@@ -156,6 +156,7 @@ class JiraIssuesDataSyncType(DataSyncType):
         "jira_username",
         "jira_api_token",
     ]
+    sensitive_fields = ["jira_api_token"]
     request_serializer_field_names = [
         "jira_url",
         "jira_project_key",


### PR DESCRIPTION
### Summary

Workspace exports included all data sync connection fields, including those marked as write-only by the API serializer (passwords, tokens). The `DataSyncType.export_serialized()` method did not participate in the `ImportExportConfig.exclude_sensitive_data` mechanism that integration types already use.

### Scope

| File | Change |
|------|--------|
| `backend/src/baserow/contrib/database/data_sync/registries.py` | Added `sensitive_fields` attribute to `DataSyncType`; updated `export_serialized()` to accept `ImportExportConfig` and filter write-only fields; updated `import_serialized()` to handle missing values |
| `backend/src/baserow/contrib/database/application_types.py` | Pass `import_export_config` to `data_sync_type.export_serialized()` |
| `backend/src/baserow/contrib/database/data_sync/postgresql_data_sync_type.py` | Declare `sensitive_fields = ["postgresql_password"]` |
| `enterprise/.../github_issues_data_sync.py` | Declare `sensitive_fields = ["github_issues_api_token"]` |
| `enterprise/.../gitlab_issues_data_sync.py` | Declare `sensitive_fields = ["gitlab_access_token"]` |
| `enterprise/.../jira_issues_data_sync.py` | Declare `sensitive_fields = ["jira_api_token"]` |
| `enterprise/.../hubspot_contacts_data_sync.py` | Declare `sensitive_fields = ["hubspot_access_token"]` |
| `backend/tests/.../test_data_sync_export_sensitive_fields.py` | New: 4 regression tests |

### Design notes

- Follows the existing `sensitive_fields` pattern from `EasyImportExportMixin` used by integrations (Slack, SMTP, LocalBaserow)
- Default behavior is safe: `exclude_sensitive_data` defaults to `True` in `ImportExportConfig`, and calling `export_serialized()` without a config also defaults to filtering
- Snapshot and duplicate paths set `exclude_sensitive_data=False` intentionally — data stays on the same instance
- Imported data syncs with filtered fields get empty-string values and will require reconfiguration before syncing. A workspace with many data sync tables (e.g. 20) means re-entering credentials for each one after import — unavoidable tradeoff, since including write-only fields in export files breaks the write-only contract

Closes: #5918

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
