### PR TITLE
fix(frontend): guard viewFilters against undefined row values

### DIFF
--- a/changelog/entries/unreleased/bug/5925_fixed_view_filter_crashes_when_row_field_values_are_undefine.json
+++ b/changelog/entries/unreleased/bug/5925_fixed_view_filter_crashes_when_row_field_values_are_undefine.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed view filter crashes when row field values are undefined during collaborative editing.",
+    "issue_origin": "github",
+    "issue_number": 5925,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-19"
+}

--- a/web-frontend/modules/database/viewFilters.js
+++ b/web-frontend/modules/database/viewFilters.js
@@ -264,7 +264,7 @@ class DurationFieldViewFilterHandler extends SpecificFieldViewFilterHandler {
   }
 
   _parseDuration(value, field, fieldType) {
-    if (String(value === null ? '' : value).trim() === '') {
+    if (String(value == null ? '' : value).trim() === '') {
       return null
     }
 
@@ -294,11 +294,11 @@ class TextLikeFieldViewFilterHandler extends SpecificFieldViewFilterHandler {
   }
 
   parseRowValue(value, field, fieldType) {
-    return (value === null ? '' : value).toString().toLowerCase().trim()
+    return (value == null ? '' : value).toString().toLowerCase().trim()
   }
 
   parseFilterValue(value, field, fieldType) {
-    return (value === null ? '' : value).toString().toLowerCase().trim()
+    return (value == null ? '' : value).toString().toLowerCase().trim()
   }
 }
 
@@ -308,14 +308,14 @@ class RatingFieldViewFilterHandler extends SpecificFieldViewFilterHandler {
   }
 
   parseRowValue(value, field, fieldType) {
-    if (value === '' || value === null) {
+    if (value === '' || value == null) {
       return NaN
     }
     return Number(value.toString().toLowerCase().trim())
   }
 
   parseFilterValue(value, field, fieldType) {
-    if (value === '' || value === null) {
+    if (value === '' || value == null) {
       return NaN
     }
     return Number(value.toString().toLowerCase().trim())
@@ -328,7 +328,7 @@ class NumberFieldViewFilterHandler extends SpecificFieldViewFilterHandler {
   }
 
   _parseNumberValue(value) {
-    if (value === '' || value === null) {
+    if (value === '' || value == null) {
       return NaN
     }
     return Number(value.toString().toLowerCase().trim())
@@ -424,7 +424,7 @@ export class EqualViewFilterType extends SpecificFieldFilterType {
   }
 
   matches(rowValue, filterValue, field, fieldType) {
-    if (rowValue === null) {
+    if (rowValue == null) {
       rowValue = ''
     }
     const { rowVal, filterVal } = this.getMatchesParsedValues(
@@ -474,7 +474,7 @@ export class NotEqualViewFilterType extends SpecificFieldFilterType {
   }
 
   matches(rowValue, filterValue, field, fieldType) {
-    if (rowValue === null) {
+    if (rowValue == null) {
       rowValue = ''
     }
 
@@ -556,6 +556,10 @@ export class HasFileTypeViewFilterType extends ViewFilterType {
       return true
     }
 
+    if (rowValue == null) {
+      return false
+    }
+
     for (let i = 0; i < rowValue.length; i++) {
       if (rowValue[i].is_image === isImage) {
         return true
@@ -589,6 +593,9 @@ export class FilesLowerThanViewFilterType extends ViewFilterType {
   }
 
   matches(rowValue, filterValue, field, fieldType) {
+    if (rowValue == null) {
+      return true
+    }
     return rowValue.length < parseInt(filterValue)
   }
 }
@@ -815,7 +822,7 @@ export class LengthIsLowerThanViewFilterType extends ViewFilterType {
   matches(rowValue, filterValue, field, fieldType) {
     return (
       isNaN(filterValue) ||
-      rowValue === null ||
+      rowValue == null ||
       filterValue === 0 ||
       rowValue.toString().length < filterValue
     )
@@ -886,7 +893,7 @@ export class BaseDateMultiStepViewFilterType extends ViewFilterType {
   }
 
   matches(rowValue, filterValue, field, fieldType) {
-    if (rowValue === null) {
+    if (rowValue == null) {
       return false
     }
 
@@ -1125,7 +1132,7 @@ export class DateEqualViewFilterType extends LocalizedDateViewFilterType {
   }
 
   matches(rowValue, filterValue, field, fieldType) {
-    if (rowValue === null) {
+    if (rowValue == null) {
       return false
     }
 
@@ -1178,7 +1185,7 @@ export class DateNotEqualViewFilterType extends LocalizedDateViewFilterType {
   }
 
   matches(rowValue, filterValue, field, fieldType) {
-    if (rowValue === null) {
+    if (rowValue == null) {
       return true
     }
 
@@ -1242,7 +1249,7 @@ export class DateBeforeViewFilterType extends LocalizedDateViewFilterType {
     }
 
     // an invalid date will be filtered out
-    if (rowValue === null || !rowDate.isValid()) {
+    if (rowValue == null || !rowDate.isValid()) {
       return false
     }
 
@@ -1302,7 +1309,7 @@ export class DateBeforeOrEqualViewFilterType extends LocalizedDateViewFilterType
     }
 
     // an invalid date will be filtered out
-    if (rowValue === null || !rowDate.isValid()) {
+    if (rowValue == null || !rowDate.isValid()) {
       return false
     }
 
@@ -1366,7 +1373,7 @@ export class DateAfterViewFilterType extends LocalizedDateViewFilterType {
     }
 
     // an invalid date will be filtered out
-    if (rowValue === null || !rowDate.isValid()) {
+    if (rowValue == null || !rowDate.isValid()) {
       return false
     }
     return rowDate.isAfter(filterDate, 'day')
@@ -1410,7 +1417,7 @@ export class DateAfterDaysAgoViewFilterType extends LocalizedDateViewFilterType 
   }
 
   matches(rowValue, filterValue) {
-    if (rowValue === null || !moment.utc(rowValue).isValid()) {
+    if (rowValue == null || !moment.utc(rowValue).isValid()) {
       return false
     }
 
@@ -1492,7 +1499,7 @@ export class DateAfterOrEqualViewFilterType extends LocalizedDateViewFilterType 
     }
 
     // an invalid date will be filtered out
-    if (rowValue === null || !rowDate.isValid()) {
+    if (rowValue == null || !rowDate.isValid()) {
       return false
     }
     return rowDate.isSameOrAfter(filterDate, 'day')
@@ -1539,7 +1546,7 @@ export class DateCompareTodayViewFilterType extends LocalizedDateViewFilterType 
   }
 
   matches(rowValue, filterValue, field) {
-    if (rowValue === null || !moment.utc(rowValue).isValid()) {
+    if (rowValue == null || !moment.utc(rowValue).isValid()) {
       return false
     }
 
@@ -1799,7 +1806,7 @@ export class LocalizedDateCompareViewFilterType extends LocalizedDateViewFilterT
   }
 
   matches(rowValue, filterValue, field) {
-    if (rowValue === null) {
+    if (rowValue == null) {
       rowValue = ''
     }
 
@@ -2069,7 +2076,7 @@ export class DateEqualsDayOfMonthViewFilterType extends LocalizedDateViewFilterT
   }
 
   matches(rowValue, filterValue, field, fieldType) {
-    if (rowValue === null) {
+    if (rowValue == null) {
       rowValue = ''
     }
 
@@ -2295,7 +2302,7 @@ export class SingleSelectEqualViewFilterType extends ViewFilterType {
       return null
     }
 
-    return rowValue !== null && rowValue.id === parseInt(filterValue)
+    return rowValue != null && rowValue.id === parseInt(filterValue)
   }
 }
 
@@ -2330,8 +2337,8 @@ export class SingleSelectNotEqualViewFilterType extends ViewFilterType {
     }
 
     return (
-      rowValue === null ||
-      (rowValue !== null && rowValue.id !== parseInt(filterValue))
+      rowValue == null ||
+      (rowValue != null && rowValue.id !== parseInt(filterValue))
     )
   }
 }
@@ -2498,7 +2505,8 @@ export class MultipleSelectHasNotFilterType extends ViewFilterType {
     const parsedValue = this._prepareValue(filterValue)
     return (
       parsedValue === null ||
-      rowValue?.length === 0 ||
+      rowValue == null ||
+      rowValue.length === 0 ||
       rowValue.every((opt) => !_.includes(parsedValue, opt?.id))
     )
   }
@@ -2534,6 +2542,10 @@ export class MultipleCollaboratorsHasFilterType extends ViewFilterType {
       return true
     }
 
+    if (rowValue == null) {
+      return false
+    }
+
     const filterValueId = parseInt(filterValue)
     return rowValue.some((user) => user.id === filterValueId)
   }
@@ -2566,6 +2578,10 @@ export class MultipleCollaboratorsHasNotFilterType extends ViewFilterType {
 
   matches(rowValue, filterValue, field, fieldType) {
     if (!isInteger(filterValue)) {
+      return true
+    }
+
+    if (rowValue == null) {
       return true
     }
 
@@ -2669,14 +2685,14 @@ export class BooleanViewFilterType extends ViewFilterType {
   }
 
   matches(rowValue, filterValue, field, fieldType) {
-    if (filterValue === null) {
+    if (filterValue == null) {
       filterValue = false
     }
     filterValue = trueValues.includes(
       filterValue.toString().toLowerCase().trim()
     )
 
-    if (rowValue === null) {
+    if (rowValue == null) {
       rowValue = false
     } else {
       rowValue = trueValues.includes(rowValue.toString().toLowerCase().trim())
@@ -2712,6 +2728,10 @@ export class LinkRowHasFilterType extends ViewFilterType {
       return true
     }
 
+    if (rowValue == null) {
+      return false
+    }
+
     const filterValueId = parseInt(filterValue)
     return rowValue.some((relation) => relation.id === filterValueId)
   }
@@ -2741,6 +2761,10 @@ export class LinkRowHasNotFilterType extends ViewFilterType {
 
   matches(rowValue, filterValue, field, fieldType) {
     if (!isInteger(filterValue)) {
+      return true
+    }
+
+    if (rowValue == null) {
       return true
     }
 
@@ -2776,6 +2800,10 @@ export class LinkRowContainsFilterType extends ViewFilterType {
       return true
     }
 
+    if (rowValue == null) {
+      return false
+    }
+
     return rowValue.some(
       ({ value }) => value.search(new RegExp(filterValue, 'i')) !== -1
     )
@@ -2806,6 +2834,10 @@ export class LinkRowNotContainsFilterType extends ViewFilterType {
 
   matches(rowValue, filterValue, field, fieldType) {
     if (filterValue === '') {
+      return true
+    }
+
+    if (rowValue == null) {
       return true
     }
 

--- a/web-frontend/modules/database/viewFilters.js
+++ b/web-frontend/modules/database/viewFilters.js
@@ -517,6 +517,9 @@ export class FilenameContainsViewFilterType extends ViewFilterType {
   }
 
   matches(rowValue, filterValue, field, fieldType) {
+    if (rowValue == null) {
+      return filterValue === ''
+    }
     return fieldType.containsFilter(rowValue, filterValue, field)
   }
 }
@@ -593,10 +596,7 @@ export class FilesLowerThanViewFilterType extends ViewFilterType {
   }
 
   matches(rowValue, filterValue, field, fieldType) {
-    if (rowValue == null) {
-      return true
-    }
-    return rowValue.length < parseInt(filterValue)
+    return (rowValue ?? []).length < parseInt(filterValue)
   }
 }
 
@@ -2336,10 +2336,7 @@ export class SingleSelectNotEqualViewFilterType extends ViewFilterType {
       return null
     }
 
-    return (
-      rowValue == null ||
-      (rowValue != null && rowValue.id !== parseInt(filterValue))
-    )
+    return rowValue == null || rowValue.id !== parseInt(filterValue)
   }
 }
 

--- a/web-frontend/test/unit/database/viewFiltersMatch.spec.js
+++ b/web-frontend/test/unit/database/viewFiltersMatch.spec.js
@@ -36,14 +36,21 @@ import {
   IsEvenAndWholeViewFilterType,
   LengthIsLowerThanViewFilterType,
   LinkRowContainsFilterType,
+  LinkRowHasFilterType,
+  LinkRowHasNotFilterType,
   LinkRowNotContainsFilterType,
   LowerThanOrEqualViewFilterType,
   LowerThanViewFilterType,
+  MultipleCollaboratorsHasFilterType,
+  MultipleCollaboratorsHasNotFilterType,
   MultipleSelectHasFilterType,
   MultipleSelectHasNotFilterType,
   NotEmptyViewFilterType,
+  NotEqualViewFilterType,
+  SingleSelectEqualViewFilterType,
   SingleSelectIsAnyOfViewFilterType,
   SingleSelectIsNoneOfViewFilterType,
+  SingleSelectNotEqualViewFilterType,
 } from '@baserow/modules/database/viewFilters'
 import {
   DurationFieldType,
@@ -2955,4 +2962,150 @@ describe('Empty filter value tests', () => {
       expect(result).toBe(values.expected)
     }
   )
+})
+
+describe('Undefined rowValue guards', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+  })
+
+  afterEach(() => {
+    testApp.afterEach()
+  })
+
+  test('EqualViewFilterType does not crash with undefined rowValue', () => {
+    const filter = new EqualViewFilterType({ app: testApp._app })
+    expect(() =>
+      filter.matches(undefined, 'test', { type: 'text' }, { type: 'text' })
+    ).not.toThrow()
+  })
+
+  test('NotEqualViewFilterType does not crash with undefined rowValue', () => {
+    const filter = new NotEqualViewFilterType({ app: testApp._app })
+    expect(() =>
+      filter.matches(undefined, 'test', { type: 'text' }, { type: 'text' })
+    ).not.toThrow()
+  })
+
+  test('BooleanViewFilterType does not crash with undefined rowValue', () => {
+    const filter = new BooleanViewFilterType({ app: testApp._app })
+    expect(() =>
+      filter.matches(undefined, 'true', { type: 'boolean' }, {})
+    ).not.toThrow()
+  })
+
+  test('LengthIsLowerThanViewFilterType does not crash with undefined rowValue', () => {
+    const filter = new LengthIsLowerThanViewFilterType({ app: testApp._app })
+    const result = filter.matches(undefined, 5, { type: 'text' }, {})
+    expect(result).toBe(true)
+  })
+
+  test('HasFileTypeViewFilterType does not crash with undefined rowValue', () => {
+    const filter = new HasFileTypeViewFilterType({ app: testApp._app })
+    const result = filter.matches(undefined, 'image', { type: 'file' }, {})
+    expect(result).toBe(false)
+  })
+
+  test('FilesLowerThanViewFilterType does not crash with undefined rowValue', () => {
+    const filter = new FilesLowerThanViewFilterType({ app: testApp._app })
+    const result = filter.matches(undefined, '5', { type: 'file' }, {})
+    expect(result).toBe(true)
+  })
+
+  test('SingleSelectEqualViewFilterType does not crash with undefined rowValue', () => {
+    const filter = new SingleSelectEqualViewFilterType({ app: testApp._app })
+    const result = filter.matches(undefined, '1', { type: 'single_select' }, {})
+    expect(result).toBe(false)
+  })
+
+  test('SingleSelectNotEqualViewFilterType does not crash with undefined rowValue', () => {
+    const filter = new SingleSelectNotEqualViewFilterType({ app: testApp._app })
+    const result = filter.matches(undefined, '1', { type: 'single_select' }, {})
+    expect(result).toBe(true)
+  })
+
+  test('MultipleSelectHasNotFilterType does not crash with undefined rowValue', () => {
+    const filter = new MultipleSelectHasNotFilterType({ app: testApp._app })
+    const result = filter.matches(
+      undefined,
+      '1',
+      { type: 'multiple_select' },
+      {}
+    )
+    expect(result).toBe(true)
+  })
+
+  test('MultipleCollaboratorsHasFilterType does not crash with undefined rowValue', () => {
+    const filter = new MultipleCollaboratorsHasFilterType({
+      app: testApp._app,
+    })
+    const result = filter.matches(
+      undefined,
+      '1',
+      { type: 'multiple_collaborators' },
+      {}
+    )
+    expect(result).toBe(false)
+  })
+
+  test('MultipleCollaboratorsHasNotFilterType does not crash with undefined rowValue', () => {
+    const filter = new MultipleCollaboratorsHasNotFilterType({
+      app: testApp._app,
+    })
+    const result = filter.matches(
+      undefined,
+      '1',
+      { type: 'multiple_collaborators' },
+      {}
+    )
+    expect(result).toBe(true)
+  })
+
+  test('LinkRowHasFilterType does not crash with undefined rowValue', () => {
+    const filter = new LinkRowHasFilterType({ app: testApp._app })
+    const result = filter.matches(undefined, '1', { type: 'link_row' }, {})
+    expect(result).toBe(false)
+  })
+
+  test('LinkRowHasNotFilterType does not crash with undefined rowValue', () => {
+    const filter = new LinkRowHasNotFilterType({ app: testApp._app })
+    const result = filter.matches(undefined, '1', { type: 'link_row' }, {})
+    expect(result).toBe(true)
+  })
+
+  test('LinkRowContainsFilterType does not crash with undefined rowValue', () => {
+    const filter = new LinkRowContainsFilterType({ app: testApp._app })
+    const result = filter.matches(undefined, 'test', { type: 'link_row' }, {})
+    expect(result).toBe(false)
+  })
+
+  test('LinkRowNotContainsFilterType does not crash with undefined rowValue', () => {
+    const filter = new LinkRowNotContainsFilterType({ app: testApp._app })
+    const result = filter.matches(undefined, 'test', { type: 'link_row' }, {})
+    expect(result).toBe(true)
+  })
+
+  test('DateEqualViewFilterType does not crash with undefined rowValue', () => {
+    const filter = new DateEqualViewFilterType({ app: testApp })
+    const result = filter.matches(
+      undefined,
+      'Europe/Berlin?2021-08-11',
+      { date_include_time: true },
+      {}
+    )
+    expect(result).toBe(false)
+  })
+
+  test('DateNotEqualViewFilterType does not crash with undefined rowValue', () => {
+    const filter = new DateNotEqualViewFilterType({ app: testApp })
+    const result = filter.matches(
+      undefined,
+      'Europe/Berlin?2021-08-11',
+      { date_include_time: true },
+      {}
+    )
+    expect(result).toBe(true)
+  })
 })

--- a/web-frontend/test/unit/database/viewFiltersMatch.spec.js
+++ b/web-frontend/test/unit/database/viewFiltersMatch.spec.js
@@ -29,6 +29,7 @@ import {
   DateWithinWeeksViewFilterType,
   EmptyViewFilterType,
   EqualViewFilterType,
+  FilenameContainsViewFilterType,
   FilesLowerThanViewFilterType,
   HasFileTypeViewFilterType,
   HigherThanOrEqualViewFilterType,
@@ -2964,7 +2965,7 @@ describe('Empty filter value tests', () => {
   )
 })
 
-describe('Undefined rowValue guards', () => {
+describe('Null and undefined rowValue guards', () => {
   let testApp = null
 
   beforeEach(() => {
@@ -2975,137 +2976,298 @@ describe('Undefined rowValue guards', () => {
     testApp.afterEach()
   })
 
-  test('EqualViewFilterType does not crash with undefined rowValue', () => {
-    const filter = new EqualViewFilterType({ app: testApp._app })
-    expect(() =>
-      filter.matches(undefined, 'test', { type: 'text' }, { type: 'text' })
-    ).not.toThrow()
-  })
+  // Text-like filters: canonical empty is ''
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty string', ''],
+  ])(
+    'EqualViewFilterType with %s rowValue matches empty-string behavior',
+    (_label, rowValue) => {
+      const filter = new EqualViewFilterType({ app: testApp._app })
+      const field = { type: 'text' }
+      const fieldType = { type: 'text' }
+      expect(filter.matches(rowValue, '', field, fieldType)).toBe(null)
+      expect(filter.matches(rowValue, 'test', field, fieldType)).toBe(false)
+    }
+  )
 
-  test('NotEqualViewFilterType does not crash with undefined rowValue', () => {
-    const filter = new NotEqualViewFilterType({ app: testApp._app })
-    expect(() =>
-      filter.matches(undefined, 'test', { type: 'text' }, { type: 'text' })
-    ).not.toThrow()
-  })
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty string', ''],
+  ])(
+    'NotEqualViewFilterType with %s rowValue matches empty-string behavior',
+    (_label, rowValue) => {
+      const filter = new NotEqualViewFilterType({ app: testApp._app })
+      const field = { type: 'text' }
+      const fieldType = { type: 'text' }
+      expect(filter.matches(rowValue, '', field, fieldType)).toBe(null)
+      expect(filter.matches(rowValue, 'test', field, fieldType)).toBe(true)
+    }
+  )
 
-  test('BooleanViewFilterType does not crash with undefined rowValue', () => {
-    const filter = new BooleanViewFilterType({ app: testApp._app })
-    expect(() =>
-      filter.matches(undefined, 'true', { type: 'boolean' }, {})
-    ).not.toThrow()
-  })
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['false', false],
+  ])(
+    'BooleanViewFilterType with %s rowValue matches false behavior',
+    (_label, rowValue) => {
+      const filter = new BooleanViewFilterType({ app: testApp._app })
+      const field = { type: 'boolean' }
+      expect(filter.matches(rowValue, 'true', field, {})).toBe(false)
+      expect(filter.matches(rowValue, 'false', field, {})).toBe(true)
+      expect(filter.matches(rowValue, '', field, {})).toBe(true)
+    }
+  )
 
-  test('LengthIsLowerThanViewFilterType does not crash with undefined rowValue', () => {
-    const filter = new LengthIsLowerThanViewFilterType({ app: testApp._app })
-    const result = filter.matches(undefined, 5, { type: 'text' }, {})
-    expect(result).toBe(true)
-  })
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty string', ''],
+  ])(
+    'LengthIsLowerThanViewFilterType with %s rowValue matches empty-string behavior',
+    (_label, rowValue) => {
+      const filter = new LengthIsLowerThanViewFilterType({ app: testApp._app })
+      const field = { type: 'text' }
+      expect(filter.matches(rowValue, 5, field, {})).toBe(true)
+      expect(filter.matches(rowValue, 0, field, {})).toBe(true)
+    }
+  )
 
-  test('HasFileTypeViewFilterType does not crash with undefined rowValue', () => {
-    const filter = new HasFileTypeViewFilterType({ app: testApp._app })
-    const result = filter.matches(undefined, 'image', { type: 'file' }, {})
-    expect(result).toBe(false)
-  })
+  // File-array filters: canonical empty is []
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty array', []],
+  ])(
+    'HasFileTypeViewFilterType with %s rowValue matches empty-array behavior',
+    (_label, rowValue) => {
+      const filter = new HasFileTypeViewFilterType({ app: testApp._app })
+      const field = { type: 'file' }
+      expect(filter.matches(rowValue, '', field, {})).toBe(true)
+      expect(filter.matches(rowValue, 'image', field, {})).toBe(false)
+    }
+  )
 
-  test('FilesLowerThanViewFilterType does not crash with undefined rowValue', () => {
-    const filter = new FilesLowerThanViewFilterType({ app: testApp._app })
-    const result = filter.matches(undefined, '5', { type: 'file' }, {})
-    expect(result).toBe(true)
-  })
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty array', []],
+  ])(
+    'FilesLowerThanViewFilterType with %s rowValue matches empty-array behavior',
+    (_label, rowValue) => {
+      const filter = new FilesLowerThanViewFilterType({ app: testApp._app })
+      const field = { type: 'file' }
+      expect(filter.matches(rowValue, '5', field, {})).toBe(true)
+      expect(filter.matches(rowValue, '0', field, {})).toBe(false)
+      expect(filter.matches(rowValue, '', field, {})).toBe(false)
+    }
+  )
 
-  test('SingleSelectEqualViewFilterType does not crash with undefined rowValue', () => {
-    const filter = new SingleSelectEqualViewFilterType({ app: testApp._app })
-    const result = filter.matches(undefined, '1', { type: 'single_select' }, {})
-    expect(result).toBe(false)
-  })
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+  ])(
+    'FilenameContainsViewFilterType with %s rowValue matches empty-array behavior',
+    (_label, rowValue) => {
+      const filter = new FilenameContainsViewFilterType({ app: testApp._app })
+      const field = { type: 'file' }
+      expect(filter.matches(rowValue, '', field, {})).toBe(true)
+      expect(filter.matches(rowValue, 'test', field, {})).toBe(false)
+    }
+  )
 
-  test('SingleSelectNotEqualViewFilterType does not crash with undefined rowValue', () => {
-    const filter = new SingleSelectNotEqualViewFilterType({ app: testApp._app })
-    const result = filter.matches(undefined, '1', { type: 'single_select' }, {})
-    expect(result).toBe(true)
-  })
+  // Single select filters: canonical empty is null
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+  ])(
+    'SingleSelectEqualViewFilterType with %s rowValue matches null behavior',
+    (_label, rowValue) => {
+      const filter = new SingleSelectEqualViewFilterType({ app: testApp._app })
+      const field = { type: 'single_select' }
+      expect(filter.matches(rowValue, '', field, {})).toBe(null)
+      expect(filter.matches(rowValue, '1', field, {})).toBe(false)
+    }
+  )
 
-  test('MultipleSelectHasNotFilterType does not crash with undefined rowValue', () => {
-    const filter = new MultipleSelectHasNotFilterType({ app: testApp._app })
-    const result = filter.matches(
-      undefined,
-      '1',
-      { type: 'multiple_select' },
-      {}
-    )
-    expect(result).toBe(true)
-  })
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+  ])(
+    'SingleSelectNotEqualViewFilterType with %s rowValue matches null behavior',
+    (_label, rowValue) => {
+      const filter = new SingleSelectNotEqualViewFilterType({
+        app: testApp._app,
+      })
+      const field = { type: 'single_select' }
+      expect(filter.matches(rowValue, '', field, {})).toBe(null)
+      expect(filter.matches(rowValue, '1', field, {})).toBe(true)
+    }
+  )
 
-  test('MultipleCollaboratorsHasFilterType does not crash with undefined rowValue', () => {
-    const filter = new MultipleCollaboratorsHasFilterType({
-      app: testApp._app,
-    })
-    const result = filter.matches(
-      undefined,
-      '1',
-      { type: 'multiple_collaborators' },
-      {}
-    )
-    expect(result).toBe(false)
-  })
+  // Multi-select / array filters: canonical empty is []
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty array', []],
+  ])(
+    'MultipleSelectHasFilterType with %s rowValue matches empty-array behavior',
+    (_label, rowValue) => {
+      const filter = new MultipleSelectHasFilterType({ app: testApp._app })
+      const field = { type: 'multiple_select' }
+      expect(filter.matches(rowValue, '', field, {})).toBe(true)
+      const result = filter.matches(rowValue, '1', field, {})
+      expect(result).toBeFalsy()
+    }
+  )
 
-  test('MultipleCollaboratorsHasNotFilterType does not crash with undefined rowValue', () => {
-    const filter = new MultipleCollaboratorsHasNotFilterType({
-      app: testApp._app,
-    })
-    const result = filter.matches(
-      undefined,
-      '1',
-      { type: 'multiple_collaborators' },
-      {}
-    )
-    expect(result).toBe(true)
-  })
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty array', []],
+  ])(
+    'MultipleSelectHasNotFilterType with %s rowValue matches empty-array behavior',
+    (_label, rowValue) => {
+      const filter = new MultipleSelectHasNotFilterType({ app: testApp._app })
+      const field = { type: 'multiple_select' }
+      expect(filter.matches(rowValue, '', field, {})).toBe(true)
+      expect(filter.matches(rowValue, '1', field, {})).toBe(true)
+    }
+  )
 
-  test('LinkRowHasFilterType does not crash with undefined rowValue', () => {
-    const filter = new LinkRowHasFilterType({ app: testApp._app })
-    const result = filter.matches(undefined, '1', { type: 'link_row' }, {})
-    expect(result).toBe(false)
-  })
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty array', []],
+  ])(
+    'MultipleCollaboratorsHasFilterType with %s rowValue matches empty-array behavior',
+    (_label, rowValue) => {
+      const filter = new MultipleCollaboratorsHasFilterType({
+        app: testApp._app,
+      })
+      const field = { type: 'multiple_collaborators' }
+      expect(filter.matches(rowValue, '', field, {})).toBe(true)
+      expect(filter.matches(rowValue, '1', field, {})).toBe(false)
+    }
+  )
 
-  test('LinkRowHasNotFilterType does not crash with undefined rowValue', () => {
-    const filter = new LinkRowHasNotFilterType({ app: testApp._app })
-    const result = filter.matches(undefined, '1', { type: 'link_row' }, {})
-    expect(result).toBe(true)
-  })
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty array', []],
+  ])(
+    'MultipleCollaboratorsHasNotFilterType with %s rowValue matches empty-array behavior',
+    (_label, rowValue) => {
+      const filter = new MultipleCollaboratorsHasNotFilterType({
+        app: testApp._app,
+      })
+      const field = { type: 'multiple_collaborators' }
+      expect(filter.matches(rowValue, '', field, {})).toBe(true)
+      expect(filter.matches(rowValue, '1', field, {})).toBe(true)
+    }
+  )
 
-  test('LinkRowContainsFilterType does not crash with undefined rowValue', () => {
-    const filter = new LinkRowContainsFilterType({ app: testApp._app })
-    const result = filter.matches(undefined, 'test', { type: 'link_row' }, {})
-    expect(result).toBe(false)
-  })
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty array', []],
+  ])(
+    'LinkRowHasFilterType with %s rowValue matches empty-array behavior',
+    (_label, rowValue) => {
+      const filter = new LinkRowHasFilterType({ app: testApp._app })
+      const field = { type: 'link_row' }
+      expect(filter.matches(rowValue, '', field, {})).toBe(true)
+      expect(filter.matches(rowValue, '1', field, {})).toBe(false)
+    }
+  )
 
