### PR TITLE
fix: Workflow action update should handle missing service type

### DIFF
--- a/backend/src/baserow/api/polymorphic.py
+++ b/backend/src/baserow/api/polymorphic.py
@@ -80,6 +80,29 @@ class BasePolymorphicSerializer(serializers.Serializer):
     # Used for instance for creating public serializers
     extra_params: Dict[str, Any] = None
 
+    default_error_messages = {
+        "missing_type": "Unable to determine the `type` of the polymorphic data.",
+        "invalid_type": '"{type_name}" is not a valid type.',
+    }
+
+    def __init__(self, *args, default_type_name: str | None = None, **kwargs):
+        # The type to fall back to when the data doesn't name one, for use
+        # where the caller can't change the type anyway, like the service of a
+        # workflow action whose action type pins it.
+        self.default_type_name = default_type_name
+        super().__init__(*args, **kwargs)
+
+    def fail_on_type_field(self, key, **kwargs):
+        """
+        Like `fail`, but keys the error under the type field, so the error
+        detail stays a dict whether this serializer is nested or standalone.
+        """
+
+        try:
+            self.fail(key, **kwargs)
+        except serializers.ValidationError as e:
+            raise serializers.ValidationError({self.type_field_name: e.detail})
+
     def get_type_from_type_name(self, name):
         return self.registry.get(name)
 
@@ -87,10 +110,26 @@ class BasePolymorphicSerializer(serializers.Serializer):
         return self.registry.get_by_model(instance.specific)
 
     def get_type_from_mapping(self, mapping):
-        if self.type_field_name in mapping:
-            return self.registry.get(mapping[self.type_field_name])
-        else:
-            self.fail("Unable to determine the `type` of the polymorphic data.")
+        type_name = (
+            mapping.get(self.type_field_name) if isinstance(mapping, dict) else None
+        )
+
+        if not type_name and self.default_type_name:
+            type_name = self.default_type_name
+
+        if type_name is None and (
+            not isinstance(mapping, dict) or self.type_field_name not in mapping
+        ):
+            self.fail_on_type_field("missing_type")
+
+        try:
+            return self.registry.get(type_name)
+        # An unhashable `type` value, e.g. a list or a dict, would crash the
+        # registry lookup. An unknown type on the other hand propagates the
+        # registry's own does-not-exist exception, which views map to their
+        # specific API errors.
+        except TypeError:
+            self.fail_on_type_field("invalid_type", type_name=type_name)
 
     def to_representation(self, instance):
         if not self.required and not instance:

--- a/backend/src/baserow/api/polymorphic.py
+++ b/backend/src/baserow/api/polymorphic.py
@@ -83,12 +83,17 @@ class BasePolymorphicSerializer(serializers.Serializer):
     default_error_messages = {
         "missing_type": "Unable to determine the `type` of the polymorphic data.",
         "invalid_type": '"{type_name}" is not a valid type.',
+        "type_mismatch": (
+            'The type is fixed to "{default_type_name}" here, so "{type_name}" '
+            "cannot be used."
+        ),
     }
 
     def __init__(self, *args, default_type_name: str | None = None, **kwargs):
-        # The type to fall back to when the data doesn't name one, for use
-        # where the caller can't change the type anyway, like the service of a
-        # workflow action whose action type pins it.
+        # The type to fall back to when the data doesn't name one, and the only
+        # type accepted when it does. For use where the caller can't change the
+        # type anyway, like the service of a workflow action whose action type
+        # pins it.
         self.default_type_name = default_type_name
         super().__init__(*args, **kwargs)
 
@@ -114,22 +119,32 @@ class BasePolymorphicSerializer(serializers.Serializer):
             mapping.get(self.type_field_name) if isinstance(mapping, dict) else None
         )
 
-        if not type_name and self.default_type_name:
+        # An absent, `null` or empty `type` all mean the caller didn't name one.
+        if type_name is None or type_name == "":
             type_name = self.default_type_name
 
-        if type_name is None and (
-            not isinstance(mapping, dict) or self.type_field_name not in mapping
-        ):
+        if type_name is None:
             self.fail_on_type_field("missing_type")
 
-        try:
-            return self.registry.get(type_name)
-        # An unhashable `type` value, e.g. a list or a dict, would crash the
-        # registry lookup. An unknown type on the other hand propagates the
-        # registry's own does-not-exist exception, which views map to their
-        # specific API errors.
-        except TypeError:
+        # A list or a dict would crash the registry lookup, and other
+        # non-string values could still match an instance's `compat_type`, so
+        # only a real name is looked up.
+        if not isinstance(type_name, str):
             self.fail_on_type_field("invalid_type", type_name=type_name)
+
+        # When the type is pinned, a different one would only pick which
+        # serializer the values are checked against, and whatever it accepted
+        # would then be dropped without a word. Refused so the caller hears it.
+        if self.default_type_name is not None and type_name != self.default_type_name:
+            self.fail_on_type_field(
+                "type_mismatch",
+                type_name=type_name,
+                default_type_name=self.default_type_name,
+            )
+
+        # An unknown type propagates the registry's own does-not-exist
+        # exception, which views map to their specific API errors.
+        return self.registry.get(type_name)
 
     def to_representation(self, instance):
         if not self.required and not instance:

--- a/backend/src/baserow/contrib/automation/api/nodes/views.py
+++ b/backend/src/baserow/contrib/automation/api/nodes/views.py
@@ -15,6 +15,7 @@ from baserow.api.decorators import (
     validate_body,
 )
 from baserow.api.schemas import CLIENT_SESSION_ID_SCHEMA_PARAMETER, get_error_schema
