### PR TITLE
fix(database): require credential re-entry when data sync connection target changes

### DIFF
--- a/backend/src/baserow/contrib/database/api/data_sync/errors.py
+++ b/backend/src/baserow/contrib/database/api/data_sync/errors.py
@@ -31,3 +31,8 @@ ERROR_TWO_WAY_DATA_SYNC_NOT_SUPPORTED = (
     HTTP_400_BAD_REQUEST,
     "Two-way sync is not supported for this data sync type.",
 )
+ERROR_DATA_SYNC_CREDENTIAL_REQUIRED = (
+    "ERROR_DATA_SYNC_CREDENTIAL_REQUIRED",
+    HTTP_400_BAD_REQUEST,
+    "When changing the connection target, the credential must be re-supplied.",
+)

--- a/backend/src/baserow/contrib/database/api/data_sync/views.py
+++ b/backend/src/baserow/contrib/database/api/data_sync/views.py
@@ -28,6 +28,7 @@ from baserow.contrib.database.data_sync.actions import (
     UpdateDataSyncTableActionType,
 )
 from baserow.contrib.database.data_sync.exceptions import (
+    DataSyncCredentialRequired,
     DataSyncDoesNotExist,
     PropertyNotFound,
     SyncError,
@@ -52,6 +53,7 @@ from baserow.core.jobs.registries import job_type_registry
 from baserow.core.utils import extract_allowed
 
 from .errors import (
+    ERROR_DATA_SYNC_CREDENTIAL_REQUIRED,
     ERROR_DATA_SYNC_DOES_NOT_EXIST,
     ERROR_PROPERTY_NOT_FOUND,
     ERROR_SYNC_ERROR,
@@ -217,6 +219,7 @@ class DataSyncView(APIView):
                     "ERROR_PROPERTY_NOT_FOUND",
                     "ERROR_SYNC_ERROR",
                     "ERROR_TWO_WAY_DATA_SYNC_NOT_SUPPORTED",
+                    "ERROR_DATA_SYNC_CREDENTIAL_REQUIRED",
                 ]
             ),
             404: get_error_schema(["ERROR_DATA_SYNC_DOES_NOT_EXIST"]),
@@ -230,6 +233,7 @@ class DataSyncView(APIView):
             PropertyNotFound: ERROR_PROPERTY_NOT_FOUND,
             SyncError: ERROR_SYNC_ERROR,
             TwoWayDataSyncNotSupported: ERROR_TWO_WAY_DATA_SYNC_NOT_SUPPORTED,
+            DataSyncCredentialRequired: ERROR_DATA_SYNC_CREDENTIAL_REQUIRED,
         }
     )
     def patch(self, request, data_sync_id):

--- a/backend/src/baserow/contrib/database/data_sync/exceptions.py
+++ b/backend/src/baserow/contrib/database/data_sync/exceptions.py
@@ -40,3 +40,10 @@ class TwoWayDataSyncNotSupported(Exception):
     Raised when two-way sync is being enabled for a data sync type that doesn't support
     it.
     """
+
+
+class DataSyncCredentialRequired(Exception):
+    """
+    Raised when a connection target field is changed without re-supplying the
+    associated credential field.
+    """

--- a/backend/src/baserow/contrib/database/data_sync/handler.py
+++ b/backend/src/baserow/contrib/database/data_sync/handler.py
@@ -33,6 +33,7 @@ from baserow.core.utils import (
 
 from .constants import BASE_DATA_SYNC_ALLOWED_FIELDS
 from .exceptions import (
+    DataSyncCredentialRequired,
     DataSyncDoesNotExist,
     PropertyNotFound,
     SyncDataSyncTableAlreadyRunning,
@@ -303,6 +304,20 @@ class DataSyncHandler:
                 # number of consecutive failures because the user could have fixed the
                 # problem after it was automatically disabled.
                 data_sync.two_way_sync_consecutive_failures = 0
+
+        for (
+            secret_field,
+            target_fields,
+        ) in data_sync_type.secret_field_dependencies.items():
+            target_changed = any(
+                field in kwargs and kwargs[field] != getattr(data_sync, field)
+                for field in target_fields
+            )
+            if target_changed and secret_field not in kwargs:
+                raise DataSyncCredentialRequired(
+                    "When changing the connection target, the credential must be "
+                    "re-supplied."
+                )
 
         data_sync = set_allowed_attrs(kwargs, allowed_fields, data_sync)
         data_sync.save()

--- a/backend/src/baserow/contrib/database/data_sync/postgresql_data_sync_type.py
+++ b/backend/src/baserow/contrib/database/data_sync/postgresql_data_sync_type.py
@@ -153,6 +153,9 @@ class PostgreSQLDataSyncType(DataSyncType):
         "postgresql_table",
         "postgresql_sslmode",
     ]
+    secret_field_dependencies = {
+        "postgresql_password": ["postgresql_host", "postgresql_port"],
+    }
 
     @contextlib.contextmanager
     def _connection(self, instance):

--- a/backend/src/baserow/contrib/database/data_sync/registries.py
+++ b/backend/src/baserow/contrib/database/data_sync/registries.py
@@ -116,6 +116,15 @@ class DataSyncType(
     one-way data sync is possible.
     """
 