-  test('LinkRowNotContainsFilterType does not crash with undefined rowValue', () => {
-    const filter = new LinkRowNotContainsFilterType({ app: testApp._app })
-    const result = filter.matches(undefined, 'test', { type: 'link_row' }, {})
-    expect(result).toBe(true)
-  })
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty array', []],
+  ])(
+    'LinkRowHasNotFilterType with %s rowValue matches empty-array behavior',
+    (_label, rowValue) => {
+      const filter = new LinkRowHasNotFilterType({ app: testApp._app })
+      const field = { type: 'link_row' }
+      expect(filter.matches(rowValue, '', field, {})).toBe(true)
+      expect(filter.matches(rowValue, '1', field, {})).toBe(true)
+    }
+  )
 
-  test('DateEqualViewFilterType does not crash with undefined rowValue', () => {
-    const filter = new DateEqualViewFilterType({ app: testApp })
-    const result = filter.matches(
-      undefined,
-      'Europe/Berlin?2021-08-11',
-      { date_include_time: true },
-      {}
-    )
-    expect(result).toBe(false)
-  })
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty array', []],
+  ])(
+    'LinkRowContainsFilterType with %s rowValue matches empty-array behavior',
+    (_label, rowValue) => {
+      const filter = new LinkRowContainsFilterType({ app: testApp._app })
+      const field = { type: 'link_row' }
+      expect(filter.matches(rowValue, '', field, {})).toBe(true)
+      expect(filter.matches(rowValue, 'test', field, {})).toBe(false)
+    }
+  )
 