+from baserow.api.services.errors import ERROR_SERVICE_INVALID_TYPE
 from baserow.api.utils import (
     DiscriminatorCustomFieldsMappingSerializer,
     type_from_data_or_registry,
@@ -75,6 +76,7 @@ from baserow.contrib.automation.workflows.exceptions import (
 from baserow.contrib.automation.workflows.handler import AutomationWorkflowHandler
 from baserow.contrib.automation.workflows.service import AutomationWorkflowService
 from baserow.core.graph.exceptions import GraphPointReferencePointInvalid
+from baserow.core.services.exceptions import ServiceTypeDoesNotExist
 
 AUTOMATION_NODES_TAG = "Automation nodes"
 
@@ -217,6 +219,7 @@ class AutomationNodeView(APIView):
             400: get_error_schema(
                 [
                     "ERROR_REQUEST_BODY_VALIDATION",
+                    "ERROR_SERVICE_INVALID_TYPE",
                 ]
             ),
             404: get_error_schema(
@@ -231,6 +234,7 @@ class AutomationNodeView(APIView):
         {
             AutomationNodeDoesNotExist: ERROR_AUTOMATION_NODE_DOES_NOT_EXIST,
             AutomationNodeMisconfiguredService: ERROR_AUTOMATION_NODE_MISCONFIGURED_SERVICE,
+            ServiceTypeDoesNotExist: ERROR_SERVICE_INVALID_TYPE,
         }
     )
     @require_request_data_type(dict)

--- a/backend/src/baserow/contrib/automation/nodes/registries.py
+++ b/backend/src/baserow/contrib/automation/nodes/registries.py
@@ -33,12 +33,14 @@ from baserow.core.services.exceptions import (
     ServiceImproperlyConfiguredDispatchException,
 )
 from baserow.core.services.handler import ServiceHandler
+from baserow.core.services.mixins import ServiceBackedTypeMixin
 from baserow.core.services.registries import ServiceTypeSubClass, service_type_registry
 from baserow.core.services.types import DispatchResult
 from baserow.core.trash.registries import TrashOperationType
 
 
 class AutomationNodeType(
+    ServiceBackedTypeMixin,
     PublicCustomFieldsInstanceMixin,
     InstanceWithFormulaMixin,
     EasyImportExportMixin,
@@ -48,6 +50,7 @@ class AutomationNodeType(
     display_name = _("Unnamed node")
 
     service_type = None
+    service_field_help_text = "The service associated with this automation node."
     parent_property_name = "workflow"
     id_mapping_name = "automation_workflow_nodes"
 

--- a/backend/src/baserow/contrib/builder/api/workflow_actions/views.py
+++ b/backend/src/baserow/contrib/builder/api/workflow_actions/views.py
@@ -20,6 +20,7 @@ from baserow.api.services.errors import (
     ERROR_SERVICE_IMPROPERLY_CONFIGURED,
     ERROR_SERVICE_INVALID_DISPATCH_CONTEXT,
     ERROR_SERVICE_INVALID_DISPATCH_CONTEXT_CONTENT,
+    ERROR_SERVICE_INVALID_TYPE,
     ERROR_SERVICE_UNEXPECTED_DISPATCH_ERROR,
 )
 from baserow.api.utils import (
@@ -78,6 +79,7 @@ from baserow.core.services.exceptions import (
     InvalidContextContentDispatchException,
     InvalidContextDispatchException,
     ServiceImproperlyConfiguredDispatchException,
+    ServiceTypeDoesNotExist,
     UnexpectedDispatchException,
 )
 from baserow.core.workflow_actions.exceptions import WorkflowActionDoesNotExist
@@ -119,6 +121,7 @@ class BuilderWorkflowActionsView(APIView):
                 [
                     "ERROR_REQUEST_BODY_VALIDATION",
                     "ERROR_INVALID_WORKFLOW_ACTION_EVENT",
+                    "ERROR_SERVICE_INVALID_TYPE",
                 ]
             ),
             404: get_error_schema(["ERROR_PAGE_DOES_NOT_EXIST"]),
@@ -130,6 +133,7 @@ class BuilderWorkflowActionsView(APIView):
             PageDoesNotExist: ERROR_PAGE_DOES_NOT_EXIST,
             ElementDoesNotExist: ERROR_ELEMENT_DOES_NOT_EXIST,
             InvalidWorkflowActionEvent: ERROR_INVALID_WORKFLOW_ACTION_EVENT,
+            ServiceTypeDoesNotExist: ERROR_SERVICE_INVALID_TYPE,
         }
     )
     @validate_body_custom_fields(
@@ -267,6 +271,7 @@ class BuilderWorkflowActionView(APIView):
                 [
                     "ERROR_REQUEST_BODY_VALIDATION",
                     "ERROR_INVALID_WORKFLOW_ACTION_EVENT",
+                    "ERROR_SERVICE_INVALID_TYPE",
                 ]
             ),
             404: get_error_schema(
@@ -281,6 +286,7 @@ class BuilderWorkflowActionView(APIView):
         {
             WorkflowActionDoesNotExist: ERROR_WORKFLOW_ACTION_DOES_NOT_EXIST,
             InvalidWorkflowActionEvent: ERROR_INVALID_WORKFLOW_ACTION_EVENT,
+            ServiceTypeDoesNotExist: ERROR_SERVICE_INVALID_TYPE,
         }
     )
     @require_request_data_type(dict)

--- a/backend/src/baserow/contrib/builder/workflow_actions/workflow_action_types.py
+++ b/backend/src/baserow/contrib/builder/workflow_actions/workflow_action_types.py
@@ -247,13 +247,6 @@ class RefreshDataSourceWorkflowActionType(BuilderWorkflowActionType):
 class BuilderWorkflowServiceActionType(BuilderWorkflowActionType):
     service_type = None  # Must be implemented by subclasses.
     serializer_field_names = ["service"]
-    request_serializer_field_overrides = {
-        "service": PolymorphicServiceRequestSerializer(
-            default=None,
-            required=False,
-            help_text="The service which this workflow action is associated with.",
-        )
-    }
     is_server_workflow = True
     serializer_field_overrides = {
         "service": PolymorphicServiceSerializer(
@@ -267,6 +260,26 @@ class BuilderWorkflowServiceActionType(BuilderWorkflowActionType):
             help_text="The service which this workflow action is associated with."
         )
     }
+
+    def get_field_overrides(
+        self, request_serializer: bool, extra_params: Dict, **kwargs
+    ) -> Dict:
+        # Built per type rather than declared, so the request serializer can
+        # fall back to the service type this action carries when the caller
+        # leaves `type` out of the service payload.
+        public = (extra_params or {}).get("public", False)
+        if request_serializer and not public:
+            return {
+                "service": PolymorphicServiceRequestSerializer(
+                    default_type_name=self.service_type,
+                    default=None,
+                    required=False,
+                    help_text="The service which this workflow action is "
+                    "associated with.",
+                )
+            }
+
+        return super().get_field_overrides(request_serializer, extra_params, **kwargs)
 
     class SerializedDict(BuilderWorkflowActionDict):
         service: Dict

--- a/backend/src/baserow/contrib/builder/workflow_actions/workflow_action_types.py
+++ b/backend/src/baserow/contrib/builder/workflow_actions/workflow_action_types.py
@@ -6,7 +6,6 @@ from django.db.models import Prefetch
 from rest_framework import serializers
 
 from baserow.api.services.serializers import (
-    PolymorphicServiceRequestSerializer,
     PolymorphicServiceSerializer,
     PublicPolymorphicServiceSerializer,
 )
@@ -59,6 +58,7 @@ from baserow.core.formula.types import BASEROW_FORMULA_MODE_SIMPLE, BaserowFormu
 from baserow.core.integrations.models import Integration
 from baserow.core.registry import Instance
 from baserow.core.services.handler import ServiceHandler
+from baserow.core.services.mixins import ServiceBackedTypeMixin
 from baserow.core.services.models import Service
 from baserow.core.services.registries import service_type_registry
 from baserow.core.services.types import DispatchResult
@@ -244,8 +244,13 @@ class RefreshDataSourceWorkflowActionType(BuilderWorkflowActionType):
         )
 
 
-class BuilderWorkflowServiceActionType(BuilderWorkflowActionType):
+class BuilderWorkflowServiceActionType(
+    ServiceBackedTypeMixin, BuilderWorkflowActionType
+):
     service_type = None  # Must be implemented by subclasses.
+    service_field_help_text = (
+        "The service which this workflow action is associated with."
+    )
     serializer_field_names = ["service"]
     is_server_workflow = True
     serializer_field_overrides = {
@@ -260,26 +265,6 @@ class BuilderWorkflowServiceActionType(BuilderWorkflowActionType):
             help_text="The service which this workflow action is associated with."
         )
     }