+    secret_field_dependencies: dict[str, list[str]] = {}
+    """
+    Maps secret fields to the connection target fields they protect. If any
+    target field changes value, the secret must be re-supplied in the same
+    request.
+
+    Example: {"postgresql_password": ["postgresql_host", "postgresql_port"]}
+    """
+
     def prepare_values(self, user: AbstractUser, values: Dict) -> Dict:
         """
         A hook that can validate or changes the provided values.

--- a/backend/tests/baserow/contrib/database/api/data_sync/test_data_sync_views.py
+++ b/backend/tests/baserow/contrib/database/api/data_sync/test_data_sync_views.py
@@ -1581,3 +1581,45 @@ def test_cannot_delete_row_without_two_way_data_sync(
     response = api_client.delete(url, HTTP_AUTHORIZATION=f"JWT {token}")
     assert response.status_code == HTTP_400_BAD_REQUEST
     assert response.json()["error"] == "ERROR_CANNOT_DELETE_ROWS_IN_TABLE"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_update_postgresql_data_sync_rejects_host_change_without_password_via_api(
+    data_fixture, api_client, create_postgresql_test_table
+):
+    default_database = settings.DATABASES["default"]
+    user, token = data_fixture.create_user_and_token()
+    database = data_fixture.create_database_application(user=user)
+
+    url = reverse("api:database:data_sync:list", kwargs={"database_id": database.id})
+    response = api_client.post(
+        url,
+        {
+            "table_name": "Test 1",
+            "type": "postgresql",
+            "synced_properties": ["id"],
+            "postgresql_host": default_database["HOST"],
+            "postgresql_username": default_database["USER"],
+            "postgresql_password": default_database["PASSWORD"],
+            "postgresql_port": default_database["PORT"],
+            "postgresql_database": default_database["NAME"],
+            "postgresql_table": create_postgresql_test_table,
+            "postgresql_sslmode": default_database["OPTIONS"].get("sslmode", "prefer"),
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    data_sync_id = response.json()["data_sync"]["id"]
+
+    url = reverse("api:database:data_sync:item", kwargs={"data_sync_id": data_sync_id})
+    response = api_client.patch(
+        url,
+        {
+            "synced_properties": ["id"],
+            "postgresql_host": "attacker.com",
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_DATA_SYNC_CREDENTIAL_REQUIRED"

--- a/backend/tests/baserow/contrib/database/data_sync/test_data_sync_handler.py
+++ b/backend/tests/baserow/contrib/database/data_sync/test_data_sync_handler.py
@@ -9,6 +9,7 @@ import responses
 from freezegun import freeze_time
 
 from baserow.contrib.database.data_sync.exceptions import (
+    DataSyncCredentialRequired,
     PropertyNotFound,
     SyncDataSyncTableAlreadyRunning,
     UniquePrimaryPropertyNotFound,
@@ -552,6 +553,174 @@ def test_update_data_sync_table(send_mock, data_fixture):
     send_mock.assert_called_once()
     assert send_mock.call_args[1]["table"].id == data_sync.table_id
     assert send_mock.call_args[1]["user"] == user
+
+
+@pytest.mark.django_db
+def test_update_data_sync_table_rejects_target_change_without_credential(data_fixture):
+    user = data_fixture.create_user()
+    database = data_fixture.create_database_application(user=user)
+
+    registry = DataSyncTypeRegistry()
+
+    class SecretICalCalendarDataSyncType(ICalCalendarDataSyncType):
+        allowed_fields = ["ical_url", "ical_secret"]
+        secret_field_dependencies = {
+            "ical_secret": ["ical_url"],
+        }
+
+    registry.register(SecretICalCalendarDataSyncType())
+
+    handler = DataSyncHandler()
+
+    data_sync = handler.create_data_sync_table(
+        user=user,
+        database=database,
+        table_name="Test",
+        type_name="ical_calendar",
+        synced_properties=["uid", "dtstart"],
+        ical_url="https://baserow.io",
+    )
+
+    with patch(
+        "baserow.contrib.database.data_sync.handler.data_sync_type_registry",
+        new=registry,
+    ):
+        with pytest.raises(DataSyncCredentialRequired):
+            handler.update_data_sync_table(
+                user=user,
+                data_sync=data_sync,
+                synced_properties=["uid", "dtstart"],
+                ical_url="https://attacker.com",
+            )
+
+
+@pytest.mark.django_db
+@patch("baserow.contrib.database.table.signals.table_updated.send")
+def test_update_data_sync_table_allows_target_change_with_credential(
+    send_mock, data_fixture
+):
+    user = data_fixture.create_user()
+    database = data_fixture.create_database_application(user=user)
+
+    registry = DataSyncTypeRegistry()
+
+    class SecretICalCalendarDataSyncType(ICalCalendarDataSyncType):
+        allowed_fields = ["ical_url", "ical_secret"]
+        secret_field_dependencies = {
+            "ical_secret": ["ical_url"],
+        }
+
+    registry.register(SecretICalCalendarDataSyncType())
+
+    handler = DataSyncHandler()
+
+    data_sync = handler.create_data_sync_table(
+        user=user,
+        database=database,
+        table_name="Test",
+        type_name="ical_calendar",
+        synced_properties=["uid", "dtstart"],
+        ical_url="https://baserow.io",
+    )
+
+    with patch(
+        "baserow.contrib.database.data_sync.handler.data_sync_type_registry",
+        new=registry,
+    ):
+        data_sync = handler.update_data_sync_table(
+            user=user,
+            data_sync=data_sync,
+            synced_properties=["uid", "dtstart"],
+            ical_url="https://new-host.com",
+            ical_secret="new-secret",
+        )
+
+    assert data_sync.ical_url == "https://new-host.com"
+
+
+@pytest.mark.django_db
+@patch("baserow.contrib.database.table.signals.table_updated.send")
+def test_update_data_sync_table_allows_non_target_change_without_credential(
+    send_mock, data_fixture
+):
+    user = data_fixture.create_user()
+    database = data_fixture.create_database_application(user=user)
+
+    registry = DataSyncTypeRegistry()
+
+    class SecretICalCalendarDataSyncType(ICalCalendarDataSyncType):
+        allowed_fields = ["ical_url", "ical_secret"]
+        secret_field_dependencies = {
+            "ical_secret": ["ical_url"],
+        }
+
+    registry.register(SecretICalCalendarDataSyncType())
+
+    handler = DataSyncHandler()
+
+    data_sync = handler.create_data_sync_table(
+        user=user,
+        database=database,
+        table_name="Test",
+        type_name="ical_calendar",
+        synced_properties=["uid", "dtstart"],
+        ical_url="https://baserow.io",
+    )
+
+    with patch(
+        "baserow.contrib.database.data_sync.handler.data_sync_type_registry",
+        new=registry,
+    ):
+        data_sync = handler.update_data_sync_table(
+            user=user,
+            data_sync=data_sync,
+            synced_properties=["uid", "dtstart", "dtend"],
+        )
+
+    assert data_sync.ical_url == "https://baserow.io"
+
+
+@pytest.mark.django_db
+@patch("baserow.contrib.database.table.signals.table_updated.send")
+def test_update_data_sync_table_allows_same_target_value_without_credential(
+    send_mock, data_fixture
+):
+    user = data_fixture.create_user()
+    database = data_fixture.create_database_application(user=user)
+
+    registry = DataSyncTypeRegistry()
+
+    class SecretICalCalendarDataSyncType(ICalCalendarDataSyncType):
+        allowed_fields = ["ical_url", "ical_secret"]
+        secret_field_dependencies = {
+            "ical_secret": ["ical_url"],
+        }
+
+    registry.register(SecretICalCalendarDataSyncType())
+
+    handler = DataSyncHandler()
+
+    data_sync = handler.create_data_sync_table(
+        user=user,
+        database=database,
+        table_name="Test",
+        type_name="ical_calendar",
+        synced_properties=["uid", "dtstart"],
+        ical_url="https://baserow.io",
+    )
+
+    with patch(
+        "baserow.contrib.database.data_sync.handler.data_sync_type_registry",
+        new=registry,
+    ):
+        data_sync = handler.update_data_sync_table(
+            user=user,
+            data_sync=data_sync,
+            synced_properties=["uid", "dtstart"],
+            ical_url="https://baserow.io",
+        )
+
+    assert data_sync.ical_url == "https://baserow.io"
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/contrib/database/data_sync/test_data_sync_postgresql.py
+++ b/backend/tests/baserow/contrib/database/data_sync/test_data_sync_postgresql.py
@@ -10,7 +10,10 @@ from django.urls import reverse
 import pytest
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 
-from baserow.contrib.database.data_sync.exceptions import SyncError
+from baserow.contrib.database.data_sync.exceptions import (
+    DataSyncCredentialRequired,
+    SyncError,
+)
 from baserow.contrib.database.data_sync.handler import DataSyncHandler
 from baserow.contrib.database.data_sync.models import (
     DataSync,
@@ -928,3 +931,136 @@ def test_create_data_sync_with_negative_int_and_positive_baserow_number_field(
         job["human_readable_error"]
         == f"The value for field {fields[1].id} cannot be negative."
     )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_postgresql_update_rejects_host_change_without_password(
+    data_fixture, create_postgresql_test_table
+):
+    default_database = settings.DATABASES["default"]
+    user = data_fixture.create_user()
+    database = data_fixture.create_database_application(user=user)
+    handler = DataSyncHandler()
+
+    data_sync = handler.create_data_sync_table(
+        user=user,
+        database=database,
+        table_name="Test",
+        type_name="postgresql",
+        synced_properties=["id"],
+        postgresql_host=default_database["HOST"],
+        postgresql_username=default_database["USER"],
+        postgresql_password=default_database["PASSWORD"],
+        postgresql_port=default_database["PORT"],
+        postgresql_database=default_database["NAME"],
+        postgresql_table=create_postgresql_test_table,
+        postgresql_sslmode=default_database["OPTIONS"].get("sslmode", "prefer"),
+    )
+
+    with pytest.raises(DataSyncCredentialRequired):
+        handler.update_data_sync_table(
+            user=user,
+            data_sync=data_sync,
+            synced_properties=["id"],
+            postgresql_host="attacker.com",
+        )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_postgresql_update_rejects_port_change_without_password(
+    data_fixture, create_postgresql_test_table
+):
+    default_database = settings.DATABASES["default"]
+    user = data_fixture.create_user()
+    database = data_fixture.create_database_application(user=user)
+    handler = DataSyncHandler()
+
+    data_sync = handler.create_data_sync_table(
+        user=user,
+        database=database,
+        table_name="Test",
+        type_name="postgresql",
+        synced_properties=["id"],
+        postgresql_host=default_database["HOST"],
+        postgresql_username=default_database["USER"],
+        postgresql_password=default_database["PASSWORD"],
+        postgresql_port=default_database["PORT"],
+        postgresql_database=default_database["NAME"],
+        postgresql_table=create_postgresql_test_table,
+        postgresql_sslmode=default_database["OPTIONS"].get("sslmode", "prefer"),
+    )
+
+    with pytest.raises(DataSyncCredentialRequired):
+        handler.update_data_sync_table(
+            user=user,
+            data_sync=data_sync,
+            synced_properties=["id"],
+            postgresql_port=9999,
+        )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_postgresql_update_allows_host_change_with_password(
+    data_fixture, create_postgresql_test_table
+):
+    default_database = settings.DATABASES["default"]
+    user = data_fixture.create_user()
+    database = data_fixture.create_database_application(user=user)
+    handler = DataSyncHandler()
+
+    data_sync = handler.create_data_sync_table(
+        user=user,
+        database=database,
+        table_name="Test",
+        type_name="postgresql",
+        synced_properties=["id"],
+        postgresql_host=default_database["HOST"],
+        postgresql_username=default_database["USER"],
+        postgresql_password=default_database["PASSWORD"],
+        postgresql_port=default_database["PORT"],
+        postgresql_database=default_database["NAME"],
+        postgresql_table=create_postgresql_test_table,
+        postgresql_sslmode=default_database["OPTIONS"].get("sslmode", "prefer"),
+    )
+
+    data_sync = handler.update_data_sync_table(
+        user=user,
+        data_sync=data_sync,
+        synced_properties=["id"],
+        postgresql_host=default_database["HOST"],
+        postgresql_password=default_database["PASSWORD"],
+    )
+    assert data_sync.postgresql_host == default_database["HOST"]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_postgresql_update_allows_non_target_change_without_password(
+    data_fixture, create_postgresql_test_table
+):
+    default_database = settings.DATABASES["default"]
+    user = data_fixture.create_user()
+    database = data_fixture.create_database_application(user=user)
+    handler = DataSyncHandler()
+
+    data_sync = handler.create_data_sync_table(
+        user=user,
+        database=database,
+        table_name="Test",
+        type_name="postgresql",
+        synced_properties=["id"],
+        postgresql_host=default_database["HOST"],
+        postgresql_username=default_database["USER"],
+        postgresql_password=default_database["PASSWORD"],
+        postgresql_port=default_database["PORT"],
+        postgresql_database=default_database["NAME"],
+        postgresql_table=create_postgresql_test_table,
+        postgresql_sslmode=default_database["OPTIONS"].get("sslmode", "prefer"),
+    )
+
+    data_sync = handler.update_data_sync_table(
+        user=user,
+        data_sync=data_sync,
+        synced_properties=["id"],
+        postgresql_schema="public",
+    )
+    assert data_sync.postgresql_schema == "public"

--- a/changelog/entries/unreleased/bug/5922_fixed_an_issue_where_data_sync_connection_target_fields_host.json
+++ b/changelog/entries/unreleased/bug/5922_fixed_an_issue_where_data_sync_connection_target_fields_host.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed an issue where data sync connection target fields (host, port, URL) could be changed without re-supplying the associated credential.",
+    "issue_origin": "github",
+    "issue_number": 5922,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-18"
+}

--- a/enterprise/backend/src/baserow_enterprise/data_sync/gitlab_issues_data_sync.py
+++ b/enterprise/backend/src/baserow_enterprise/data_sync/gitlab_issues_data_sync.py
@@ -216,6 +216,9 @@ class GitLabIssuesDataSyncType(DataSyncType):
         "gitlab_url",
         "gitlab_project_id",
     ]
+    secret_field_dependencies = {
+        "gitlab_access_token": ["gitlab_url"],
+    }
 
     def prepare_sync_job_values(self, instance):
         # Raise the error so that the job doesn't start and the user is informed with

--- a/enterprise/backend/src/baserow_enterprise/data_sync/jira_issues_data_sync.py
+++ b/enterprise/backend/src/baserow_enterprise/data_sync/jira_issues_data_sync.py
@@ -171,6 +171,9 @@ class JiraIssuesDataSyncType(DataSyncType):
         "jira_authentication",
         "jira_username",
     ]
+    secret_field_dependencies = {
+        "jira_api_token": ["jira_url"],
+    }
 
     def prepare_sync_job_values(self, instance):
         # Raise the error so that the job doesn't start and the user is informed with


### PR DESCRIPTION
## Summary

When updating a data sync via PATCH, changing a connection target field (host/port/URL) without re-supplying the associated credential now returns a 400 error. This prevents the stored credential from being silently redirected to a different endpoint.

### Example

https://github.com/user-attachments/assets/78fd8086-3d64-4b1a-8a03-535067528a84

Closes: #5922 

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