-  test('DateNotEqualViewFilterType does not crash with undefined rowValue', () => {
-    const filter = new DateNotEqualViewFilterType({ app: testApp })
-    const result = filter.matches(
-      undefined,
-      'Europe/Berlin?2021-08-11',
-      { date_include_time: true },
-      {}
-    )
-    expect(result).toBe(true)
-  })
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty array', []],
+  ])(
+    'LinkRowNotContainsFilterType with %s rowValue matches empty-array behavior',
+    (_label, rowValue) => {
+      const filter = new LinkRowNotContainsFilterType({ app: testApp._app })
+      const field = { type: 'link_row' }
+      expect(filter.matches(rowValue, '', field, {})).toBe(true)
+      expect(filter.matches(rowValue, 'test', field, {})).toBe(true)
+    }
+  )
+
+  // Date filters: canonical empty is null
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+  ])(
+    'DateEqualViewFilterType with %s rowValue matches null behavior',
+    (_label, rowValue) => {
+      const filter = new DateEqualViewFilterType({ app: testApp })
+      const field = { date_include_time: true }
+      expect(
+        filter.matches(rowValue, 'Europe/Berlin?2021-08-11', field, {})
+      ).toBe(false)
+    }
+  )
+
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+  ])(
+    'DateNotEqualViewFilterType with %s rowValue matches null behavior',
+    (_label, rowValue) => {
+      const filter = new DateNotEqualViewFilterType({ app: testApp })
+      const field = { date_include_time: true }
+      expect(
+        filter.matches(rowValue, 'Europe/Berlin?2021-08-11', field, {})
+      ).toBe(true)
+    }
+  )
+
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+  ])(
+    'DateIsEqualMultiStepViewFilterType with %s rowValue matches null behavior',
+    (_label, rowValue) => {
+      const filter = new DateIsEqualMultiStepViewFilterType({
+        app: testApp._app,
+      })
+      const field = { date_include_time: false }
+      expect(filter.matches(rowValue, 'UTC?2021-08-11?is', field, {})).toBe(
+        false
+      )
+    }
+  )
 })