-
-    def get_field_overrides(
-        self, request_serializer: bool, extra_params: Dict, **kwargs
-    ) -> Dict:
-        # Built per type rather than declared, so the request serializer can
-        # fall back to the service type this action carries when the caller
-        # leaves `type` out of the service payload.
-        public = (extra_params or {}).get("public", False)
-        if request_serializer and not public:
-            return {
-                "service": PolymorphicServiceRequestSerializer(
-                    default_type_name=self.service_type,
-                    default=None,
-                    required=False,
-                    help_text="The service which this workflow action is "
-                    "associated with.",
-                )
-            }
-
-        return super().get_field_overrides(request_serializer, extra_params, **kwargs)
 
     class SerializedDict(BuilderWorkflowActionDict):
         service: Dict

--- a/backend/src/baserow/contrib/database/api/workflow_actions/views.py
+++ b/backend/src/baserow/contrib/database/api/workflow_actions/views.py
@@ -17,6 +17,7 @@ from baserow.api.decorators import (
 from baserow.api.errors import ERROR_USER_NOT_IN_GROUP
 from baserow.api.exceptions import ThrottledAPIException
 from baserow.api.schemas import CLIENT_SESSION_ID_SCHEMA_PARAMETER, get_error_schema
+from baserow.api.services.errors import ERROR_SERVICE_INVALID_TYPE
 from baserow.api.utils import (
     CustomFieldRegistryMappingSerializer,
     DiscriminatorCustomFieldsMappingSerializer,
@@ -70,6 +71,7 @@ from baserow.contrib.database.workflow_actions.service import (
 )
 from baserow.core.exceptions import UserNotInWorkspace
 from baserow.core.feature_flags import FF_BUTTON_FIELD, feature_flag_is_enabled
+from baserow.core.services.exceptions import ServiceTypeDoesNotExist
 from baserow.core.workflow_actions.exceptions import WorkflowActionDoesNotExist
 
 
@@ -105,6 +107,7 @@ class DatabaseWorkflowActionsView(APIView):
                     "ERROR_REQUEST_BODY_VALIDATION",
                     "ERROR_USER_NOT_IN_GROUP",
                     "ERROR_WORKFLOW_ACTION_INVALID_INTEGRATION",
+                    "ERROR_SERVICE_INVALID_TYPE",
                 ]
             ),
             403: get_error_schema(
@@ -120,6 +123,7 @@ class DatabaseWorkflowActionsView(APIView):
             UserNotInWorkspace: ERROR_USER_NOT_IN_GROUP,
             WorkflowActionTypeDeactivated: ERROR_WORKFLOW_ACTION_TYPE_DEACTIVATED,
             WorkflowActionInvalidIntegration: ERROR_WORKFLOW_ACTION_INVALID_INTEGRATION,
+            ServiceTypeDoesNotExist: ERROR_SERVICE_INVALID_TYPE,
         }
     )
     @validate_body_custom_fields(
@@ -277,6 +281,7 @@ class DatabaseWorkflowActionView(APIView):
                     "ERROR_REQUEST_BODY_VALIDATION",
                     "ERROR_USER_NOT_IN_GROUP",
                     "ERROR_WORKFLOW_ACTION_INVALID_INTEGRATION",
+                    "ERROR_SERVICE_INVALID_TYPE",
                 ]
             ),
             403: get_error_schema(
@@ -296,6 +301,7 @@ class DatabaseWorkflowActionView(APIView):
             UserNotInWorkspace: ERROR_USER_NOT_IN_GROUP,
             WorkflowActionTypeDeactivated: ERROR_WORKFLOW_ACTION_TYPE_DEACTIVATED,
             WorkflowActionInvalidIntegration: ERROR_WORKFLOW_ACTION_INVALID_INTEGRATION,
+            ServiceTypeDoesNotExist: ERROR_SERVICE_INVALID_TYPE,
         }
     )
     @require_request_data_type(dict)

