### PR TITLE
fix: Use objects_and_trash when creating or duplicating page

### DIFF
--- a/backend/src/baserow/contrib/builder/pages/handler.py
+++ b/backend/src/baserow/contrib/builder/pages/handler.py
@@ -199,7 +199,7 @@ class PageHandler:
             self.is_page_path_unique(
                 page.builder,
                 path,
-                base_queryset=Page.objects.exclude(
+                base_queryset=Page.objects_and_trash.exclude(
                     id=page.id
                 ),  # We don't want to conflict with the current page
                 raises=True,
@@ -372,7 +372,11 @@ class PageHandler:
         :return: A unique name to use.
         """
 
-        existing_pages_names = list(builder.page_set.values_list("name", flat=True))
+        existing_pages_names = list(
+            Page.objects_and_trash.filter(builder=builder).values_list(
+                "name", flat=True
+            )
+        )
         return find_unused_name([proposed_name], existing_pages_names, max_length=255)
 
     def find_unused_page_path(self, builder: Builder, proposed_path: str) -> str:
@@ -388,7 +392,11 @@ class PageHandler:
         if page_path.endswith("/"):
             page_path = page_path[:-1]
 
-        existing_paths = list(builder.page_set.values_list("path", flat=True))
+        existing_paths = list(
+            Page.objects_and_trash.filter(builder=builder).values_list(
+                "path", flat=True
+            )
+        )
         return find_unused_name(
             [page_path], existing_paths, max_length=255, suffix="/{0}"
         )
@@ -499,7 +507,7 @@ class PageHandler:
         :return: If the path is unique
         """
 
-        queryset = Page.objects if base_queryset is None else base_queryset
+        queryset = Page.objects_and_trash if base_queryset is None else base_queryset
 
         existing_paths = queryset.filter(builder=builder).values_list("path", flat=True)
 

--- a/backend/tests/baserow/contrib/builder/pages/test_page_handler.py
+++ b/backend/tests/baserow/contrib/builder/pages/test_page_handler.py
@@ -26,6 +26,7 @@ from baserow.contrib.builder.pages.models import Page
 from baserow.contrib.builder.workflow_actions.models import BuilderWorkflowAction
 from baserow.core.graph.types import GraphPointPosition
 from baserow.core.handler import CoreHandler
+from baserow.core.trash.handler import TrashHandler
 from baserow.core.user_sources.user_source_user import UserSourceUser
 
 
@@ -286,6 +287,23 @@ def test_duplicate_application_preserves_multi_page_header_children(data_fixture
     assert imported_child.parent_element_id == imported_header.id
 
 
+@pytest.mark.django_db
+def test_duplicate_page_when_previous_duplicate_is_trashed(data_fixture):
+    user = data_fixture.create_user()
+    builder = data_fixture.create_builder_application(user=user)
+    page = data_fixture.create_builder_page(builder=builder, path="/test")
+
+    first_clone = PageHandler().duplicate_page(page)
+    assert first_clone.path == "/test/2"
+
+    TrashHandler.trash(user, builder.workspace, builder, first_clone)
+
+    # The trashed clone still holds /test/2 under the (builder, path) unique
+    # constraint, so the next duplicate must skip to the next free path.
+    second_clone = PageHandler().duplicate_page(page)
+    assert second_clone.path == "/test/3"
+
+
 def test_is_page_path_valid():
     assert PageHandler().is_page_path_valid("test/", []) is True
     assert PageHandler().is_page_path_valid("test/:id", []) is False
@@ -344,6 +362,18 @@ def test_find_unused_page_path(data_fixture):
 
 
 @pytest.mark.django_db
+def test_find_unused_page_path_with_trashed_page(data_fixture):
+    user = data_fixture.create_user()
+    builder = data_fixture.create_builder_application(user=user)
+    data_fixture.create_builder_page(builder=builder, path="/test")
+    trashed_page = data_fixture.create_builder_page(builder=builder, path="/test/2")
+
+    TrashHandler.trash(user, builder.workspace, builder, trashed_page)
+
+    assert PageHandler().find_unused_page_path(builder, "/test") == "/test/3"
+
+
+@pytest.mark.django_db
 def test_is_page_path_unique(data_fixture):
     builder = data_fixture.create_builder_application()
 
@@ -373,6 +403,42 @@ def test_is_page_path_unique_raises(data_fixture):
 
     with pytest.raises(PagePathNotUnique):
         PageHandler().is_page_path_unique(builder, "/test/:id", raises=True)
+
+
+@pytest.mark.django_db
+def test_is_page_path_unique_with_trashed_page(data_fixture):
+    user = data_fixture.create_user()
+    builder = data_fixture.create_builder_application(user=user)
+    trashed_page = data_fixture.create_builder_page(builder=builder, path="/test")
+
+    TrashHandler.trash(user, builder.workspace, builder, trashed_page)
+
+    assert PageHandler().is_page_path_unique(builder, "/test") is False
+
+
+@pytest.mark.django_db
+def test_create_page_page_path_not_unique_with_trashed_page(data_fixture):
+    user = data_fixture.create_user()
+    builder = data_fixture.create_builder_application(user=user)
+    trashed_page = data_fixture.create_builder_page(builder=builder, path="/test")
+
+    TrashHandler.trash(user, builder.workspace, builder, trashed_page)
+
+    with pytest.raises(PagePathNotUnique):
+        PageHandler().create_page(builder, name="test", path="/test")
+
+
+@pytest.mark.django_db
+def test_update_page_page_path_not_unique_with_trashed_page(data_fixture):
+    user = data_fixture.create_user()
+    builder = data_fixture.create_builder_application(user=user)
+    trashed_page = data_fixture.create_builder_page(builder=builder, path="/taken")
+    page = data_fixture.create_builder_page(builder=builder, path="/test")
+
+    TrashHandler.trash(user, builder.workspace, builder, trashed_page)
+
+    with pytest.raises(PagePathNotUnique):
+        PageHandler().update_page(page, path="/taken")
 
 
 def test_generalise_path():

--- a/changelog/entries/unreleased/bug/fixed_a_bug_that_prevented_creating_or_duplicating_a_builder.json
+++ b/changelog/entries/unreleased/bug/fixed_a_bug_that_prevented_creating_or_duplicating_a_builder.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed a bug that prevented creating or duplicating a builder page when a trashed page uses the same path.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-08-20"
+}


### PR DESCRIPTION
### What is in this PR
This PR fixes a bug that caused a crash when creating/duplicating a page.

We recently removed the unique constraint on builder page names. When a page is trashed, and a new page is created with the same path, the frontend would show an error, and the backend raised an exception:
```
  File "/baserow/venv/lib/python3.14/site-packages/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/baserow/venv/lib/python3.14/site-packages/django/db/backends/utils.py", line 105, in _execute
    return self.cursor.execute(sql, params)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
django.db.utils.IntegrityError: duplicate key value violates unique constraint "builder_page_builder_id_path_1f48e2c0_uniq"
DETAIL:  Key (builder_id, path)=(262, ) already exists.
```

The fix is to use `objects_and_trash` to ensure trashed pages are also excluded in filters.

### How to test this PR
- Create a Builder app.
- Duplicate the "Homepage" page.
- Trash the duplicate "Homepage 2" page.
- Duplicate the "Homepage" page again; this time you'll see the crash.

In this branch, you should be able to duplicate the page successfully.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
