### PR TITLE
fix: serialize only updated fields in WebSocket row update events

### DIFF
--- a/backend/src/baserow/contrib/database/rows/handler.py
+++ b/backend/src/baserow/contrib/database/rows/handler.py
@@ -1262,6 +1262,9 @@ class RowHandler:
             row_ids=[row.id],
         )
 
+        # rows_before_update is serialized in full so the frontend can
+        # reconstruct the pre-update state for filter/sort/search transitions.
+        # rows can be partial because the frontend merges it onto the existing row.
         rows_updated.send(
             self,
             rows=rows,
@@ -2734,6 +2737,9 @@ class RowHandler:
             # replace updated rows with fresh versions with formula values
             cascade_updated.updated_rows = cascade_updated_rows
 
+        # rows_before_update is serialized in full so the frontend can
+        # reconstruct the pre-update state for filter/sort/search transitions.
+        # rows can be partial because the frontend merges it onto the existing row.
         rows_updated.send(
             self,
             rows=updated_rows_to_return,

--- a/backend/src/baserow/contrib/database/rows/handler.py
+++ b/backend/src/baserow/contrib/database/rows/handler.py
@@ -1204,9 +1204,12 @@ class RowHandler:
             )
             getattr(row, name).set(value)
 
+        field_objects_to_always_update = model.get_field_objects_to_always_update()
         always_updated_fields = ["updated_on"] + [
-            fo["field"].db_column for fo in model.get_field_objects_to_always_update()
+            fo["field"].db_column for fo in field_objects_to_always_update
         ]
+        for field_object in field_objects_to_always_update:
+            updated_field_ids.add(field_object["field"].id)
         if getattr(model, LAST_MODIFIED_BY_COLUMN_NAME, None):
             setattr(row, LAST_MODIFIED_BY_COLUMN_NAME, user if user.id else None)
             always_updated_fields.append(LAST_MODIFIED_BY_COLUMN_NAME)
@@ -1240,6 +1243,11 @@ class RowHandler:
                 table, [row], model, updated_field_ids, m2m_change_tracker
             )
         )
+
+        updated_field_ids.update(
+            field.id for field in dependant_fields if field.table_id == table.id
+        )
+
         # We need to refresh here as ExpressionFields might have had their values
         # updated. Django does not support UPDATE .... RETURNING and so we need to
         # query for the rows updated values instead.
@@ -1262,6 +1270,7 @@ class RowHandler:
             model=model,
             before_return=before_return,
             updated_field_ids=updated_field_ids,
+            serialize_only_updated_fields=True,
             m2m_change_tracker=m2m_change_tracker,
             fields=[f for f in updated_fields if f.id in updated_field_ids],
             dependant_fields=dependant_fields,
@@ -2733,6 +2742,7 @@ class RowHandler:
             model=model,
             before_return=before_return,
             updated_field_ids=updated_field_ids,
+            serialize_only_updated_fields=True,
             m2m_change_tracker=m2m_change_tracker,
             send_realtime_update=send_realtime_update,
             send_webhook_events=send_webhook_events,

--- a/backend/tests/baserow/contrib/database/ws/test_ws_rows_signals.py
+++ b/backend/tests/baserow/contrib/database/ws/test_ws_rows_signals.py
@@ -16,7 +16,11 @@ from baserow.contrib.database.rows.registries import (
     RowMetadataType,
     row_metadata_registry,
 )
-from baserow.test_utils.helpers import AnyInt, register_instance_temporarily
+from baserow.test_utils.helpers import (
+    AnyInt,
+    register_instance_temporarily,
+    setup_interesting_test_table,
+)
 
 
 @pytest.mark.django_db(transaction=True)
@@ -125,12 +129,15 @@ def test_row_updated(mock_broadcast_to_channel_group, data_fixture):
     assert args[0][0] == f"table-{table.id}"
     assert args[0][1]["type"] == "rows_updated"
     assert args[0][1]["table_id"] == table.id