--- a/backend/src/baserow/contrib/database/workflow_actions/workflow_action_types.py
+++ b/backend/src/baserow/contrib/database/workflow_actions/workflow_action_types.py
@@ -5,10 +5,6 @@ from django.contrib.auth.models import AbstractUser
 from django.core.files.storage import Storage
 from django.db.models import Manager, Prefetch, QuerySet
 
-from rest_framework import serializers
-from rest_framework.exceptions import ErrorDetail
-from rest_framework.fields import empty
-
 from baserow.api.services.serializers import PolymorphicServiceRequestSerializer
 from baserow.contrib.database.api.workflow_actions.serializers import (
     DatabasePolymorphicServiceSerializer,
@@ -64,44 +60,6 @@ if TYPE_CHECKING:
     )
 
 
-class DefaultTypedServiceRequestSerializer(PolymorphicServiceRequestSerializer):
-    """
-    A service request serializer that names the service type itself when the
-    caller leaves it out, so an action can be created already configured.
-
-    The action type decides which service backs it, and the editor knows that
-    service under a name of its own, so it has no way to supply this one.
-    """
-
-    def __init__(self, *args, service_type_name: str = None, **kwargs):
-        self.service_type_name = service_type_name
-        super().__init__(*args, **kwargs)
-
-    def run_validation(self, data=empty) -> Any:
-        if isinstance(data, dict):
-            supplied_type = data.get("type")
-            if not supplied_type:
-                data = {**data, "type": self.service_type_name}
-            elif supplied_type != self.service_type_name:
-                # The action type already fixes which service backs it, so a
-                # different type here only picks the serializer, and whatever
-                # it accepted is then dropped without a word. Refused rather
-                # than corrected, so the caller hears about it.
-                raise serializers.ValidationError(
-                    {
-                        "type": [
-                            ErrorDetail(
-                                f"This action is always backed by a "
-                                f"'{self.service_type_name}' service, so "
-                                f"'{supplied_type}' cannot be used here.",
-                                code="invalid",
-                            )
-                        ]
-                    }
-                )
-        return super().run_validation(data)
-
-
 class DatabaseWorkflowServiceActionType(DatabaseWorkflowActionType):
     service_type = None  # Must be implemented by subclasses.
 
