### PR TITLE
fix: Ensure AI Assistance creates valid formulas

### DIFF
--- a/backend/src/baserow/contrib/automation/formula_importer.py
+++ b/backend/src/baserow/contrib/automation/formula_importer.py
@@ -4,9 +4,10 @@ from typing import Dict, Union
 from baserow.contrib.automation.data_providers.registries import (
     automation_data_provider_type_registry,
 )
+from baserow.core.exceptions import InstanceTypeDoesNotExist
 from baserow.core.formula import (
+    BaserowFormulaException,
     BaserowFormulaObject,
-    BaserowFormulaSyntaxError,
     get_parse_tree_for_formula,
 )
 from baserow.core.formula.types import BASEROW_FORMULA_MODE_RAW
@@ -48,12 +49,20 @@ def import_formula(
     try:
         tree = get_parse_tree_for_formula(formula["formula"])
         new_formula = AutomationFormulaImporter(id_mapping, **kwargs).visit(tree)
-    except BaserowFormulaSyntaxError:
-        # The formula can't be parsed, so there is nothing to migrate. It was
-        # already invalid before the import, and failing here would make the
-        # whole automation impossible to duplicate, export or import.
+    except (
+        BaserowFormulaException,
+        RecursionError,
+        InstanceTypeDoesNotExist,
+        ValueError,
+    ) as exc:
+        # The formula can't be parsed, references an unknown data provider, or
+        # contains a bogus path, so there is nothing to migrate. It was already
+        # invalid before the import, and failing here would make the whole
+        # automation impossible to duplicate, export or import.
         logger.warning(
-            "Skipping the import of an unparsable formula: %s", formula["formula"]
+            "Skipping the import of an invalid formula %r: %s",
+            formula["formula"],
+            exc,
         )
         return formula
 

--- a/backend/src/baserow/contrib/automation/formula_importer.py
+++ b/backend/src/baserow/contrib/automation/formula_importer.py
@@ -1,11 +1,18 @@
+import logging
 from typing import Dict, Union
 
 from baserow.contrib.automation.data_providers.registries import (
     automation_data_provider_type_registry,
 )
-from baserow.core.formula import BaserowFormulaObject, get_parse_tree_for_formula
+from baserow.core.formula import (
+    BaserowFormulaObject,
+    BaserowFormulaSyntaxError,
+    get_parse_tree_for_formula,
+)
 from baserow.core.formula.types import BASEROW_FORMULA_MODE_RAW
 from baserow.core.services.formula_importer import BaserowFormulaImporter
+
+logger = logging.getLogger(__name__)
 
 
 class AutomationFormulaImporter(BaserowFormulaImporter):
@@ -38,8 +45,17 @@ def import_formula(
     if formula["mode"] == BASEROW_FORMULA_MODE_RAW or not formula["formula"]:
         return formula
 
-    tree = get_parse_tree_for_formula(formula["formula"])
-    new_formula = AutomationFormulaImporter(id_mapping, **kwargs).visit(tree)
+    try:
+        tree = get_parse_tree_for_formula(formula["formula"])
+        new_formula = AutomationFormulaImporter(id_mapping, **kwargs).visit(tree)
+    except BaserowFormulaSyntaxError:
+        # The formula can't be parsed, so there is nothing to migrate. It was
+        # already invalid before the import, and failing here would make the
+        # whole automation impossible to duplicate, export or import.
+        logger.warning(
+            "Skipping the import of an unparsable formula: %s", formula["formula"]
+        )
+        return formula
 
     if new_formula != formula["formula"]:
         # We create a new instance to show it's a different formula

--- a/backend/src/baserow/contrib/builder/formula_importer.py
+++ b/backend/src/baserow/contrib/builder/formula_importer.py
@@ -4,9 +4,10 @@ from typing import Dict, Union
 from baserow.contrib.builder.data_providers.registries import (
     builder_data_provider_type_registry,
 )
+from baserow.core.exceptions import InstanceTypeDoesNotExist
 from baserow.core.formula import (
+    BaserowFormulaException,
     BaserowFormulaObject,
-    BaserowFormulaSyntaxError,
     get_parse_tree_for_formula,
 )
 from baserow.core.formula.types import BASEROW_FORMULA_MODE_RAW
@@ -61,12 +62,20 @@ def import_formula(
     try:
         tree = get_parse_tree_for_formula(formula["formula"])
         new_formula = BuilderFormulaImporter(id_mapping, **kwargs).visit(tree)
-    except BaserowFormulaSyntaxError:
-        # The formula can't be parsed, so there is nothing to migrate. It was
-        # already invalid before the import, and failing here would make the
-        # whole application impossible to duplicate, export or import.
+    except (
+        BaserowFormulaException,
+        RecursionError,
+        InstanceTypeDoesNotExist,
+        ValueError,
+    ) as exc:
+        # The formula can't be parsed, references an unknown data provider, or
+        # contains a bogus path, so there is nothing to migrate. It was already
+        # invalid before the import, and failing here would make the whole
+        # application impossible to duplicate, export or import.
         logger.warning(
-            "Skipping the import of an unparsable formula: %s", formula["formula"]
+            "Skipping the import of an invalid formula %r: %s",
+            formula["formula"],
+            exc,
         )
         return formula
 

--- a/backend/src/baserow/contrib/builder/formula_importer.py
+++ b/backend/src/baserow/contrib/builder/formula_importer.py
@@ -1,11 +1,18 @@
+import logging
 from typing import Dict, Union
 
 from baserow.contrib.builder.data_providers.registries import (
     builder_data_provider_type_registry,
 )
-from baserow.core.formula import BaserowFormulaObject, get_parse_tree_for_formula
+from baserow.core.formula import (
+    BaserowFormulaObject,
+    BaserowFormulaSyntaxError,
+    get_parse_tree_for_formula,
+)
 from baserow.core.formula.types import BASEROW_FORMULA_MODE_RAW
 from baserow.core.services.formula_importer import BaserowFormulaImporter
+
+logger = logging.getLogger(__name__)
 
 
 class BuilderFormulaImporter(BaserowFormulaImporter):
@@ -51,8 +58,17 @@ def import_formula(
     if formula["mode"] == BASEROW_FORMULA_MODE_RAW or not formula["formula"]:
         return formula
 
-    tree = get_parse_tree_for_formula(formula["formula"])
-    new_formula = BuilderFormulaImporter(id_mapping, **kwargs).visit(tree)
+    try:
+        tree = get_parse_tree_for_formula(formula["formula"])
+        new_formula = BuilderFormulaImporter(id_mapping, **kwargs).visit(tree)
+    except BaserowFormulaSyntaxError:
+        # The formula can't be parsed, so there is nothing to migrate. It was
+        # already invalid before the import, and failing here would make the
+        # whole application impossible to duplicate, export or import.
+        logger.warning(
+            "Skipping the import of an unparsable formula: %s", formula["formula"]
+        )
+        return formula
 
     if new_formula != formula["formula"]:
         # We create a new instance to show it's a different formula

--- a/backend/tests/baserow/contrib/automation/test_formula_importer.py
+++ b/backend/tests/baserow/contrib/automation/test_formula_importer.py
@@ -1,0 +1,68 @@
+from collections import defaultdict
+from typing import List
+
+import pytest
+
+from baserow.contrib.automation.formula_importer import import_formula
+from baserow.core.formula import BaserowFormulaObject
+from baserow.core.formula.registries import DataProviderType
+from baserow.core.formula.runtime_formula_context import RuntimeFormulaContext
+from baserow.core.utils import MirrorDict
+
+
+class TestDataProviderType(DataProviderType):
+    type = "test_provider"
+
+    def get_data_chunk(
+        self, runtime_formula_context: RuntimeFormulaContext, path: List[str]
+    ):
+        return super().get_data_chunk(runtime_formula_context, path)
+
+    def import_path(self, path, id_mapping):
+        path[0] = str(id_mapping["node"][int(path[0])])
+        return path
+
+
+@pytest.fixture()
+def mutable_automation_data_provider_registry():
+    from baserow.contrib.automation.data_providers.registries import (
+        automation_data_provider_type_registry,
+    )
+
+    before = automation_data_provider_type_registry.registry.copy()
+    yield automation_data_provider_type_registry
+    automation_data_provider_type_registry.registry = before
+
+
+@pytest.mark.django_db
+def test_formula_import_updates_the_path(mutable_automation_data_provider_registry):
+    mutable_automation_data_provider_registry.register(TestDataProviderType())
+
+    id_mapping = defaultdict(lambda: MirrorDict())
+    id_mapping["node"] = {1: 42}
+
+    result = import_formula(
+        BaserowFormulaObject.create("get('test_provider.1.field_10')"), id_mapping
+    )
+
+    assert result["formula"] == "get('test_provider.42.field_10')"
+
+
+@pytest.mark.django_db
+def test_formula_import_ignores_unparsable_formula(
+    mutable_automation_data_provider_registry,
+):
+    """
+    An invalid formula can be persisted by code paths that bypass the API
+    serializers. It must not make the whole automation impossible to
+    duplicate, export or import.
+    """
+
+    mutable_automation_data_provider_registry.register(TestDataProviderType())
+
+    id_mapping = defaultdict(lambda: MirrorDict())
+    invalid = "'Hello' World'"
+
+    result = import_formula(BaserowFormulaObject.create(invalid), id_mapping)
+
+    assert result["formula"] == invalid

--- a/backend/tests/baserow/contrib/automation/test_formula_importer.py
+++ b/backend/tests/baserow/contrib/automation/test_formula_importer.py
@@ -66,3 +66,34 @@ def test_formula_import_ignores_unparsable_formula(
     result = import_formula(BaserowFormulaObject.create(invalid), id_mapping)
 
     assert result["formula"] == invalid
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "invalid_formula",
+    [
+        pytest.param("get('unknown_provider.x')", id="InstanceTypeDoesNotExist"),
+        pytest.param(
+            "get('test_provider.abc.field_10')", id="ValueError-non-numeric-id"
+        ),
+        pytest.param("get('')", id="ValueError-empty-path"),
+        pytest.param("field_by_id(1)", id="FieldByIdReferencesAreDeprecated"),
+        pytest.param("(" * 5000 + "1" + ")" * 5000, id="RecursionError"),
+    ],
+)
+def test_formula_import_ignores_parseable_but_invalid_formula(
+    invalid_formula, mutable_automation_data_provider_registry
+):
+    """
+    A formula that parses but references an unknown data provider, a bogus
+    path, or deprecated syntax must not make the whole automation impossible
+    to duplicate, export or import either.
+    """
+
+    mutable_automation_data_provider_registry.register(TestDataProviderType())
+
+    id_mapping = defaultdict(lambda: MirrorDict())
+
+    result = import_formula(BaserowFormulaObject.create(invalid_formula), id_mapping)
+
+    assert result["formula"] == invalid_formula

--- a/backend/tests/baserow/contrib/builder/test_formula_importer.py
+++ b/backend/tests/baserow/contrib/builder/test_formula_importer.py
@@ -108,3 +108,32 @@ def test_formula_import_ignores_unparsable_formula(
     result = import_formula(BaserowFormulaObject.create(invalid), id_mapping)
 
     assert result["formula"] == invalid
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "invalid_formula",
+    [
+        pytest.param("get('unknown_provider.x')", id="InstanceTypeDoesNotExist"),
+        pytest.param("get('test_provider.abc.10')", id="ValueError-non-numeric-id"),
+        pytest.param("get('')", id="ValueError-empty-path"),
+        pytest.param("field_by_id(1)", id="FieldByIdReferencesAreDeprecated"),
+        pytest.param("(" * 5000 + "1" + ")" * 5000, id="RecursionError"),
+    ],
+)
+def test_formula_import_ignores_parseable_but_invalid_formula(
+    invalid_formula, mutable_builder_data_provider_registry
+):
+    """
+    A formula that parses but references an unknown data provider, a bogus
+    path, or deprecated syntax must not make the whole application impossible
+    to duplicate, export or import either.
+    """
+
+    mutable_builder_data_provider_registry.register(TestDataProviderTypeWithImport())
+
+    id_mapping = defaultdict(lambda: MirrorDict())
+
+    result = import_formula(BaserowFormulaObject.create(invalid_formula), id_mapping)
+
+    assert result["formula"] == invalid_formula

--- a/backend/tests/baserow/contrib/builder/test_formula_importer.py
+++ b/backend/tests/baserow/contrib/builder/test_formula_importer.py
@@ -88,3 +88,23 @@ def test_formula_import_formula_with_import(
     result = import_formula(BaserowFormulaObject.create(formula["input"]), id_mapping)
 
     assert result["formula"] == formula.get("output2", formula["output"])
+
+
+@pytest.mark.django_db
+def test_formula_import_ignores_unparsable_formula(
+    mutable_builder_data_provider_registry,
+):
+    """
+    An invalid formula can be persisted by code paths that bypass the API
+    serializers. It must not make the whole application impossible to
+    duplicate, export or import.
+    """
+
+    mutable_builder_data_provider_registry.register(TestDataProviderType())
+
+    id_mapping = defaultdict(lambda: MirrorDict())
+    invalid = "'Hello' World'"
+
+    result = import_formula(BaserowFormulaObject.create(invalid), id_mapping)
+
+    assert result["formula"] == invalid

--- a/changelog/entries/unreleased/bug/fixes_the_ai_assistant_storing_broken_formulas_that_broke_du.json
+++ b/changelog/entries/unreleased/bug/fixes_the_ai_assistant_storing_broken_formulas_that_broke_du.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixes the AI assistant storing broken formulas that broke duplicating and exporting.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-08-18"
+}

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/automation/types/node.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/automation/types/node.py
@@ -14,17 +14,17 @@ from django.conf import settings
 from pydantic import Field, PrivateAttr, model_serializer, model_validator
 
 from baserow.contrib.automation.nodes.models import AutomationNode
-from baserow.core.formula.types import (
-    BASEROW_FORMULA_MODE_ADVANCED,
-    BaserowFormulaObject,
-)
+from baserow.core.formula.types import BASEROW_FORMULA_MODE_ADVANCED
 from baserow.core.services.handler import ServiceHandler
 from baserow.core.services.models import Service
 from baserow_enterprise.assistant.tools.shared.formula_utils import (
     FORMULA_PREFIX,
+    ensure_valid_formula,
     formula_desc,
+    formula_object,
     literal_or_placeholder,
     needs_formula,
+    wrap_static_string,
 )
 from baserow_enterprise.assistant.types import BaseModel
 
@@ -57,6 +57,7 @@ def _upsert_field_mappings(
     to_create, to_update = [], []
 
     for field_id, (formula, enabled) in values.items():
+        formula = ensure_valid_formula(formula)
         if field_id in existing:
             mapping = existing[field_id]
             mapping.value = formula
@@ -532,7 +533,7 @@ def _default_update_formulas(service: Service, formulas: dict[str, str]):
     save = False
     for field_name, formula in formulas.items():
         if hasattr(service, field_name):
-            setattr(service, field_name, BaserowFormulaObject.create(formula=formula))
+            setattr(service, field_name, formula_object(formula=formula))
             save = True
     if save:
         ServiceHandler().update_service(service.get_type(), service)
@@ -569,7 +570,7 @@ def _row_action_update_formulas(
     )
 
     if row_id_formula:
-        service.row_id = row_id_formula
+        service.row_id = ensure_valid_formula(row_id_formula)
         ServiceHandler().update_service(service.get_type(), service)
 
 
@@ -592,14 +593,14 @@ def _row_action_apply_direct(n: ActionNodeCreate, service: Service):
     _upsert_field_mappings(
         service,
         {
-            fv.field_id: (f"'{fv.value}'", True)
+            fv.field_id: (wrap_static_string(fv.value), True)
             for fv in (n.values or [])
             if not needs_formula(fv.value)
         },
     )
 
     if n.row_id and not needs_formula(n.row_id):
-        service.row_id = f"'{n.row_id}'"
+        service.row_id = wrap_static_string(n.row_id)
         ServiceHandler().update_service(service.get_type(), service)
 
 
@@ -836,13 +837,13 @@ def _row_action_update_apply_direct(n: "NodeUpdate", service: Service):
     _upsert_field_mappings(
         service,
         {
-            fv.field_id: (f"'{fv.value}'", True)
+            fv.field_id: (wrap_static_string(fv.value), True)
             for fv in (n.values or [])
             if not needs_formula(fv.value)
         },
     )
     if n.row_id and not needs_formula(n.row_id):
-        service.row_id = f"'{n.row_id}'"
+        service.row_id = wrap_static_string(n.row_id)
         ServiceHandler().update_service(service.get_type(), service)
 
 

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/automation/types/node.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/automation/types/node.py
@@ -551,7 +551,7 @@ def _router_update_formulas(
         label = orm_edge.label.lower()
         if label in formulas_lower:
             orm_edge.condition["mode"] = BASEROW_FORMULA_MODE_ADVANCED
-            orm_edge.condition["formula"] = formulas_lower[label]
+            orm_edge.condition["formula"] = ensure_valid_formula(formulas_lower[label])
             updates.append(orm_edge)
     if updates:
         EdgeModel.objects.bulk_update(updates, ["condition"])

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/builder/agents.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/builder/agents.py
@@ -22,14 +22,12 @@ from baserow.contrib.builder.elements.mixins import CollectionElementTypeMixin
 from baserow.contrib.builder.elements.registries import element_type_registry
 from baserow.contrib.builder.pages.models import Page
 from baserow.contrib.builder.workflow_actions.signals import workflow_action_updated
-from baserow.core.formula.types import (
-    BASEROW_FORMULA_MODE_ADVANCED,
-    BaserowFormulaObject,
-)
+from baserow.core.formula.types import BASEROW_FORMULA_MODE_ADVANCED
 from baserow.core.utils import to_path
 from baserow_enterprise.assistant.tools.shared.agents import get_formula_generator
 from baserow_enterprise.assistant.tools.shared.formula_utils import (
     create_example_from_json_schema,
+    formula_object,
     minimize_json_schema,
 )
 
@@ -502,11 +500,11 @@ def update_single_data_source_formulas(
             if generated:
                 service_kwargs: dict[str, Any] = {}
                 if "row_id" in generated:
-                    service_kwargs["row_id"] = BaserowFormulaObject.create(
+                    service_kwargs["row_id"] = formula_object(
                         generated["row_id"], mode=BASEROW_FORMULA_MODE_ADVANCED
                     )
                 if "search_query" in generated:
-                    service_kwargs["search_query"] = BaserowFormulaObject.create(
+                    service_kwargs["search_query"] = formula_object(
                         generated["search_query"],
                         mode=BASEROW_FORMULA_MODE_ADVANCED,
                     )
@@ -585,7 +583,7 @@ def update_single_element_formulas(
                             if "." not in field_name and hasattr(
                                 orm_element, field_name
                             ):
-                                kwargs[field_name] = BaserowFormulaObject.create(
+                                kwargs[field_name] = formula_object(
                                     formula,
                                     mode=BASEROW_FORMULA_MODE_ADVANCED,
                                 )

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/builder/helpers.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/builder/helpers.py
@@ -763,10 +763,8 @@ def add_field_mapping_to_action(
     from baserow.contrib.integrations.local_baserow.models import (
         LocalBaserowTableServiceFieldMapping,
     )
-    from baserow.core.formula.types import (
-        BASEROW_FORMULA_MODE_ADVANCED,
-        BaserowFormulaObject,
-    )
+    from baserow.core.formula.types import BASEROW_FORMULA_MODE_ADVANCED
+    from baserow_enterprise.assistant.tools.shared.formula_utils import formula_object
 
     action = BuilderWorkflowActionService().get_workflow_action(user, action_id)
     action_type = action.get_type().type
@@ -784,7 +782,7 @@ def add_field_mapping_to_action(
     ).first()
 
     if existing:
-        existing.value = BaserowFormulaObject.create(
+        existing.value = formula_object(
             value_formula, mode=BASEROW_FORMULA_MODE_ADVANCED
         )
         existing.enabled = True
@@ -794,9 +792,7 @@ def add_field_mapping_to_action(
         LocalBaserowTableServiceFieldMapping.objects.create(
             service=service,
             field_id=field_id,
-            value=BaserowFormulaObject.create(
-                value_formula, mode=BASEROW_FORMULA_MODE_ADVANCED
-            ),
+            value=formula_object(value_formula, mode=BASEROW_FORMULA_MODE_ADVANCED),
             enabled=True,
         )
         status = "created"

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/builder/types/data_source.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/builder/types/data_source.py
@@ -9,12 +9,10 @@ from typing import TYPE_CHECKING, Any, Callable, Literal
 
 from pydantic import Field, PrivateAttr, model_serializer, model_validator
 
-from baserow.core.formula.types import (
-    BASEROW_FORMULA_MODE_ADVANCED,
-    BaserowFormulaObject,
-)
+from baserow.core.formula.types import BASEROW_FORMULA_MODE_ADVANCED
 from baserow_enterprise.assistant.tools.shared.formula_utils import (
     formula_desc,
+    formula_object,
     literal_or_placeholder,
     needs_formula,
 )
@@ -145,13 +143,13 @@ class DataSourceCreate(BaseModel):
         kwargs: dict[str, Any] = {"table": table}
 
         if self.type == "get_row" and self.row_id is not None:
-            kwargs["row_id"] = BaserowFormulaObject.create(
+            kwargs["row_id"] = formula_object(
                 literal_or_placeholder(self.row_id),
                 mode=BASEROW_FORMULA_MODE_ADVANCED,
             )
 
         if self.type == "list_rows" and self.search_query:
-            kwargs["search_query"] = BaserowFormulaObject.create(
+            kwargs["search_query"] = formula_object(
                 literal_or_placeholder(self.search_query),
                 mode=BASEROW_FORMULA_MODE_ADVANCED,
             )
@@ -212,12 +210,12 @@ class DataSourceCreate(BaseModel):
         service_kwargs: dict[str, Any] = {}
 
         if "row_id" in formulas:
-            service_kwargs["row_id"] = BaserowFormulaObject.create(
+            service_kwargs["row_id"] = formula_object(
                 formulas["row_id"], mode=BASEROW_FORMULA_MODE_ADVANCED
             )
 
         if "search_query" in formulas:
-            service_kwargs["search_query"] = BaserowFormulaObject.create(
+            service_kwargs["search_query"] = formula_object(
                 formulas["search_query"], mode=BASEROW_FORMULA_MODE_ADVANCED
             )
 
@@ -287,13 +285,13 @@ class DataSourceUpdate(BaseModel):
             kwargs["table"] = table
 
         if self.row_id is not None:
-            kwargs["row_id"] = BaserowFormulaObject.create(
+            kwargs["row_id"] = formula_object(
                 literal_or_placeholder(self.row_id),
                 mode=BASEROW_FORMULA_MODE_ADVANCED,
             )
 
         if self.search_query is not None:
-            kwargs["search_query"] = BaserowFormulaObject.create(
+            kwargs["search_query"] = formula_object(
                 literal_or_placeholder(self.search_query),
                 mode=BASEROW_FORMULA_MODE_ADVANCED,
             )

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/builder/types/element.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/builder/types/element.py
@@ -24,13 +24,11 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import Field, model_validator
 
-from baserow.core.formula.types import (
-    BASEROW_FORMULA_MODE_ADVANCED,
-    BaserowFormulaObject,
-)
+from baserow.core.formula.types import BASEROW_FORMULA_MODE_ADVANCED
 from baserow.core.graph.types import GraphPointPosition
 from baserow_enterprise.assistant.tools.shared.formula_utils import (
     formula_desc,
+    formula_object,
     literal_or_placeholder,
     needs_formula,
     wrap_static_string,
@@ -146,7 +144,7 @@ class TableFieldConfig(BaseModel):
 
 def _heading_orm(el: "ElementItemCreate", user, page) -> dict:
     return {
-        "value": BaserowFormulaObject.create(
+        "value": formula_object(
             literal_or_placeholder(el.value)
             if needs_formula(el.value)
             else wrap_static_string(el.value or ""),
@@ -158,7 +156,7 @@ def _heading_orm(el: "ElementItemCreate", user, page) -> dict:
 
 def _text_orm(el: "ElementItemCreate", user, page) -> dict:
     return {
-        "value": BaserowFormulaObject.create(
+        "value": formula_object(
             literal_or_placeholder(el.value)
             if needs_formula(el.value)
             else wrap_static_string(el.value or ""),
@@ -171,7 +169,7 @@ def _text_orm(el: "ElementItemCreate", user, page) -> dict:
 def _button_orm(el: "ElementItemCreate", user, page) -> dict:
     text = el.value or el.label or ""
     return {
-        "value": BaserowFormulaObject.create(
+        "value": formula_object(
             literal_or_placeholder(text)
             if needs_formula(text)
             else wrap_static_string(text),
@@ -182,7 +180,7 @@ def _button_orm(el: "ElementItemCreate", user, page) -> dict:
 
 def _link_orm(el: "ElementItemCreate", user, page) -> dict:
     kwargs: dict[str, Any] = {
-        "value": BaserowFormulaObject.create(
+        "value": formula_object(
             literal_or_placeholder(el.value)
             if needs_formula(el.value)
             else wrap_static_string(el.value or ""),
@@ -199,14 +197,12 @@ def _link_orm(el: "ElementItemCreate", user, page) -> dict:
         kwargs["page_parameters"] = [
             {
                 "name": p.name,
-                "value": BaserowFormulaObject.create(
-                    p.value, mode=BASEROW_FORMULA_MODE_ADVANCED
-                ),
+                "value": formula_object(p.value, mode=BASEROW_FORMULA_MODE_ADVANCED),
             }
             for p in (el.link_page_parameters or [])
         ]
     elif nav == "custom" and el.navigate_to_url:
-        kwargs["navigate_to_url"] = BaserowFormulaObject.create(
+        kwargs["navigate_to_url"] = formula_object(
             literal_or_placeholder(el.navigate_to_url)
             if needs_formula(el.navigate_to_url)
             else wrap_static_string(el.navigate_to_url),
@@ -221,7 +217,7 @@ def _image_orm(el: "ElementItemCreate", user, page) -> dict:
     alt_text = el.alt_text or ""
     return {
         "image_source_type": el.image_source_type or "url",
-        "image_url": BaserowFormulaObject.create(
+        "image_url": formula_object(
             literal_or_placeholder(image_url)
             if needs_formula(image_url)
             else wrap_static_string(image_url)
@@ -229,7 +225,7 @@ def _image_orm(el: "ElementItemCreate", user, page) -> dict:
             else "''",
             mode=BASEROW_FORMULA_MODE_ADVANCED,
         ),
-        "alt_text": BaserowFormulaObject.create(
+        "alt_text": formula_object(
             literal_or_placeholder(alt_text)
             if needs_formula(alt_text)
             else wrap_static_string(alt_text)
@@ -250,8 +246,8 @@ def _column_orm(el: "ElementItemCreate", user, page) -> dict:
 
 def _form_container_orm(el: "ElementItemCreate", user, page) -> dict:
     return {
-        "submit_button_label": BaserowFormulaObject.create(
-            f"'{el.submit_button_label or 'Submit'}'",
+        "submit_button_label": formula_object(
+            wrap_static_string(el.submit_button_label or "Submit"),
             mode=BASEROW_FORMULA_MODE_ADVANCED,
         ),
         "reset_initial_values_post_submission": el.reset_initial_values_post_submission
@@ -262,13 +258,14 @@ def _form_container_orm(el: "ElementItemCreate", user, page) -> dict:
 def _input_text_orm(el: "ElementItemCreate", user, page) -> dict:
     default_value = el.default_value or ""
     return {
-        "label": BaserowFormulaObject.create(
-            f"'{el.label or ''}'", mode=BASEROW_FORMULA_MODE_ADVANCED
+        "label": formula_object(
+            wrap_static_string(el.label or ""), mode=BASEROW_FORMULA_MODE_ADVANCED
         ),
-        "placeholder": BaserowFormulaObject.create(
-            f"'{el.placeholder or ''}'", mode=BASEROW_FORMULA_MODE_ADVANCED
+        "placeholder": formula_object(
+            wrap_static_string(el.placeholder or ""),
+            mode=BASEROW_FORMULA_MODE_ADVANCED,
         ),
-        "default_value": BaserowFormulaObject.create(
+        "default_value": formula_object(
             literal_or_placeholder(default_value)
             if needs_formula(default_value)
             else (wrap_static_string(default_value) if default_value else "''"),
@@ -284,13 +281,14 @@ def _input_text_orm(el: "ElementItemCreate", user, page) -> dict:
 def _choice_orm(el: "ElementItemCreate", user, page) -> dict:
     default_value = el.default_value or ""
     return {
-        "label": BaserowFormulaObject.create(
-            f"'{el.label or ''}'", mode=BASEROW_FORMULA_MODE_ADVANCED
+        "label": formula_object(
+            wrap_static_string(el.label or ""), mode=BASEROW_FORMULA_MODE_ADVANCED
         ),
-        "placeholder": BaserowFormulaObject.create(
-            f"'{el.placeholder or ''}'", mode=BASEROW_FORMULA_MODE_ADVANCED
+        "placeholder": formula_object(
+            wrap_static_string(el.placeholder or ""),
+            mode=BASEROW_FORMULA_MODE_ADVANCED,
         ),
-        "default_value": BaserowFormulaObject.create(
+        "default_value": formula_object(
             literal_or_placeholder(default_value)
             if needs_formula(default_value)
             else (wrap_static_string(default_value) if default_value else "''"),
@@ -307,10 +305,10 @@ def _choice_orm(el: "ElementItemCreate", user, page) -> dict:
 def _checkbox_orm(el: "ElementItemCreate", user, page) -> dict:
     default_value = el.default_value or "false"
     return {
-        "label": BaserowFormulaObject.create(
-            f"'{el.label or ''}'", mode=BASEROW_FORMULA_MODE_ADVANCED
+        "label": formula_object(
+            wrap_static_string(el.label or ""), mode=BASEROW_FORMULA_MODE_ADVANCED
         ),
-        "default_value": BaserowFormulaObject.create(
+        "default_value": formula_object(
             literal_or_placeholder(default_value)
             if needs_formula(default_value)
             else default_value,
@@ -322,8 +320,8 @@ def _checkbox_orm(el: "ElementItemCreate", user, page) -> dict:
 
 def _datetime_picker_orm(el: "ElementItemCreate", user, page) -> dict:
     return {
-        "label": BaserowFormulaObject.create(
-            f"'{el.label or ''}'", mode=BASEROW_FORMULA_MODE_ADVANCED
+        "label": formula_object(
+            wrap_static_string(el.label or ""), mode=BASEROW_FORMULA_MODE_ADVANCED
         ),
         "required": el.required or False,
         "include_time": el.include_time or False,
@@ -333,14 +331,15 @@ def _datetime_picker_orm(el: "ElementItemCreate", user, page) -> dict:
 
 def _record_selector_orm(el: "ElementItemCreate", user, page) -> dict:
     return {
-        "label": BaserowFormulaObject.create(
-            f"'{el.label or ''}'", mode=BASEROW_FORMULA_MODE_ADVANCED
+        "label": formula_object(
+            wrap_static_string(el.label or ""), mode=BASEROW_FORMULA_MODE_ADVANCED
         ),
         "data_source_id": el.data_source,
         "required": el.required or False,
         "multiple": el.multiple or False,
-        "placeholder": BaserowFormulaObject.create(
-            f"'{el.placeholder or ''}'", mode=BASEROW_FORMULA_MODE_ADVANCED
+        "placeholder": formula_object(
+            wrap_static_string(el.placeholder or ""),
+            mode=BASEROW_FORMULA_MODE_ADVANCED,
         ),
     }
 
@@ -349,8 +348,8 @@ def _table_orm(el: "ElementItemCreate", user, page) -> dict:
     kwargs: dict[str, Any] = {
         "data_source_id": el.data_source,
         "items_per_page": el.items_per_page or 20,
-        "button_load_more_label": BaserowFormulaObject.create(
-            f"'{el.button_load_more_label or 'Load more'}'",
+        "button_load_more_label": formula_object(
+            wrap_static_string(el.button_load_more_label or "Load more"),
             mode=BASEROW_FORMULA_MODE_ADVANCED,
         ),
     }
@@ -668,7 +667,7 @@ def _update_simple_formulas(
         if "." in field_name:
             continue
         if hasattr(orm_element, field_name):
-            kwargs[field_name] = BaserowFormulaObject.create(
+            kwargs[field_name] = formula_object(
                 formula, mode=BASEROW_FORMULA_MODE_ADVANCED
             )
 
@@ -695,7 +694,7 @@ def _update_table_formulas(
         config_key = parts[2]
         if 0 <= index < len(collection_fields):
             cf = collection_fields[index]
-            cf.config[config_key] = BaserowFormulaObject.create(
+            cf.config[config_key] = formula_object(
                 formula, mode=BASEROW_FORMULA_MODE_ADVANCED
             )
             cf.save(update_fields=["config"])
@@ -784,7 +783,7 @@ def _convert_table_fields(
                     "name": field_cfg.name,
                     "type": "text",
                     "config": {
-                        "value": BaserowFormulaObject.create(
+                        "value": formula_object(
                             value_formula, mode=BASEROW_FORMULA_MODE_ADVANCED
                         )
                     },
@@ -801,7 +800,7 @@ def _convert_table_fields(
                     "name": field_cfg.name,
                     "type": "button",
                     "config": {
-                        "label": BaserowFormulaObject.create(
+                        "label": formula_object(
                             label_formula, mode=BASEROW_FORMULA_MODE_ADVANCED
                         )
                     },
@@ -1313,7 +1312,7 @@ class CollectionElementCreate(_ElementBase):
 def _heading_update(el: "ElementUpdate") -> dict:
     kwargs: dict[str, Any] = {}
     if el.value is not None:
-        kwargs["value"] = BaserowFormulaObject.create(
+        kwargs["value"] = formula_object(
             literal_or_placeholder(el.value)
             if needs_formula(el.value)
             else wrap_static_string(el.value),
@@ -1327,7 +1326,7 @@ def _heading_update(el: "ElementUpdate") -> dict:
 def _text_update(el: "ElementUpdate") -> dict:
     kwargs: dict[str, Any] = {}
     if el.value is not None:
-        kwargs["value"] = BaserowFormulaObject.create(
+        kwargs["value"] = formula_object(
             literal_or_placeholder(el.value)
             if needs_formula(el.value)
             else wrap_static_string(el.value),
@@ -1342,7 +1341,7 @@ def _button_update(el: "ElementUpdate") -> dict:
     kwargs: dict[str, Any] = {}
     text = el.value or el.label
     if text is not None:
-        kwargs["value"] = BaserowFormulaObject.create(
+        kwargs["value"] = formula_object(
             literal_or_placeholder(text)
             if needs_formula(text)
             else wrap_static_string(text),
@@ -1354,7 +1353,7 @@ def _button_update(el: "ElementUpdate") -> dict:
 def _link_update(el: "ElementUpdate") -> dict:
     kwargs: dict[str, Any] = {}
     if el.value is not None:
-        kwargs["value"] = BaserowFormulaObject.create(
+        kwargs["value"] = formula_object(
             literal_or_placeholder(el.value)
             if needs_formula(el.value)
             else wrap_static_string(el.value),
@@ -1369,7 +1368,7 @@ def _link_update(el: "ElementUpdate") -> dict:
     if el.navigate_to_page_id is not None:
         kwargs["navigate_to_page_id"] = el.navigate_to_page_id
     if el.navigate_to_url is not None:
-        kwargs["navigate_to_url"] = BaserowFormulaObject.create(
+        kwargs["navigate_to_url"] = formula_object(
             literal_or_placeholder(el.navigate_to_url)
             if needs_formula(el.navigate_to_url)
             else wrap_static_string(el.navigate_to_url),
@@ -1383,14 +1382,14 @@ def _image_update(el: "ElementUpdate") -> dict:
     if el.image_source_type is not None:
         kwargs["image_source_type"] = el.image_source_type
     if el.image_url is not None:
-        kwargs["image_url"] = BaserowFormulaObject.create(
+        kwargs["image_url"] = formula_object(
             literal_or_placeholder(el.image_url)
             if needs_formula(el.image_url)
             else wrap_static_string(el.image_url),
             mode=BASEROW_FORMULA_MODE_ADVANCED,
         )
     if el.alt_text is not None:
-        kwargs["alt_text"] = BaserowFormulaObject.create(
+        kwargs["alt_text"] = formula_object(
             literal_or_placeholder(el.alt_text)
             if needs_formula(el.alt_text)
             else wrap_static_string(el.alt_text),
@@ -1413,8 +1412,8 @@ def _column_update(el: "ElementUpdate") -> dict:
 def _form_container_update(el: "ElementUpdate") -> dict:
     kwargs: dict[str, Any] = {}
     if el.submit_button_label is not None:
-        kwargs["submit_button_label"] = BaserowFormulaObject.create(
-            f"'{el.submit_button_label}'",
+        kwargs["submit_button_label"] = formula_object(
+            wrap_static_string(el.submit_button_label),
             mode=BASEROW_FORMULA_MODE_ADVANCED,
         )
     return kwargs
@@ -1423,15 +1422,15 @@ def _form_container_update(el: "ElementUpdate") -> dict:
 def _input_text_update(el: "ElementUpdate") -> dict:
     kwargs: dict[str, Any] = {}
     if el.label is not None:
-        kwargs["label"] = BaserowFormulaObject.create(
-            f"'{el.label}'", mode=BASEROW_FORMULA_MODE_ADVANCED
+        kwargs["label"] = formula_object(
+            wrap_static_string(el.label), mode=BASEROW_FORMULA_MODE_ADVANCED
         )
     if el.placeholder is not None:
-        kwargs["placeholder"] = BaserowFormulaObject.create(
-            f"'{el.placeholder}'", mode=BASEROW_FORMULA_MODE_ADVANCED
+        kwargs["placeholder"] = formula_object(
+            wrap_static_string(el.placeholder), mode=BASEROW_FORMULA_MODE_ADVANCED
         )
     if el.default_value is not None:
-        kwargs["default_value"] = BaserowFormulaObject.create(
+        kwargs["default_value"] = formula_object(
             literal_or_placeholder(el.default_value)
             if needs_formula(el.default_value)
             else (wrap_static_string(el.default_value) if el.default_value else "''"),
@@ -1451,15 +1450,15 @@ def _input_text_update(el: "ElementUpdate") -> dict:
 def _choice_update(el: "ElementUpdate") -> dict:
     kwargs: dict[str, Any] = {}
     if el.label is not None:
-        kwargs["label"] = BaserowFormulaObject.create(
-            f"'{el.label}'", mode=BASEROW_FORMULA_MODE_ADVANCED
+        kwargs["label"] = formula_object(
+            wrap_static_string(el.label), mode=BASEROW_FORMULA_MODE_ADVANCED
         )
     if el.placeholder is not None:
-        kwargs["placeholder"] = BaserowFormulaObject.create(
-            f"'{el.placeholder}'", mode=BASEROW_FORMULA_MODE_ADVANCED
+        kwargs["placeholder"] = formula_object(
+            wrap_static_string(el.placeholder), mode=BASEROW_FORMULA_MODE_ADVANCED
         )
     if el.default_value is not None:
-        kwargs["default_value"] = BaserowFormulaObject.create(
+        kwargs["default_value"] = formula_object(
             literal_or_placeholder(el.default_value)
             if needs_formula(el.default_value)
             else (wrap_static_string(el.default_value) if el.default_value else "''"),
@@ -1477,11 +1476,11 @@ def _choice_update(el: "ElementUpdate") -> dict:
 def _checkbox_update(el: "ElementUpdate") -> dict:
     kwargs: dict[str, Any] = {}
     if el.label is not None:
-        kwargs["label"] = BaserowFormulaObject.create(
-            f"'{el.label}'", mode=BASEROW_FORMULA_MODE_ADVANCED
+        kwargs["label"] = formula_object(
+            wrap_static_string(el.label), mode=BASEROW_FORMULA_MODE_ADVANCED
         )
     if el.default_value is not None:
-        kwargs["default_value"] = BaserowFormulaObject.create(
+        kwargs["default_value"] = formula_object(
             literal_or_placeholder(el.default_value)
             if needs_formula(el.default_value)
             else el.default_value,
@@ -1495,11 +1494,11 @@ def _checkbox_update(el: "ElementUpdate") -> dict:
 def _datetime_picker_update(el: "ElementUpdate") -> dict:
     kwargs: dict[str, Any] = {}
     if el.label is not None:
-        kwargs["label"] = BaserowFormulaObject.create(
-            f"'{el.label}'", mode=BASEROW_FORMULA_MODE_ADVANCED
+        kwargs["label"] = formula_object(
+            wrap_static_string(el.label), mode=BASEROW_FORMULA_MODE_ADVANCED
         )
     if el.default_value is not None:
-        kwargs["default_value"] = BaserowFormulaObject.create(
+        kwargs["default_value"] = formula_object(
             literal_or_placeholder(el.default_value)
             if needs_formula(el.default_value)
             else (wrap_static_string(el.default_value) if el.default_value else "''"),
@@ -1528,8 +1527,8 @@ def _table_update(el: "ElementUpdate") -> dict:
     if el.items_per_page is not None:
         kwargs["items_per_page"] = el.items_per_page
     if el.button_load_more_label is not None:
-        kwargs["button_load_more_label"] = BaserowFormulaObject.create(
-            f"'{el.button_load_more_label}'",
+        kwargs["button_load_more_label"] = formula_object(
+            wrap_static_string(el.button_load_more_label),
             mode=BASEROW_FORMULA_MODE_ADVANCED,
         )
     has_field_change = (

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/builder/types/workflow_action.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/builder/types/workflow_action.py
@@ -9,12 +9,10 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import Field, model_validator
 
-from baserow.core.formula.types import (
-    BASEROW_FORMULA_MODE_ADVANCED,
-    BaserowFormulaObject,
-)
+from baserow.core.formula.types import BASEROW_FORMULA_MODE_ADVANCED
 from baserow_enterprise.assistant.tools.shared.formula_utils import (
     formula_desc,
+    formula_object,
     literal_or_placeholder,
     needs_formula,
 )
@@ -91,11 +89,11 @@ def _strip_formula_prefix(value: str) -> str:
 
 def _notification_orm_kwargs(action: "ActionCreate") -> dict:
     return {
-        "title": BaserowFormulaObject.create(
+        "title": formula_object(
             literal_or_placeholder(action.title),
             mode=BASEROW_FORMULA_MODE_ADVANCED,
         ),
-        "description": BaserowFormulaObject.create(
+        "description": formula_object(
             literal_or_placeholder(action.description),
             mode=BASEROW_FORMULA_MODE_ADVANCED,
         ),
@@ -109,7 +107,7 @@ def _open_page_orm_kwargs(action: "ActionCreate") -> dict:
         "page_parameters": [
             {
                 "name": p.name,
-                "value": BaserowFormulaObject.create(
+                "value": formula_object(
                     literal_or_placeholder(p.value),
                     mode=BASEROW_FORMULA_MODE_ADVANCED,
                 ),
@@ -119,7 +117,7 @@ def _open_page_orm_kwargs(action: "ActionCreate") -> dict:
         "query_parameters": [
             {
                 "name": p.name,
-                "value": BaserowFormulaObject.create(
+                "value": formula_object(
                     literal_or_placeholder(p.value),
                     mode=BASEROW_FORMULA_MODE_ADVANCED,
                 ),
@@ -170,7 +168,7 @@ def _row_service_kwargs(action: "ActionCreate", user, workspace) -> dict:
     kwargs: dict[str, Any] = {"table": table}
 
     if action.type in ("update_row", "delete_row") and action.row_id:
-        kwargs["row_id"] = BaserowFormulaObject.create(
+        kwargs["row_id"] = formula_object(
             _strip_formula_prefix(action.row_id),
             mode=BASEROW_FORMULA_MODE_ADVANCED,
         )
@@ -198,7 +196,7 @@ def _field_mappings(action: "ActionCreate") -> list[dict] | None:
         mappings.append(
             {
                 "field_id": int(fv.field_id),
-                "value": BaserowFormulaObject.create(
+                "value": formula_object(
                     formula_value, mode=BASEROW_FORMULA_MODE_ADVANCED
                 ),
                 "enabled": True,
@@ -270,7 +268,7 @@ def _update_row_formulas(
 
     # Update row_id
     if "row_id" in formulas:
-        service.row_id = BaserowFormulaObject.create(
+        service.row_id = formula_object(
             formulas["row_id"], mode=BASEROW_FORMULA_MODE_ADVANCED
         )
         service.save(update_fields=["row_id"])
@@ -279,7 +277,7 @@ def _update_row_formulas(
     for mapping in service.field_mappings.all():
         key = f"field_{mapping.field_id}"
         if key in formulas:
-            mapping.value = BaserowFormulaObject.create(
+            mapping.value = formula_object(
                 formulas[key], mode=BASEROW_FORMULA_MODE_ADVANCED
             )
             mapping.save(update_fields=["value"])
@@ -302,14 +300,14 @@ def _update_open_page_formulas(
     for i, p in enumerate(page_params):
         key = f"page_param_{i}"
         if key in formulas:
-            p["value"] = BaserowFormulaObject.create(
+            p["value"] = formula_object(
                 formulas[key], mode=BASEROW_FORMULA_MODE_ADVANCED
             )
 
     for i, p in enumerate(query_params):
         key = f"query_param_{i}"
         if key in formulas:
-            p["value"] = BaserowFormulaObject.create(
+            p["value"] = formula_object(
                 formulas[key], mode=BASEROW_FORMULA_MODE_ADVANCED
             )
 

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/shared/__init__.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/shared/__init__.py
@@ -1,10 +1,15 @@
 from .agents import get_formula_generator
 from .formula_utils import (
+    EMPTY_FORMULA,
     FORMULA_PREFIX,
     RAW_FORMULA_RE,
     BaseFormulaContext,
     create_example_from_json_schema,
+    ensure_valid_formula,
     formula_desc,
+    formula_object,
+    is_string_literal,
+    is_valid_formula,
     literal_or_placeholder,
     minimize_json_schema,
     needs_formula,
@@ -12,12 +17,17 @@ from .formula_utils import (
 )
 
 __all__ = [
+    "EMPTY_FORMULA",
     "FORMULA_PREFIX",
     "RAW_FORMULA_RE",
     "needs_formula",
     "formula_desc",
     "literal_or_placeholder",
     "wrap_static_string",
+    "is_valid_formula",
+    "is_string_literal",
+    "ensure_valid_formula",
+    "formula_object",
     "minimize_json_schema",
     "create_example_from_json_schema",
     "BaseFormulaContext",

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/shared/formula_utils.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/shared/formula_utils.py
@@ -1,16 +1,31 @@
+import logging
 import re
 from abc import ABC, abstractmethod
 from datetime import date, datetime
 from typing import Any
 
-from baserow.core.formula.types import FormulaContext
+from baserow.core.formula.parser.exceptions import BaserowFormulaException
+from baserow.core.formula.parser.generated.BaserowFormula import BaserowFormula
+from baserow.core.formula.parser.parser import get_parse_tree_for_formula
+from baserow.core.formula.types import (
+    BASEROW_FORMULA_MODE_SIMPLE,
+    BaserowFormulaMode,
+    BaserowFormulaObject,
+    FormulaContext,
+)
 from baserow.core.utils import to_path
+
+logger = logging.getLogger(__name__)
 
 # =============================================================================
 # Formula Detection Constants and Helpers
 # =============================================================================
 
 FORMULA_PREFIX = "$formula:"
+
+# An empty string literal, used as a placeholder for values that are either
+# missing or resolved later on by the formula generator agent.
+EMPTY_FORMULA = "''"
 
 # Detects raw formula syntax the LLM might write instead of using $formula:.
 # Matches: get('...'), concat(...), {{ ... }}, comparison operators, if(...),
@@ -75,26 +90,109 @@ def literal_or_placeholder(value: str | None) -> str:
     """
 
     if not value or needs_formula(value):
-        return "''"
+        return EMPTY_FORMULA
     return wrap_static_string(value)
+
+
+def is_valid_formula(value: str) -> bool:
+    """
+    Check whether the given formula can be parsed.
+
+    :param value: The formula to parse.
+    :return: True if the formula is syntactically valid.
+    """
+
+    try:
+        get_parse_tree_for_formula(value)
+    except (BaserowFormulaException, RecursionError):
+        return False
+    return True
+
+
+def is_string_literal(value: str) -> bool:
+    """
+    Check whether the given formula is a single, complete string literal.
+
+    Used to detect values the LLM already quoted itself (e.g. ``'Submit'``).
+    Inspecting the first and last character isn't enough: ``'Managers' Week'``
+    looks quoted, but is invalid syntax.
+
+    :param value: The formula to parse.
+    :return: True if the formula is exactly one string literal.
+    """
+
+    try:
+        tree = get_parse_tree_for_formula(value)
+    except (BaserowFormulaException, RecursionError):
+        return False
+    return isinstance(tree.expr(), BaserowFormula.StringLiteralContext)
 
 
 def wrap_static_string(value: str) -> str:
     """
     Wrap a static string as a Baserow formula literal.
 
-    If the value is already a quoted formula literal (e.g. ``'Submit'``),
-    it is returned unchanged to avoid double-wrapping which would produce
-    escaped quotes visible in the UI (e.g. ``'\\'Submit\\''``).
+    If the value already *is* a valid string literal (e.g. ``'Submit'``), it is
+    returned unchanged to avoid double-wrapping which would produce escaped
+    quotes visible in the UI (e.g. ``'\\'Submit\\''``). Anything else is escaped
+    the same way the frontend does it, so that values containing apostrophes
+    (``Sales Managers' Week``) or backslashes still produce parsable formulas.
 
     :param value: Plain text string or already-quoted formula literal.
     :return: Formula-compatible string literal with proper escaping.
     """
 
-    if len(value) >= 2 and value[0] == "'" and value[-1] == "'":
+    if is_string_literal(value):
         return value
-    escaped = value.replace("'", "\\'")
+    escaped = value.replace("\\", "\\\\").replace("'", "\\'")
     return f"'{escaped}'"
+
+
+def ensure_valid_formula(formula: str) -> str:
+    """
+    Guarantee that a formula written by the assistant can be parsed.
+
+    Values coming from the LLM regularly contain unescaped apostrophes, and an
+    invalid formula can be persisted because the assistant writes through the
+    handlers instead of the API serializers. It only surfaces much later, when
+    the application is duplicated or exported and the formula importer fails to
+    parse it. Falling back to a static string literal keeps the value visible
+    and editable in the UI instead of breaking the whole application.
+
+    :param formula: The formula about to be persisted.
+    :return: The formula itself, or a string literal fallback.
+    """
+
+    if not formula or not isinstance(formula, str) or is_valid_formula(formula):
+        return formula
+
+    fallback = wrap_static_string(formula)
+    logger.warning(
+        "The assistant produced an invalid formula, storing it as a static "
+        "string literal instead: %s",
+        formula,
+    )
+    return fallback
+
+
+def formula_object(
+    formula: str = "",
+    mode: BaserowFormulaMode = BASEROW_FORMULA_MODE_SIMPLE,
+    version: str = "0.1",
+) -> BaserowFormulaObject:
+    """
+    Drop-in replacement of ``BaserowFormulaObject.create`` for assistant values.
+
+    Every formula the assistant persists must go through here so that an
+    invalid one can never reach the database. See :func:`ensure_valid_formula`.
+
+    :param formula: The formula to store.
+    :param mode: The formula mode.
+    :param version: The formula version.
+    :return: A ``BaserowFormulaObject`` holding a parsable formula.
+    """
+
+    return BaserowFormulaObject.create(ensure_valid_formula(formula), mode, version)
 
 
 # =============================================================================

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/shared/formula_utils.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/shared/formula_utils.py
@@ -159,6 +159,16 @@ def ensure_valid_formula(formula: str) -> str:
     parse it. Falling back to a static string literal keeps the value visible
     and editable in the UI instead of breaking the whole application.
 
+    This is a deliberate trade-off: the write succeeds with only the warning
+    below, so a value that was meant to be a formula degrades silently.
+    Typed targets such as ``row_id`` then fail later with a handled dispatch
+    error (via the ensurers in ``resolve_service_formulas``), while text
+    targets render the raw formula text verbatim. We accept this because the
+    formula generator already resolves its output against example context
+    before it is persisted, making the fallback rare for generated formulas;
+    the common trigger is static text with apostrophes, where the quoted
+    literal is exactly the intended value.
+
     :param formula: The formula about to be persisted.
     :return: The formula itself, or a string literal fallback.
     """

--- a/enterprise/backend/tests/baserow_enterprise_tests/assistant/test_assistant_automation_node_tools.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/assistant/test_assistant_automation_node_tools.py
@@ -302,3 +302,54 @@ def test_delete_node_wrong_workspace(data_fixture):
 
     # Node should still exist
     assert AutomationNode.objects.filter(id=action_node.id).exists()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_literal_values_with_apostrophes_stay_valid_formulas(data_fixture):
+    """
+    Regression test: literal values coming from the LLM used to be wrapped as
+    `f"'{value}'"`, so a value such as `Sales Managers' Week 3` was persisted as
+    an unparsable formula. It only blew up later, when the workflow was
+    duplicated, exported or imported.
+    """
+
+    from baserow.contrib.automation.workflows.service import AutomationWorkflowService
+    from baserow.core.formula import BaserowFormulaObject
+    from baserow_enterprise.assistant.tools.shared.formula_utils import is_valid_formula
+
+    user = data_fixture.create_user()
+    workspace = data_fixture.create_workspace(user=user)
+    database = data_fixture.create_database_application(user=user, workspace=workspace)
+    table = data_fixture.create_database_table(database=database)
+    field = data_fixture.create_text_field(table=table)
+    automation = data_fixture.create_automation_application(
+        user=user, workspace=workspace
+    )
+    workflow = data_fixture.create_automation_workflow(automation=automation)
+    node = data_fixture.create_local_baserow_create_row_action_node(
+        user=user, workflow=workflow, service_kwargs={"table": table}
+    )
+
+    node_create = ActionNodeCreate(
+        ref="row1",
+        label="Create row",
+        previous_node_ref="trigger1",
+        type="create_row",
+        table_id=table.id,
+        row_id="Sales Managers' Week 3",
+        values=[{"field_id": field.id, "value": "Sales Managers' Week 3"}],
+    )
+    node_create.apply_direct_values(node.service)
+
+    service = node.service.specific
+    service.refresh_from_db()
+    mapping = service.field_mappings.get(field_id=field.id)
+
+    assert is_valid_formula(BaserowFormulaObject.to_formula(mapping.value)["formula"])
+    assert is_valid_formula(BaserowFormulaObject.to_formula(service.row_id)["formula"])
+
+    # The workflow must remain duplicable, which is where the invalid formula
+    # used to surface as a `BaserowFormulaSyntaxError`.
+    duplicated = AutomationWorkflowService().duplicate_workflow(user, workflow)
+
+    assert duplicated.id != workflow.id

--- a/enterprise/backend/tests/baserow_enterprise_tests/assistant/test_assistant_automation_node_tools.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/assistant/test_assistant_automation_node_tools.py
@@ -353,3 +353,62 @@ def test_literal_values_with_apostrophes_stay_valid_formulas(data_fixture):
     duplicated = AutomationWorkflowService().duplicate_workflow(user, workflow)
 
     assert duplicated.id != workflow.id
+
+
+@pytest.mark.django_db(transaction=True)
+def test_router_edge_conditions_stay_valid_formulas(data_fixture):
+    """
+    Generated router edge conditions are written into the edge's JSON
+    ``condition`` instead of a service field, so they must go through
+    ``ensure_valid_formula`` like every other assistant-written formula. An
+    unparsable condition falls back to a string literal so the workflow stays
+    duplicable, exportable and importable.
+    """
+
+    from baserow.contrib.automation.workflows.service import AutomationWorkflowService
+    from baserow.core.formula.types import BASEROW_FORMULA_MODE_ADVANCED
+    from baserow_enterprise.assistant.tools.automation.types.node import (
+        RouterEdgeCreate,
+    )
+    from baserow_enterprise.assistant.tools.shared.formula_utils import is_valid_formula
+
+    user = data_fixture.create_user()
+    router_node = data_fixture.create_core_router_action_node_with_edges(
+        user=user
+    ).router
+
+    node_create = ActionNodeCreate(
+        ref="router1",
+        label="Router",
+        previous_node_ref="trigger1",
+        type="router",
+        edges=[
+            RouterEdgeCreate(label="Do this", condition="High priority"),
+            RouterEdgeCreate(label="Do that", condition="Low priority"),
+        ],
+    )
+    node_create.update_service_with_formulas(
+        router_node.service,
+        {
+            "Do this": "get('previous_node.1.field')",
+            "Do that": "Managers' pick",  # unparsable: unterminated string literal
+        },
+    )
+
+    edges = router_node.service.specific.edges
+    valid_edge = edges.get(label="Do this")
+    assert valid_edge.condition["formula"] == "get('previous_node.1.field')"
+    assert valid_edge.condition["mode"] == BASEROW_FORMULA_MODE_ADVANCED
+
+    fallback_edge = edges.get(label="Do that")
+    assert fallback_edge.condition["formula"] == "'Managers\\' pick'"
+    assert is_valid_formula(fallback_edge.condition["formula"])
+    assert fallback_edge.condition["mode"] == BASEROW_FORMULA_MODE_ADVANCED
+
+    # The workflow must remain duplicable, which is where an unparsable
+    # condition would surface in the formula importer.
+    duplicated = AutomationWorkflowService().duplicate_workflow(
+        user, router_node.workflow
+    )
+
+    assert duplicated.id != router_node.workflow.id

--- a/enterprise/backend/tests/baserow_enterprise_tests/assistant/test_assistant_builder_tools.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/assistant/test_assistant_builder_tools.py
@@ -47,9 +47,13 @@ from baserow_enterprise.assistant.tools.builder.types import (
     TypographyStyleOverride,
 )
 from baserow_enterprise.assistant.tools.shared.formula_utils import (
+    ensure_valid_formula,
     formula_desc,
+    formula_object,
+    is_valid_formula,
     literal_or_placeholder,
     needs_formula,
+    wrap_static_string,
 )
 
 from .utils import create_fake_tool_helpers, make_test_ctx
@@ -123,6 +127,57 @@ class TestFormulaUtils:
     def test_literal_or_placeholder_literal(self):
         assert literal_or_placeholder("Submit") == "'Submit'"
         assert literal_or_placeholder(None) == "''"
+
+    def test_wrap_static_string_escapes_apostrophes(self):
+        assert wrap_static_string("Sales Managers' Week") == (
+            "'Sales Managers\\' Week'"
+        )
+        assert wrap_static_string("Employees' Week") == "'Employees\\' Week'"
+
+    def test_wrap_static_string_escapes_backslashes(self):
+        assert wrap_static_string("C:\\") == "'C:\\\\'"
+
+    def test_wrap_static_string_keeps_valid_literals(self):
+        assert wrap_static_string("'Submit'") == "'Submit'"
+        assert wrap_static_string("'It\\'s'") == "'It\\'s'"
+
+    def test_wrap_static_string_rewraps_invalid_literals(self):
+        # Looks quoted, but the inner apostrophe makes it invalid syntax.
+        assert is_valid_formula(wrap_static_string("'Sales Managers' Week 3'"))
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Sales Managers' Week 3",
+            "'Sales Managers' Week 3'",
+            "Submit",
+            "'Submit'",
+            "C:\\",
+            "",
+        ],
+    )
+    def test_wrap_static_string_always_parses(self, value):
+        assert is_valid_formula(wrap_static_string(value))
+
+    def test_literal_or_placeholder_escapes_apostrophes(self):
+        assert is_valid_formula(literal_or_placeholder("Sales Managers' Week 3"))
+
+    def test_ensure_valid_formula_keeps_valid_formulas(self):
+        assert ensure_valid_formula("get('page_parameter.id')") == (
+            "get('page_parameter.id')"
+        )
+        assert ensure_valid_formula("'Submit'") == "'Submit'"
+        assert ensure_valid_formula("") == ""
+
+    def test_ensure_valid_formula_falls_back_to_a_literal(self):
+        result = ensure_valid_formula("'Sales Managers' Week 3'")
+
+        assert is_valid_formula(result)
+
+    def test_formula_object_never_stores_an_invalid_formula(self):
+        formula = formula_object("'Sales Managers' Week 3'")
+
+        assert is_valid_formula(formula["formula"])
 
 
 # ===========================================================================


### PR DESCRIPTION
### What is in this PR
This PR fixes a bug with the AI Assistant that allowed it to persist invalid formulas, which could result in a state where the automation workflow or builder application can't be duplicated or exported.

Resolves [this Sentry issue](https://baserow-eu.sentry.io/issues/141141572/).

### How to test this PR
It's a bit tricky to reproduce the bug exactly in the frontend, mainly because the AI isn't deterministic. Still, you can try the following in the latest `develop`.

Set up your `.env.docker-dev` with these:
```
BASEROW_ENTERPRISE_ASSISTANT_LLM_MODEL=openai:gpt-5.5
BASEROW_ENTERPRISE_ASSISTANT_LLM_TEMPERATURE=1
OPENAI_API_KEY=<your api key>
```

Then using Kuma, give it a prompt like this:
```
Create a new automation app with a new workflow named “my workflow”. Give it a periodic trigger that runs once a day at 09:00 UTC, and one create_row action node targeting the “Table” table with with “Name” set to “Hello ’ World”.
```

Sometimes Kuma will create the node with a valid formula, but other times, it'll create a formula with an unescaped quote. Then if you try to duplicate the automation, the backend crashes with:
```
  File "/baserow/venv/lib/python3.14/site-packages/antlr4/error/ErrorListener.py", line 60, in syntaxError
    delegate.syntaxError(recognizer, offendingSymbol, line, column, msg, e)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/baserow/backend/src/baserow/core/formula/parser/parser.py", line 22, in syntaxError
    raise BaserowFormulaSyntaxError(message)
baserow.core.formula.parser.exceptions.BaserowFormulaSyntaxError: Invalid syntax at line 1, col 9: mismatched input 'World' expecting the end of the formula
```

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