+    # before_return still contains all fields (before_rows_update signal
+    # does not pass serialize_only_updated_fields)
     assert args[0][1]["rows_before_update"][0]["id"] == row.id
     assert args[0][1]["rows_before_update"][0][f"field_{field.id}"] is None
     assert args[0][1]["rows_before_update"][0][f"field_{field_2.id}"] is None
+    # rows payload contains only the updated field (serialize_only_updated_fields=True)
     assert args[0][1]["rows"][0]["id"] == row.id
     assert args[0][1]["rows"][0][f"field_{field.id}"] == "Test"
-    assert args[0][1]["rows"][0][f"field_{field_2.id}"] is None
+    assert f"field_{field_2.id}" not in args[0][1]["rows"][0]
     assert args[0][1]["metadata"] == {}
 
     row.refresh_from_db()
@@ -146,7 +153,8 @@ def test_row_updated(mock_broadcast_to_channel_group, data_fixture):
     assert args[0][1]["table_id"] == table.id
     assert args[0][1]["rows"][0]["id"] == row.id
     assert args[0][1]["rows"][0][f"field_{field.id}"] == "First"
-    assert args[0][1]["rows"][0][f"field_{field_2.id}"] == "Second"
+    # field_2 not in payload — only field_1 was updated
+    assert f"field_{field_2.id}" not in args[0][1]["rows"][0]
     assert args[0][1]["metadata"] == {}
 
 