@@ -133,8 +91,8 @@ class DatabaseWorkflowServiceActionType(DatabaseWorkflowActionType):
         # to the service type this action carries.
         if request_serializer:
             return {
-                "service": DefaultTypedServiceRequestSerializer(
-                    service_type_name=self.service_type,
+                "service": PolymorphicServiceRequestSerializer(
+                    default_type_name=self.service_type,
                     default=None,
                     required=False,
                     help_text="The service which this workflow action is "

--- a/backend/src/baserow/contrib/database/workflow_actions/workflow_action_types.py
+++ b/backend/src/baserow/contrib/database/workflow_actions/workflow_action_types.py
@@ -5,7 +5,6 @@ from django.contrib.auth.models import AbstractUser
 from django.core.files.storage import Storage
 from django.db.models import Manager, Prefetch, QuerySet
 
-from baserow.api.services.serializers import PolymorphicServiceRequestSerializer
 from baserow.contrib.database.api.workflow_actions.serializers import (
     DatabasePolymorphicServiceSerializer,
 )
@@ -49,6 +48,7 @@ from baserow.core.services.exceptions import (
     ServiceImproperlyConfiguredDispatchException,
 )
 from baserow.core.services.handler import ServiceHandler
+from baserow.core.services.mixins import ServiceBackedTypeMixin
 from baserow.core.services.models import Service
 from baserow.core.services.registries import service_type_registry
 from baserow.core.services.types import DispatchResult
@@ -60,8 +60,13 @@ if TYPE_CHECKING:
     )
 
 
-class DatabaseWorkflowServiceActionType(DatabaseWorkflowActionType):
+class DatabaseWorkflowServiceActionType(
+    ServiceBackedTypeMixin, DatabaseWorkflowActionType
+):
     service_type = None  # Must be implemented by subclasses.
+    service_field_help_text = (
+        "The service which this workflow action is associated with."
+    )
 
     # Where `import_serialized` leaves the field it is importing into, for
     # `deserialize_property`, which the base class hands the cache but not the
@@ -83,24 +88,6 @@ class DatabaseWorkflowServiceActionType(DatabaseWorkflowActionType):
 
     class SerializedDict(DatabaseWorkflowActionDict):
         service: Dict
-
-    def get_field_overrides(
-        self, request_serializer: bool, extra_params: Dict, **kwargs
-    ) -> Dict:
-        # Built per type rather than declared, so the serializer can fall back
-        # to the service type this action carries.
-        if request_serializer:
-            return {
-                "service": PolymorphicServiceRequestSerializer(
-                    default_type_name=self.service_type,
-                    default=None,
-                    required=False,
-                    help_text="The service which this workflow action is "
-                    "associated with.",
-                )
-            }
-
-        return super().get_field_overrides(request_serializer, extra_params, **kwargs)
 
     @property
     def allowed_fields(self) -> List[str]:

--- a/backend/src/baserow/core/services/mixins.py
+++ b/backend/src/baserow/core/services/mixins.py
@@ -1,0 +1,56 @@
+from typing import Optional
+
+from rest_framework import serializers
+
+from baserow.api.services.serializers import PolymorphicServiceRequestSerializer
+
+
+class ServiceBackedTypeMixin:
+    """
+    For a registry type that is always backed by one service type, like a
+    workflow action or an automation node. The type names the service type it
+    pins in `service_type`, and this mixin pins the `service` field of its
+    request serializers to it: a payload may leave the service `type` out, and
+    may not name a different one.
+
+    Must come before `CustomFieldsInstanceMixin` in the bases.
+    """
+
+    service_type: Optional[str] = None
+    """The `ServiceType.type` this type is backed by. Set by subclasses."""
+
+    service_field_help_text = "The service which this type is associated with."
+
+    def get_service_request_field(self) -> serializers.Field:
+        return PolymorphicServiceRequestSerializer(
+            default_type_name=self.service_type,
+            default=None,
+            required=False,
+            help_text=self.service_field_help_text,
+        )
+
+    def get_serializer_class(
+        self, *args, request_serializer: bool = False, extra_params=None, **kwargs
+    ):
+        serializer_class = super().get_serializer_class(
+            *args,
+            request_serializer=request_serializer,
+            extra_params=extra_params,
+            **kwargs,
+        )
+
+        # Only a request serializer that exposes `service` gets the pinned
+        # field. Whether it does is decided by the base serializer, e.g. an
+        # automation node is created without a service but updated with one,
+        # and the public serializers keep their own.
+        if (
+            request_serializer
+            and not (extra_params or {}).get("public", False)
+            and "service" in serializer_class.Meta.fields
+        ):
+            serializer_class._declared_fields = {
+                **serializer_class._declared_fields,
+                "service": self.get_service_request_field(),
+            }
+
+        return serializer_class

--- a/backend/src/baserow/test_utils/fixtures/workflow_action.py
+++ b/backend/src/baserow/test_utils/fixtures/workflow_action.py
@@ -32,6 +32,10 @@ class WorkflowActionFixture:
                 kwargs["service"] = self.create_local_baserow_update_rows_service(
                     integration=integration,
                 )
+            elif model_class is LocalBaserowDeleteRowWorkflowAction:
+                kwargs["service"] = self.create_local_baserow_delete_row_service(
+                    integration=integration,
+                )
             else:
                 kwargs["service"] = self.create_local_baserow_upsert_row_service(
                     integration=integration,

--- a/backend/tests/baserow/api/applications/test_application_views.py
+++ b/backend/tests/baserow/api/applications/test_application_views.py
@@ -18,7 +18,7 @@ from rest_framework.status import (
 from baserow.contrib.database.models import Database
 from baserow.core.job_types import DuplicateApplicationJobType
 from baserow.core.jobs.handler import JobHandler
-from baserow.core.models import Template
+from baserow.core.models import Application, Template
 from baserow.core.operations import ListApplicationsWorkspaceOperationType
 from baserow.core.registries import application_type_registry
 
@@ -229,6 +229,31 @@ def test_list_applications_without_workspace(api_client, data_fixture):
     )
     response_json = response.json()
     assert response_json == []
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("application_type", ["", None])
+def test_create_application_without_a_type(api_client, data_fixture, application_type):
+    """
+    An empty type must not fall through to whichever application type is
+    registered first, which is what the registry's compat lookup would return.
+    """
+
+    user, token = data_fixture.create_user_and_token()
+    workspace = data_fixture.create_workspace(user=user)
+
+    response = api_client.post(
+        reverse("api:applications:list", kwargs={"workspace_id": workspace.id}),
+        {"name": "Test 1", "type": application_type},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    response_json = response.json()
+    assert response_json["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+    assert response_json["detail"]["type"][0]["code"] == "missing_type"
+    assert Application.objects.count() == 0
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/contrib/automation/api/nodes/test_nodes_views.py
+++ b/backend/tests/baserow/contrib/automation/api/nodes/test_nodes_views.py
@@ -421,6 +421,47 @@ def test_update_node(api_client, data_fixture):
 
 
 @pytest.mark.django_db
+def test_update_node_service_without_type_is_a_validation_error(
+    api_client, data_fixture
+):
+    """
+    A service payload without a `type` must be rejected with a machine-readable
+    validation error instead of crashing the polymorphic serializer.
+    """
+
+    user, token = data_fixture.create_user_and_token()
+    workflow = data_fixture.create_automation_workflow(user)
+    node = data_fixture.create_local_baserow_get_row_action_node(
+        user=user, workflow=workflow
+    )
+    response = api_client.patch(
+        reverse(API_URL_ITEM, kwargs={"node_id": node.id}),
+        {"service": {"row_id": "'42'"}},
+        **get_api_kwargs(token),
+    )
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    response_json = response.json()
+    assert response_json["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+    assert response_json["detail"]["service"]["type"][0]["code"] == "missing_type"
+
+
+@pytest.mark.django_db
+def test_update_node_service_with_invalid_type(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    workflow = data_fixture.create_automation_workflow(user)
+    node = data_fixture.create_local_baserow_get_row_action_node(
+        user=user, workflow=workflow
+    )
+    response = api_client.patch(
+        reverse(API_URL_ITEM, kwargs={"node_id": node.id}),
+        {"service": {"type": "unknown_service_type"}},
+        **get_api_kwargs(token),
+    )
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_SERVICE_INVALID_TYPE"
+
+
+@pytest.mark.django_db
 def test_updating_node_with_invalid_formula_arguments_throws_error(
     api_client, data_fixture
 ):

--- a/backend/tests/baserow/contrib/automation/api/nodes/test_nodes_views.py
+++ b/backend/tests/baserow/contrib/automation/api/nodes/test_nodes_views.py
@@ -421,12 +421,46 @@ def test_update_node(api_client, data_fixture):
 
 
 @pytest.mark.django_db
-def test_update_node_service_without_type_is_a_validation_error(
-    api_client, data_fixture
+@pytest.mark.parametrize("service_type", ["", None])
+def test_update_node_service_without_type_uses_the_node_service_type(
+    api_client, data_fixture, service_type
 ):
     """
-    A service payload without a `type` must be rejected with a machine-readable
-    validation error instead of crashing the polymorphic serializer.
+    The node type pins the service type, so a payload that leaves it out, or
+    sends it empty, must validate against that type instead of failing on the
+    polymorphic serializer.
+    """
+
+    user, token = data_fixture.create_user_and_token()
+    workflow = data_fixture.create_automation_workflow(user)
+    node = data_fixture.create_local_baserow_get_row_action_node(
+        user=user, workflow=workflow
+    )
+    service = {"row_id": "'42'"}
+    if service_type is not None:
+        service["type"] = service_type
+
+    response = api_client.patch(
+        reverse(API_URL_ITEM, kwargs={"node_id": node.id}),
+        {"service": service},
+        **get_api_kwargs(token),
+    )
+
+    assert response.status_code == HTTP_200_OK
+    response_json = response.json()
+    assert response_json["service"]["type"] == "local_baserow_get_row"
+    assert response_json["service"]["row_id"]["formula"] == "'42'"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("service_type", ["http_request", "unknown_service_type"])
+def test_update_node_service_with_a_type_the_node_does_not_use_is_refused(
+    api_client, data_fixture, service_type
+):
+    """
+    A different type would only pick which serializer the values are checked
+    against, after which they are applied to the node's own service type and
+    silently dropped. It must be refused instead, whether or not it exists.
     """
 
     user, token = data_fixture.create_user_and_token()
@@ -436,29 +470,16 @@ def test_update_node_service_without_type_is_a_validation_error(
     )
     response = api_client.patch(
         reverse(API_URL_ITEM, kwargs={"node_id": node.id}),
-        {"service": {"row_id": "'42'"}},
+        {"service": {"type": service_type, "url": "'http://example.notexist/'"}},
         **get_api_kwargs(token),
     )
     assert response.status_code == HTTP_400_BAD_REQUEST
     response_json = response.json()
     assert response_json["error"] == "ERROR_REQUEST_BODY_VALIDATION"
-    assert response_json["detail"]["service"]["type"][0]["code"] == "missing_type"
-
-
-@pytest.mark.django_db
-def test_update_node_service_with_invalid_type(api_client, data_fixture):
-    user, token = data_fixture.create_user_and_token()
-    workflow = data_fixture.create_automation_workflow(user)
-    node = data_fixture.create_local_baserow_get_row_action_node(
-        user=user, workflow=workflow
-    )
-    response = api_client.patch(
-        reverse(API_URL_ITEM, kwargs={"node_id": node.id}),
-        {"service": {"type": "unknown_service_type"}},
-        **get_api_kwargs(token),
-    )
-    assert response.status_code == HTTP_400_BAD_REQUEST
-    assert response.json()["error"] == "ERROR_SERVICE_INVALID_TYPE"
+    type_error = response_json["detail"]["service"]["type"][0]
+    assert type_error["code"] == "type_mismatch"
+    assert service_type in type_error["error"]
+    assert "local_baserow_get_row" in type_error["error"]
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/contrib/builder/api/workflow_actions/test_workflow_actions_views.py
+++ b/backend/tests/baserow/contrib/builder/api/workflow_actions/test_workflow_actions_views.py
@@ -643,6 +643,78 @@ def test_update_update_row_workflow_action(api_client, data_fixture):
 
 
 @pytest.mark.django_db
+def test_update_workflow_action_service_without_type(api_client, data_fixture):
+    """
+    The service type is pinned by the action type, so a payload that leaves it
+    out must still validate instead of failing on the polymorphic serializer.
+    """
+
+    user, token = data_fixture.create_user_and_token()
+    table, fields, rows = data_fixture.build_table(
+        user=user,
+        columns=[("Animal", "text")],
+        rows=[["Badger"]],
+    )
+    first_row = table.get_model().objects.get()
+    field = table.field_set.get(name="Animal")
+    page = data_fixture.create_builder_page(user=user)
+    element = data_fixture.create_builder_button_element(page=page)
+    workflow_action = data_fixture.create_local_baserow_update_row_workflow_action(
+        page=page, element=element, event=EventTypes.CLICK, user=user
+    )
+
+    url = reverse(
+        "api:builder:workflow_action:item",
+        kwargs={"workflow_action_id": workflow_action.id},
+    )
+    response = api_client.patch(
+        url,
+        {
+            "service": {
+                "table_id": table.id,
+                "row_id": str(first_row.id),
+                "integration_id": workflow_action.service.integration_id,
+                "field_mappings": [
+                    {"field_id": field.id, "value": "'Pony'", "enabled": True}
+                ],
+            },
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    response_json = response.json()
+    assert response.status_code == HTTP_200_OK
+    assert response_json["service"]["type"] == LocalBaserowUpsertRowServiceType.type
+    assert response_json["service"]["table_id"] == table.id
+    assert response_json["service"]["row_id"]["formula"] == str(first_row.id)
+
+
+@pytest.mark.django_db
+def test_update_workflow_action_service_with_invalid_type(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    page = data_fixture.create_builder_page(user=user)
+    element = data_fixture.create_builder_button_element(page=page)
+    workflow_action = data_fixture.create_local_baserow_update_row_workflow_action(
+        page=page, element=element, event=EventTypes.CLICK, user=user
+    )
+
+    url = reverse(
+        "api:builder:workflow_action:item",
+        kwargs={"workflow_action_id": workflow_action.id},
+    )
+    response = api_client.patch(
+        url,
+        {"service": {"type": "local_baserow_upsert_row1"}},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_SERVICE_INVALID_TYPE"
+
+
+@pytest.mark.django_db
 def test_dispatch_local_baserow_create_row_workflow_action(api_client, data_fixture):
     user, token = data_fixture.create_user_and_token()
     table, fields, rows = data_fixture.build_table(

--- a/backend/tests/baserow/contrib/builder/api/workflow_actions/test_workflow_actions_views.py
+++ b/backend/tests/baserow/contrib/builder/api/workflow_actions/test_workflow_actions_views.py
@@ -711,7 +711,75 @@ def test_update_workflow_action_service_with_invalid_type(api_client, data_fixtu
     )
 
     assert response.status_code == HTTP_400_BAD_REQUEST
-    assert response.json()["error"] == "ERROR_SERVICE_INVALID_TYPE"
+    response_json = response.json()
+    assert response_json["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+    assert response_json["detail"]["service"]["type"][0]["code"] == "type_mismatch"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("service_type", [["local_baserow_upsert_row"], {"a": 1}, 1])
+def test_update_workflow_action_service_with_a_non_string_type(
+    api_client, data_fixture, service_type
+):
+    user, token = data_fixture.create_user_and_token()
+    page = data_fixture.create_builder_page(user=user)
+    element = data_fixture.create_builder_button_element(page=page)
+    workflow_action = data_fixture.create_local_baserow_update_row_workflow_action(
+        page=page, element=element, event=EventTypes.CLICK, user=user
+    )
+
+    url = reverse(
+        "api:builder:workflow_action:item",
+        kwargs={"workflow_action_id": workflow_action.id},
+    )
+    response = api_client.patch(
+        url,
+        {"service": {"type": service_type}},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    response_json = response.json()
+    assert response_json["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+    assert response_json["detail"]["service"]["type"][0]["code"] == "invalid_type"
+
+
+@pytest.mark.django_db
+def test_update_workflow_action_service_with_a_type_the_action_does_not_use(
+    api_client, data_fixture
+):
+    """
+    The action type pins the service type, so naming another registered type
+    would only pick which serializer the values are checked against and then
+    silently drop them. It must be refused instead.
+    """
+
+    user, token = data_fixture.create_user_and_token()
+    page = data_fixture.create_builder_page(user=user)
+    element = data_fixture.create_builder_button_element(page=page)
+    workflow_action = data_fixture.create_local_baserow_update_row_workflow_action(
+        page=page, element=element, event=EventTypes.CLICK, user=user
+    )
+
+    url = reverse(
+        "api:builder:workflow_action:item",
+        kwargs={"workflow_action_id": workflow_action.id},
+    )
+    response = api_client.patch(
+        url,
+        {"service": {"type": "local_baserow_get_row", "row_id": "'42'"}},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    response_json = response.json()
+    assert response_json["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+    type_error = response_json["detail"]["service"]["type"][0]
+    assert type_error["code"] == "type_mismatch"
+    assert "local_baserow_get_row" in type_error["error"]
+    assert LocalBaserowUpsertRowServiceType.type in type_error["error"]
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/contrib/database/api/test_workflow_action_views.py
+++ b/backend/tests/baserow/contrib/database/api/test_workflow_action_views.py
@@ -615,6 +615,31 @@ def test_updating_with_a_service_type_the_action_does_not_use_is_refused(
 
 
 @pytest.mark.django_db
+def test_updating_with_an_unknown_service_type_is_refused(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    button_field = data_fixture.create_button_field(table=table)
+    action = data_fixture.create_database_workflow_action(
+        LocalBaserowCreateRowWorkflowAction, field=button_field
+    )
+
+    response = api_client.patch(
+        reverse(
+            "api:database:workflow_actions:item",
+            kwargs={"workflow_action_id": action.id},
+        ),
+        {"service": {"type": "nope"}},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST, response.json()
+    response_json = response.json()
+    assert response_json["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+    assert response_json["detail"]["service"]["type"][0]["code"] == "type_mismatch"
+
+
+@pytest.mark.django_db
 def test_naming_the_service_type_the_action_already_uses_is_accepted(
     api_client, data_fixture
 ):

--- a/backend/tests/baserow/core/services/test_service_backed_type_mixin.py
+++ b/backend/tests/baserow/core/services/test_service_backed_type_mixin.py
@@ -1,0 +1,101 @@
+import pytest
+
+from baserow.api.services.serializers import (
+    PolymorphicServiceRequestSerializer,
+    PolymorphicServiceSerializer,
+    PublicPolymorphicServiceSerializer,
+)
+from baserow.contrib.automation.api.nodes.serializers import (
+    CreateAutomationNodeSerializer,
+    UpdateAutomationNodeSerializer,
+)
+from baserow.contrib.automation.nodes.node_types import LocalBaserowGetRowNodeType
+from baserow.contrib.automation.nodes.registries import automation_node_type_registry
+from baserow.contrib.builder.workflow_actions.registries import (
+    builder_workflow_action_type_registry,
+)
+from baserow.contrib.builder.workflow_actions.workflow_action_types import (
+    CreateRowWorkflowActionType,
+)
+from baserow.contrib.database.workflow_actions.registries import (
+    database_workflow_action_type_registry,
+)
+from baserow.contrib.database.workflow_actions.workflow_action_types import (
+    LocalBaserowCreateRowWorkflowActionType,
+)
+
+
+def service_field(serializer_class):
+    return serializer_class().fields["service"]
+
+
+@pytest.mark.parametrize(
+    "registry,type_class,serializer_kwargs",
+    [
+        (builder_workflow_action_type_registry, CreateRowWorkflowActionType, {}),
+        (
+            database_workflow_action_type_registry,
+            LocalBaserowCreateRowWorkflowActionType,
+            {},
+        ),
+        (
+            automation_node_type_registry,
+            LocalBaserowGetRowNodeType,
+            {"base_class": UpdateAutomationNodeSerializer},
+        ),
+    ],
+)
+def test_request_serializer_service_field_is_pinned_to_the_service_type(
+    registry, type_class, serializer_kwargs
+):
+    instance_type = registry.get(type_class.type)
+
+    serializer_class = instance_type.get_serializer_class(
+        request_serializer=True, **serializer_kwargs
+    )
+
+    field = service_field(serializer_class)
+    assert isinstance(field, PolymorphicServiceRequestSerializer)
+    assert field.default_type_name is not None
+    assert field.default_type_name == type_class.service_type
+
+
+def test_response_serializer_service_field_is_untouched():
+    instance_type = builder_workflow_action_type_registry.get(
+        CreateRowWorkflowActionType.type
+    )
+
+    field = service_field(instance_type.get_serializer_class())
+
+    assert type(field) is PolymorphicServiceSerializer
+    assert field.default_type_name is None
+
+
+def test_public_request_serializer_service_field_is_untouched():
+    instance_type = builder_workflow_action_type_registry.get(
+        CreateRowWorkflowActionType.type
+    )
+
+    field = service_field(
+        instance_type.get_serializer_class(
+            request_serializer=True, extra_params={"public": True}
+        )
+    )
+
+    assert type(field) is PublicPolymorphicServiceSerializer
+
+
+def test_request_serializer_without_a_service_field_gains_none():
+    """
+    An automation node is created without a service, and the create view
+    documents per-type request serializers over that base, so the pinned
+    field must not be declared where `service` isn't a field.
+    """
+
+    instance_type = automation_node_type_registry.get(LocalBaserowGetRowNodeType.type)
+
+    serializer_class = instance_type.get_serializer_class(
+        request_serializer=True, base_class=CreateAutomationNodeSerializer
+    )
+
+    assert "service" not in serializer_class().fields

--- a/changelog/entries/unreleased/bug/fixes_a_crash_when_saving_a_workflow_action_with_a_missing_s.json
+++ b/changelog/entries/unreleased/bug/fixes_a_crash_when_saving_a_workflow_action_with_a_missing_s.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixes a crash when saving a workflow action with a missing service type.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-08-21"
+}


### PR DESCRIPTION
### What is in this PR
This fixes a crash when a workflow action is updated, but either:
- The `type` is omitted in the payload, or
- The `type` is invalid.

In the Sentry issue, you'll notice that the payload omits the `type`, resulting in a 500 error.

Fixes [this Sentry issue](https://baserow-eu.sentry.io/issues/96050159/).

I've also fixed the endpoints for Automation and Database to handle the same scenarios.

### How to test this PR

In `develop`, create a Builder app with a Button that has a Workflow Action that creates a row in a local baserow table.

Observe the network tab in your browser console, then update the workflow action service. Make a note of the payload, which contains the IDs you'll need when reproducing the error below.

In your shell, store the access token:
```shell
TOKEN=$(curl -s -X POST http://localhost:8000/api/user/token-auth/ \
  -H "Content-Type: application/json" \
  -d '{"email": "<your user>", "password": "<your password>"}' | jq -r .access_token)
```

Or just copy the access token from your network tab.

Then, make a request to update the workflow action:
```shell
curl -i -X PATCH 'http://localhost:8000/api/builder/workflow_action/17/' \
  -H "Authorization: JWT $TOKEN" -H "Content-Type: application/json" \
  --data-binary @- <<'JSON'
{
  "service": {
      "id": 57,
      "integration_id": 6,
      "type": "local_baserow_upsert_row",
      "schema": null,
      "context_data": null,
      "context_data_schema": null,
      "sample_data": null,
      "table_id": 57,
      "field_mappings": [
          {
              "enabled": true,
              "field_id": 569,
              "value": {
                  "formula": "'a'",
                  "mode": "simple"
              }
          }
      ],
      "row_id": {
          "formula": "",
          "mode": "simple",
          "version": "0.1"
      }
  }
}
JSON
```

This should work.

Now, send the same request, but delete the `"type": "local_baserow_upsert_row",` from the payload. You should see a crash:
```python
  File "/baserow/backend/src/baserow/api/polymorphic.py", line 93, in get_type_from_mapping
    self.fail("Unable to determine the `type` of the polymorphic data.")
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/baserow/venv/lib/python3.14/site-packages/rest_framework/fields.py", line 599, in fail
    raise AssertionError(msg)
AssertionError: ValidationError raised by `PolymorphicServiceRequestSerializer`, but error key `Unable to determine the `type` of the polymorphic data.` does not exist in the `error_messages` dictionary.
```

Next, try to supply an invalid type, e.g. `"type": "local_baserow_upsert_row1",`, it should crash with a different error:
```python
  File "/baserow/backend/src/baserow/api/polymorphic.py", line 91, in get_type_from_mapping
    return self.registry.get(mapping[self.type_field_name])
           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/baserow/backend/src/baserow/core/registry.py", line 792, in get
    raise self.does_not_exist_exception_class(
        type_name, f"The {self.name} type {type_name} does not exist."
    )
baserow.core.services.exceptions.ServiceTypeDoesNotExist: ('local_baserow_upsert_row1', 'The integration_service type local_baserow_upsert_row1 does not exist.')
HTTP PATCH /api/builder/workflow_action/17/ 500 [0.08, 172.19.0.1:56150]
```

In this branch:
- An invalid type should return a proper 400 error.
- A missing type should succeed (defaults to the service's own type).

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