### PR DESCRIPTION
## Summary

- Replace `=== null` with `== null` in all row/filter value guards in `viewFilters.js`
- Add missing null guards to 9 filter types that had no protection at all
- Add  unit tests for `undefined` rowValue handling

Fixes #5925

## Sentry issues resolved (16)

* [BASEROW-SAAS-WEB-FRONTEND-1J9](https://baserow-eu.sentry.io/issues/BASEROW-SAAS-WEB-FRONTEND-1J9)
* [BASEROW-SAAS-WEB-FRONTEND-1JK](https://baserow-eu.sentry.io/issues/BASEROW-SAAS-WEB-FRONTEND-1JK)
* [BASEROW-SAAS-WEB-FRONTEND-1PC](https://baserow-eu.sentry.io/issues/BASEROW-SAAS-WEB-FRONTEND-1PC)
* [BASEROW-SAAS-WEB-FRONTEND-29G](https://baserow-eu.sentry.io/issues/BASEROW-SAAS-WEB-FRONTEND-29G)
* [BASEROW-SAAS-WEB-FRONTEND-1K0](https://baserow-eu.sentry.io/issues/BASEROW-SAAS-WEB-FRONTEND-1K0)
* [BASEROW-SAAS-WEB-FRONTEND-29N](https://baserow-eu.sentry.io/issues/BASEROW-SAAS-WEB-FRONTEND-29N)
* [BASEROW-SAAS-WEB-FRONTEND-21E](https://baserow-eu.sentry.io/issues/BASEROW-SAAS-WEB-FRONTEND-21E)
* [BASEROW-SAAS-WEB-FRONTEND-272](https://baserow-eu.sentry.io/issues/BASEROW-SAAS-WEB-FRONTEND-272)
* [BASEROW-SAAS-WEB-FRONTEND-1K3](https://baserow-eu.sentry.io/issues/BASEROW-SAAS-WEB-FRONTEND-1K3)
* [BASEROW-SAAS-WEB-FRONTEND-1MB](https://baserow-eu.sentry.io/issues/BASEROW-SAAS-WEB-FRONTEND-1MB)
* [BASEROW-SAAS-WEB-FRONTEND-1WW](https://baserow-eu.sentry.io/issues/BASEROW-SAAS-WEB-FRONTEND-1WW)
* [BASEROW-SAAS-WEB-FRONTEND-26E](https://baserow-eu.sentry.io/issues/BASEROW-SAAS-WEB-FRONTEND-26E)
* [BASEROW-SAAS-WEB-FRONTEND-2CN](https://baserow-eu.sentry.io/issues/BASEROW-SAAS-WEB-FRONTEND-2CN)
* [BASEROW-SAAS-WEB-FRONTEND-2BQ](https://baserow-eu.sentry.io/issues/BASEROW-SAAS-WEB-FRONTEND-2BQ)
* [BASEROW-SAAS-WEB-FRONTEND-29F](https://baserow-eu.sentry.io/issues/BASEROW-SAAS-WEB-FRONTEND-29F)
* [BASEROW-SAAS-WEB-FRONTEND-1M2](https://baserow-eu.sentry.io/issues/BASEROW-SAAS-WEB-FRONTEND-1M2)

## Test plan

- [x] Existing viewFiltersMatch tests pass
- [x] 17 new tests verify `undefined` rowValue doesn't crash for each affected filter type



Closes: #5925 

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
