### PR TITLE
fix: Ensure HTTP Trigger doesn't crash on non UTF-8 encoded body

### DIFF
--- a/backend/src/baserow/contrib/integrations/core/api/webhooks/views.py
+++ b/backend/src/baserow/contrib/integrations/core/api/webhooks/views.py
@@ -1,6 +1,9 @@
+from django.core.files.uploadedfile import UploadedFile
 from django.db import transaction
+from django.utils.datastructures import MultiValueDict
 
 from drf_spectacular.utils import extend_schema
+from rest_framework.exceptions import ParseError, UnsupportedMediaType
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.status import HTTP_204_NO_CONTENT
@@ -52,8 +55,34 @@ class CoreHTTPTriggerView(APIView):
     def handle_request_data(self, request):
         headers = {key: value for key, value in request.headers.items()}
         query_params = dict(request.GET.items())
-        raw_body = request.body.decode("utf-8") if request.body else ""
-        body = request.data if hasattr(request, "data") else {}
+
+        # The sender is an arbitrary third-party system, so the body can
+        # arrive in any encoding; it must never cause a 500. `request.body`
+        # must be accessed before `request.data`, because multipart parsing
+        # consumes the request stream.
+        raw_body = ""
+        if request.body:
+            charset = (request.content_params or {}).get("charset")
+            try:
+                raw_body = request.body.decode(charset or "utf-8")
+            except (UnicodeDecodeError, LookupError):
+                raw_body = request.body.decode("utf-8", errors="replace")
+
+        try:
+            body = request.data
+        except (UnsupportedMediaType, ParseError):
+            body = {}
+
+        if isinstance(body, MultiValueDict):
+            # Form and multipart bodies can contain `UploadedFile` values,
+            # which wouldn't survive the JSON serialization towards the
+            # workflow's Celery task; keep only the plain form fields.
+            fields = {}
+            for key, values in body.lists():
+                values = [v for v in values if not isinstance(v, UploadedFile)]
+                if values:
+                    fields[key] = values[0] if len(values) == 1 else values
+            body = fields
 
         return {
             "method": request.method,

--- a/backend/tests/baserow/contrib/integrations/core/api/webhooks/test_webhook_views.py
+++ b/backend/tests/baserow/contrib/integrations/core/api/webhooks/test_webhook_views.py
@@ -1,11 +1,35 @@
+import json
+from unittest.mock import patch
+
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
 import pytest
 from rest_framework.status import HTTP_204_NO_CONTENT, HTTP_405_METHOD_NOT_ALLOWED
 
+from baserow.core.services.registries import service_type_registry
+
 
 def get_url(uid):
     return reverse("api:http_trigger", kwargs={"webhook_uid": uid})
+
+
+def post_webhook(api_client, uid, body, content_type):
+    """
+    POSTs the given raw body to the webhook endpoint and returns the response
+    together with the request_data that was forwarded to the trigger's
+    on_event, or None if the trigger was never fired.
+    """
+
+    with patch.object(
+        service_type_registry.get("http_trigger"), "on_event"
+    ) as mock_on_event:
+        resp = api_client.generic(
+            "POST", get_url(uid) + "?test=true", data=body, content_type=content_type
+        )
+
+    request_data = mock_on_event.call_args[0][1] if mock_on_event.called else None
+    return resp, request_data
 
 
 @pytest.mark.parametrize(
@@ -51,3 +75,151 @@ def test_allows_valid_http_methods(api_client, data_fixture, http_method):
     resp = getattr(api_client, http_method)(url)
 
     assert resp.status_code == HTTP_204_NO_CONTENT
+
+
+@pytest.mark.django_db
+def test_non_utf8_json_body_triggers_with_replaced_raw_body(api_client, data_fixture):
+    node = data_fixture.create_http_trigger_node()
+
+    resp, request_data = post_webhook(
+        api_client,
+        node.service.uid,
+        '{"name": "Hällo"}'.encode("iso-8859-1"),
+        "application/json",
+    )
+
+    assert resp.status_code == HTTP_204_NO_CONTENT
+    assert request_data["raw_body"] == '{"name": "H�llo"}'
+    assert request_data["body"] == {}
+
+
+@pytest.mark.django_db
+def test_declared_charset_is_used_to_decode_the_body(api_client, data_fixture):
+    node = data_fixture.create_http_trigger_node()
+
+    resp, request_data = post_webhook(
+        api_client,
+        node.service.uid,
+        "Hällo".encode("iso-8859-1"),
+        "text/plain; charset=iso-8859-1",
+    )
+
+    assert resp.status_code == HTTP_204_NO_CONTENT
+    assert request_data["raw_body"] == "Hällo"
+    assert request_data["body"] == {}
+
+
+@pytest.mark.django_db
+def test_invalid_declared_charset_falls_back_to_utf8(api_client, data_fixture):
+    node = data_fixture.create_http_trigger_node()
+
+    resp, request_data = post_webhook(
+        api_client,
+        node.service.uid,
+        "Hällo".encode("iso-8859-1"),
+        "text/plain; charset=banana",
+    )
+
+    assert resp.status_code == HTTP_204_NO_CONTENT
+    assert request_data["raw_body"] == "H�llo"
+
+
+@pytest.mark.django_db
+def test_binary_body_triggers(api_client, data_fixture):
+    node = data_fixture.create_http_trigger_node()
+
+    resp, request_data = post_webhook(
+        api_client,
+        node.service.uid,
+        b"\x89PNG\r\n\x1a\n\x00\x01\x02",
+        "application/octet-stream",
+    )
+
+    assert resp.status_code == HTTP_204_NO_CONTENT
+    assert request_data["body"] == {}
+    # The payload must survive the JSON serialization towards the
+    # workflow's Celery task.
+    json.dumps(request_data)
+
+
+@pytest.mark.django_db
+def test_plain_text_body_triggers_with_raw_body(api_client, data_fixture):
+    node = data_fixture.create_http_trigger_node()
+
+    resp, request_data = post_webhook(
+        api_client, node.service.uid, b"hello world", "text/plain"
+    )
+
+    assert resp.status_code == HTTP_204_NO_CONTENT
+    assert request_data["raw_body"] == "hello world"
+    assert request_data["body"] == {}
+
+
+@pytest.mark.django_db
+def test_malformed_json_body_falls_back_to_empty_body(api_client, data_fixture):
+    node = data_fixture.create_http_trigger_node()
+
+    resp, request_data = post_webhook(
+        api_client, node.service.uid, b'{"name": ', "application/json"
+    )
+
+    assert resp.status_code == HTTP_204_NO_CONTENT
+    assert request_data["raw_body"] == '{"name": '
+    assert request_data["body"] == {}
+
+
+@pytest.mark.django_db
+def test_valid_json_body_is_parsed(api_client, data_fixture):
+    node = data_fixture.create_http_trigger_node()
+
+    resp, request_data = post_webhook(
+        api_client,
+        node.service.uid,
+        '{"name": "Müller"}'.encode(),
+        "application/json",
+    )
+
+    assert resp.status_code == HTTP_204_NO_CONTENT
+    assert request_data["body"] == {"name": "Müller"}
+    assert request_data["raw_body"] == '{"name": "Müller"}'
+
+
+@pytest.mark.django_db
+def test_form_urlencoded_body_preserves_multi_value_fields(api_client, data_fixture):
+    node = data_fixture.create_http_trigger_node()
+
+    resp, request_data = post_webhook(
+        api_client,
+        node.service.uid,
+        b"a=1&a=2&b=3",
+        "application/x-www-form-urlencoded",
+    )
+
+    assert resp.status_code == HTTP_204_NO_CONTENT
+    assert request_data["body"] == {"a": ["1", "2"], "b": "3"}
+
+
+@pytest.mark.django_db
+def test_multipart_body_keeps_only_serializable_form_fields(api_client, data_fixture):
+    node = data_fixture.create_http_trigger_node()
+
+    with patch.object(
+        service_type_registry.get("http_trigger"), "on_event"
+    ) as mock_on_event:
+        resp = api_client.post(
+            get_url(node.service.uid) + "?test=true",
+            data={
+                "name": "Müller",
+                "attachment": SimpleUploadedFile(
+                    "test.png", b"\x89PNG\r\n\x1a\n", content_type="image/png"
+                ),
+            },
+            format="multipart",
+        )
+
+    assert resp.status_code == HTTP_204_NO_CONTENT
+    request_data = mock_on_event.call_args[0][1]
+    assert request_data["body"] == {"name": "Müller"}
+    # The payload must survive the JSON serialization towards the
+    # workflow's Celery task.
+    json.dumps(request_data)

--- a/changelog/entries/unreleased/bug/fixed_the_automation_http_trigger_webhook_returning_errors_f.json
+++ b/changelog/entries/unreleased/bug/fixed_the_automation_http_trigger_webhook_returning_errors_f.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed the automation HTTP trigger webhook returning errors for requests with non UTF-8, plain text, binary, or malformed bodies.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-08-20"
+}


### PR DESCRIPTION
### What is in this PR
This PR fixes a bug in the HTTP Trigger webhook view.

When the request body contains non UTF-8 chars, the request fails hard. This has been fixed by trying to use the charset provided in the request, or falling back to replace mode.

Fixes [this Sentry issue](https://baserow-eu.sentry.io/issues/141637787/).

### How to test this PR
In `develop`, create a workflow using a trigger of HTTP Trigger, followed by a Create rows node that persists the body to a table.

Test the workflow, and send this request:
```bash
curl -i -X POST 'http://localhost:8000/api/webhooks/fe974e8f-e902-4ccd-bd6e-57d4b5abc6d7/?test=true' \
  -H 'Content-Type: application/json' \
  --data-binary $'{"name": b"H\xebllo"}'
```

You should see an error in the backend:
```python
  File "/baserow/backend/src/baserow/contrib/integrations/core/api/webhooks/views.py", line 55, in handle_request_data
    raw_body = request.body.decode("utf-8") if request.body else ""
               ~~~~~~~~~~~~~~~~~~~^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe8 in position 11: invalid continuation byte
```

In this branch, the request will work, but since the encoding wasn't provided, the body will be replaced:
> <img width="250" alt="image" src="https://github.com/user-attachments/assets/0ae758e8-321b-4623-a82e-5b0ef6bbf023" />

Send the request again, but this time provide the encoding:
```bash
curl -i -X POST 'http://localhost:8000/api/webhooks/fe974e8f-e902-4ccd-bd6e-57d4b5abc6d7/?test=true' \
  -H 'Content-Type: application/json; charset=iso-8859-1' \
  --data-binary $'{"name": "H\xebllo"}'
```

This time, the correct encoding is accepted:
> <img width="208" height="36" alt="image" src="https://github.com/user-attachments/assets/7d7b806e-9b86-4447-874f-2aceb74b2479" />

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
