### PR TITLE
fix: Ensure Aggregate rows formula without property is correctly handled

### DIFF
--- a/backend/src/baserow/contrib/integrations/local_baserow/service_types.py
+++ b/backend/src/baserow/contrib/integrations/local_baserow/service_types.py
@@ -1564,6 +1564,12 @@ class LocalBaserowAggregateRowsUserServiceType(
         Returns the usual properties for this service type.
         """
 
+        if not path:
+            # When path is empty, e.g. `get('data_source.123')`, we should
+            # return all properties since we don't know which specific
+            # properties are needed.
+            return ["result"]
+
         if path[0] == "result":
             return ["result"]
 

--- a/backend/tests/baserow/contrib/integrations/local_baserow/service_types/test_aggregate_rows_service_type.py
+++ b/backend/tests/baserow/contrib/integrations/local_baserow/service_types/test_aggregate_rows_service_type.py
@@ -681,3 +681,27 @@ def test_create_local_baserow_aggregate_rows_service_with_unsupported_aggregatio
         match=f"The {unsupported_agg_type} aggregation type is not currently supported.",
     ):
         service_type.prepare_values({"aggregation_type": unsupported_agg_type}, user)
+
+
+def test_local_baserow_aggregate_rows_extract_properties_with_empty_path():
+    """
+    When path is empty, e.g. `get('data_source.606')`, extract_properties should
+    return all properties instead of raising an IndexError.
+    """
+
+    service_type = service_type_registry.get("local_baserow_aggregate_rows")
+
+    assert service_type.extract_properties(Mock(), []) == ["result"]
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        (["result"], ["result"]),
+        (["field_123"], []),
+    ],
+)
+def test_local_baserow_aggregate_rows_extract_properties(path, expected):
+    service_type = service_type_registry.get("local_baserow_aggregate_rows")
+
+    assert service_type.extract_properties(Mock(), path) == expected

--- a/changelog/entries/unreleased/bug/fixed_a_bug_in_summarize_field_data_source_using_aggregation.json
+++ b/changelog/entries/unreleased/bug/fixed_a_bug_in_summarize_field_data_source_using_aggregation.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed a bug in Summarize field data source using aggregation that caused a crash in preview and published modes.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-08-20"
+}


### PR DESCRIPTION
### What is in this PR
This PR fixes a bug in how the properties are extracted in the Aggregate rows service type.

Fixes [this Sentry issue](https://baserow-eu.sentry.io/issues/141421991/)

### How to test this PR
In the latest `develop`, create a Summarize rows data source, and use Aggregation -> Count on any field:
> <img width="400" alt="image" src="https://github.com/user-attachments/assets/0052e2b0-bd77-464d-b19a-0fbec9af4151" />

Then create a Heading element, select Advanced mode, and select the data source:
> <img width="500" alt="image" src="https://github.com/user-attachments/assets/59dc6244-d353-4806-86ed-4881f2bde4c1" />

Preview/publish the app, and you'll see a 500 error. The backend logs will show this exception:
```
  File "/baserow/backend/src/baserow/contrib/builder/data_providers/data_provider_types.py", line 254, in extract_properties
    data_source.service_id: service_type.extract_properties(
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        data_source.service.specific, rest, **kwargs
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/baserow/backend/src/baserow/contrib/integrations/local_baserow/service_types.py", line 1567, in extract_properties
    if path[0] == "result":
       ~~~~^^^
IndexError: list index out of range
```

In this branch the data source should work as expected.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