@@ -198,8 +206,94 @@ def test_row_updated_with_metadata(mock_broadcast_to_channel_group, data_fixture
     assert args[0][1]["rows_before_update"][0][f"field_{field_2.id}"] is None
     assert args[0][1]["rows"][0]["id"] == row.id
     assert args[0][1]["rows"][0][f"field_{field.id}"] == "Test"
-    assert args[0][1]["rows"][0][f"field_{field_2.id}"] is None
+    assert f"field_{field_2.id}" not in args[0][1]["rows"][0]
     assert args[0][1]["metadata"] == {"1": {"row_id": row.id}}
+
+
+@pytest.mark.django_db(transaction=True)
+@patch("baserow.ws.registries.broadcast_to_channel_group")
+def test_row_updated_serializes_only_updated_fields(
+    mock_broadcast_to_channel_group, data_fixture
+):
+    table, user, row, _, context = setup_interesting_test_table(data_fixture)
+    n2id = context["name_to_field_id"]
+    text_field_id = n2id["text"]
+
+    mock_broadcast_to_channel_group.reset_mock()
+    RowHandler().update_row_by_id(
+        user=user,
+        table=table,
+        row_id=row.id,
+        values={f"field_{text_field_id}": "changed"},
+    )
+
+    args = mock_broadcast_to_channel_group.delay.call_args
+    payload = args[0][1]
+    assert payload["type"] == "rows_updated"
+
+    row_data = payload["rows"][0]
+    updated_ids = set(payload["updated_field_ids"])
+    row_field_keys = {k for k in row_data if k.startswith("field_")}
+
+    assert row_data[f"field_{text_field_id}"] == "changed"
+    assert f"field_{n2id['last_modified_datetime_us']}" in row_data
+    for key in row_field_keys:
+        fid = int(key.split("_", 1)[1])
+        assert fid in updated_ids, f"{key} in payload but not in updated_field_ids"
+
+    unrelated_keys = {
+        f"field_{n2id[name]}"
+        for name in ("long_text", "url", "email", "boolean", "phone_number")
+    }
+    for key in unrelated_keys:
+        assert key not in row_data, f"{key} should not be in partial payload"
+
+    before_data = payload["rows_before_update"][0]
+    for key in unrelated_keys:
+        assert key in before_data, f"{key} missing from before_rows_update"
+
+
+@pytest.mark.django_db(transaction=True)
+@patch("baserow.ws.registries.broadcast_to_channel_group")
+def test_batch_row_updated_serializes_only_updated_fields(
+    mock_broadcast_to_channel_group, data_fixture
+):
+    table, user, row, blank_row, context = setup_interesting_test_table(data_fixture)
+    n2id = context["name_to_field_id"]
+    text_field_id = n2id["text"]
+
+    mock_broadcast_to_channel_group.reset_mock()
+    with transaction.atomic():
+        RowHandler().update_rows(
+            user,
+            table,
+            [
+                {"id": row.id, f"field_{text_field_id}": "batch1"},
+                {"id": blank_row.id, f"field_{text_field_id}": "batch2"},
+            ],
+        )
+
+    args = mock_broadcast_to_channel_group.delay.call_args
+    payload = args[0][1]
+    assert payload["type"] == "rows_updated"
+
+    updated_ids = set(payload["updated_field_ids"])
+    unrelated_keys = {
+        f"field_{n2id[name]}"
+        for name in ("long_text", "url", "email", "boolean", "phone_number")
+    }
+
+    for row_data in payload["rows"]:
+        row_field_keys = {k for k in row_data if k.startswith("field_")}
+        for key in row_field_keys:
+            fid = int(key.split("_", 1)[1])
+            assert fid in updated_ids, f"{key} in payload but not in updated_field_ids"
+        for key in unrelated_keys:
+            assert key not in row_data
+
+    for before_data in payload["rows_before_update"]:
+        for key in unrelated_keys:
+            assert key in before_data
 
 
 @pytest.mark.django_db(transaction=True)

--- a/backend/tests/baserow/contrib/database/ws/test_ws_rows_signals.py
+++ b/backend/tests/baserow/contrib/database/ws/test_ws_rows_signals.py
@@ -285,6 +285,7 @@ def test_batch_row_updated_serializes_only_updated_fields(
 
     for row_data in payload["rows"]:
         row_field_keys = {k for k in row_data if k.startswith("field_")}
+        assert f"field_{n2id['last_modified_datetime_us']}" in row_data
         for key in row_field_keys:
             fid = int(key.split("_", 1)[1])
             assert fid in updated_ids, f"{key} in payload but not in updated_field_ids"

--- a/changelog/entries/unreleased/bug/5927_reduced_websocket_row_update_payload_size_by_serializing_onl.json
+++ b/changelog/entries/unreleased/bug/5927_reduced_websocket_row_update_payload_size_by_serializing_onl.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Reduced WebSocket row update payload size by serializing only changed fields instead of all fields.",
+    "issue_origin": "github",
+    "issue_number": 5927,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-19"
+}

--- a/web-frontend/modules/database/realtime.js
+++ b/web-frontend/modules/database/realtime.js
@@ -209,14 +209,13 @@ export const registerRealtimeEvents = (realtime) => {
 
   realtime.registerEvent('rows_updated', async (context, data) => {
     const { app, store } = context
+    const beforeById = Object.fromEntries(
+      (data.rows_before_update || []).map((r) => [r.id, r])
+    )
     for (const viewType of Object.values(app.$registry.getAll('view'))) {
       for (let i = 0; i < data.rows.length; i++) {
         const row = data.rows[i]
-
-        // A row may be updated by the backend, while it wasn't requested by the user,
-        // causing rows before update and rows updated sets asymmetry. In that case,
-        // we just want a skeleton of a row.
-        const rowBeforeUpdate = data.rows_before_update[i] || { id: row.id }
+        const rowBeforeUpdate = beforeById[row.id] || { id: row.id }
 
         await viewType.rowUpdated(
           context,


### PR DESCRIPTION
Closes #5927
Closes #3563 

## Summary

- Pass `serialize_only_updated_fields=True` in the two main `rows_updated.send()` call sites (single row update and batch update) so WS payloads include only changed fields instead of all fields
- Skip the row-move call site — it sends `updated_field_ids=[]` and doesn't benefit from this optimization
- Add tests verifying that WS `rows_updated` messages contain only the updated field (not all fields)

## Test plan

- [x] Unit test: single row update — WS payload contains only the changed field, not other fields on the table
- [x] Unit test: batch row update — same verification for multi-row updates
- [x] Unit test: `before_rows_update` payload still contains all fields (unchanged behavior for webhooks)
- [x] Existing test suite passes — no regressions in WS signal handling


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
