### PR TITLE
refactor: default the dispatch context stubs on the base class

### DIFF
--- a/backend/src/baserow/contrib/automation/automation_dispatch_context.py
+++ b/backend/src/baserow/contrib/automation/automation_dispatch_context.py
@@ -11,8 +11,6 @@ from baserow.contrib.automation.nodes.models import AutomationActionNode
 from baserow.contrib.automation.workflows.models import AutomationWorkflow
 from baserow.core.cache import local_cache
 from baserow.core.services.dispatch_context import DispatchContext
-from baserow.core.services.models import Service
-from baserow.core.services.utils import ServiceAdhocRefinements
 
 
 class AutomationDispatchContext(DispatchContext):
@@ -107,38 +105,3 @@ class AutomationDispatchContext(DispatchContext):
         """
 
         return super().get_timezone_name()
-
-    def range(self, service: Service):
-        return [0, None]
-
-    def sortings(self) -> Optional[str]:
-        return None
-
-    def filters(self) -> Optional[str]:
-        return None
-
-    @property
-    def is_publicly_sortable(self) -> bool:
-        return False
-
-    @property
-    def is_publicly_filterable(self) -> bool:
-        return False
-
-    @property
-    def is_publicly_searchable(self) -> bool:
-        return False
-
-    @property
-    def public_allowed_properties(self) -> Optional[Dict[str, Dict[int, List[str]]]]:
-        return None
-
-    def search_query(self) -> Optional[str]:
-        return None
-
-    def searchable_fields(self):
-        return []
-
-    def validate_filter_search_sort_fields(
-        self, fields: List[str], refinement: ServiceAdhocRefinements
-    ): ...

--- a/backend/src/baserow/contrib/builder/data_sources/builder_dispatch_context.py
+++ b/backend/src/baserow/contrib/builder/data_sources/builder_dispatch_context.py
@@ -166,10 +166,10 @@ class BuilderDispatchContext(DispatchContext):
                     pass
 
         # max prevent negative values
-        return [
+        return (
             max(0, offset),
             max(0, count) if count is not None else None,
-        ]
+        )
 
     def get_element_property_options(self) -> Dict[str, Dict[str, bool]]:
         """

--- a/backend/src/baserow/contrib/dashboard/data_sources/dispatch_context.py
+++ b/backend/src/baserow/contrib/dashboard/data_sources/dispatch_context.py
@@ -1,9 +1,8 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional
 
 from django.http import HttpRequest
 
 from baserow.core.services.dispatch_context import DispatchContext
-from baserow.core.services.utils import ServiceAdhocRefinements
 
 if TYPE_CHECKING:
     from baserow.contrib.dashboard.widgets.models import Widget
@@ -24,39 +23,3 @@ class DashboardDispatchContext(DispatchContext):
         self.widget = widget
 
         super().__init__()
-
-    def range(self, service):
-        offset, count = 0, None
-        return [offset, count]
-
-    @property
-    def is_publicly_searchable(self):
-        return False
-
-    def search_query(self):
-        return None
-
-    def searchable_fields(self):
-        return []
-
-    @property
-    def is_publicly_filterable(self):
-        return False
-
-    def filters(self):
-        return None
-
-    @property
-    def is_publicly_sortable(self):
-        return False
-
-    def sortings(self):
-        return None
-
-    @property
-    def public_allowed_properties(self):
-        return None
-
-    def validate_filter_search_sort_fields(
-        self, fields: List[str], refinement: ServiceAdhocRefinements
-    ): ...

--- a/backend/src/baserow/contrib/database/workflow_actions/dispatch_context.py
+++ b/backend/src/baserow/contrib/database/workflow_actions/dispatch_context.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from django.contrib.auth.models import AbstractUser
 
@@ -9,8 +9,6 @@ from baserow.contrib.database.fields.models import ButtonField
 from baserow.contrib.database.rows.data_providers import RowDataProviderType
 from baserow.core.formula.registries import DataProviderTypeRegistry
 from baserow.core.services.dispatch_context import DispatchContext
-from baserow.core.services.models import Service
-from baserow.core.services.utils import ServiceAdhocRefinements
 
 
 class DatabaseDispatchContext(DispatchContext):
@@ -20,6 +18,10 @@ class DatabaseDispatchContext(DispatchContext):
     It carries the clicked row so actions can read its values, and the acting
     user so Local Baserow services can authorise as the clicker rather than as
     an integration's `authorized_user` (ADR 006 section 5).
+
+    Search, filter, sort and pagination stay at the base class defaults: button
+    fields are absent from public views, so no anonymous caller reaches this
+    context, and nothing dispatched by a click is a paginated list service.
     """
 
     own_properties = ["field", "row"]
@@ -68,44 +70,3 @@ class DatabaseDispatchContext(DispatchContext):
     @property
     def data_provider_registry(self) -> DataProviderTypeRegistry:
         return database_data_provider_type_registry
-
-    def range(self, service: Service) -> tuple[int, int | None]:
-        # Nothing dispatched by a button click is a paginated list service.
-        return 0, None
-
-    @property
-    def is_publicly_searchable(self) -> bool:
-        # Button fields are absent from public views, so no anonymous caller
-        # reaches this context. Same for every hook below.
-        return False
-
-    def search_query(self) -> Optional[str]:
-        return None
-
-    def searchable_fields(self) -> List[str]:
-        return []
-
-    @property
-    def is_publicly_filterable(self) -> bool:
-        return False
-
-    def filters(self) -> Optional[str]:
-        return None
-
-    @property
-    def is_publicly_sortable(self) -> bool:
-        return False
-
-    def sortings(self) -> Optional[str]:
-        return None
-
-    @property
-    def public_allowed_properties(self) -> Optional[Dict[str, Dict[int, List[str]]]]:
-        return None
-
-    def validate_filter_search_sort_fields(
-        self, fields: List[str], refinement: ServiceAdhocRefinements
-    ):
-        raise NotImplementedError(
-            "A button dispatch has no ad hoc refinement surface to validate."
-        )

--- a/backend/src/baserow/core/services/dispatch_context.py
+++ b/backend/src/baserow/core/services/dispatch_context.py
@@ -61,8 +61,8 @@ class DispatchContext(RuntimeFormulaContext, ABC):
     def range(self, service: Service) -> tuple[int, int | None]:
         """
         Should return the pagination requested for the given service. Defaults to
-        no pagination, which suits every context that doesn't dispatch a paginated
-        list service.
+        the first page at the service's own default size, which suits every
+        context that has no pagination surface of its own.
 
         :params service: The service we want the pagination for.
         :return: a tuple were the first value is the offset to apply and the second

--- a/backend/src/baserow/core/services/dispatch_context.py
+++ b/backend/src/baserow/core/services/dispatch_context.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 from typing import Any, Dict, List, Optional
 
 from django.contrib.auth.models import AbstractUser
@@ -58,16 +58,19 @@ class DispatchContext(RuntimeFormulaContext, ABC):
         self.actor = actor
         super().__init__()
 
-    @abstractmethod
     def range(self, service: Service) -> tuple[int, int | None]:
         """
-        Should return the pagination requested for the given service.
+        Should return the pagination requested for the given service. Defaults to
+        no pagination, which suits every context that doesn't dispatch a paginated
+        list service.
 
         :params service: The service we want the pagination for.
         :return: a tuple were the first value is the offset to apply and the second
           value is the count of records to return. The count can be None it which case
           the default number of record should be returned.
         """
+
+        return 0, None
 
     def clone(self, **kwargs) -> RuntimeFormulaContextSubClass:
         """
@@ -107,22 +110,24 @@ class DispatchContext(RuntimeFormulaContext, ABC):
         return True
 
     @property
-    @abstractmethod
     def is_publicly_searchable(self) -> bool:
         """
         Responsible for returning whether external service visitors
-        can apply search or not.
+        can apply search or not. Defaults to False, only contexts with a public
+        surface can opt in.
         """
 
-    @abstractmethod
+        return False
+
     def search_query(self) -> Optional[str]:
         """
         Responsible for returning the on-demand search query, depending
         on which module the `DispatchContext` is used by.
         """
 
-    @abstractmethod
-    def searchable_fields(self) -> Optional[List[str]]:
+        return None
+
+    def searchable_fields(self) -> List[str]:
         """
         Responsible for returning the on-demand searchable fields, depending
         on which module the `DispatchContext` is used by.
@@ -131,37 +136,42 @@ class DispatchContext(RuntimeFormulaContext, ABC):
         return []
 
     @property
-    @abstractmethod
     def is_publicly_filterable(self) -> bool:
         """
         Responsible for returning whether external service visitors
-        can apply filters or not.
+        can apply filters or not. Defaults to False, only contexts with a public
+        surface can opt in.
         """
 
-    @abstractmethod
+        return False
+
     def filters(self) -> Optional[str]:
         """
         Responsible for returning the on-demand filters, depending
         on which module the `DispatchContext` is used by.
         """
 
+        return None
+
     @property
-    @abstractmethod
     def is_publicly_sortable(self) -> bool:
         """
         Responsible for returning whether external service visitors
-        can apply sortings or not.
+        can apply sortings or not. Defaults to False, only contexts with a public
+        surface can opt in.
         """
 
-    @abstractmethod
+        return False
+
     def sortings(self) -> Optional[str]:
         """
         Responsible for returning the on-demand sortings, depending
         on which module the `DispatchContext` is used by.
         """
 
+        return None
+
     @property
-    @abstractmethod
     def public_allowed_properties(self) -> Optional[Dict[str, Dict[int, List[str]]]]:
         """
         Return a Dict where keys are ["all", "external", "internal"] and values
@@ -179,7 +189,8 @@ class DispatchContext(RuntimeFormulaContext, ABC):
         sensitive (required only by the backend).
         """
 
-    @abstractmethod
+        return None
+
     def validate_filter_search_sort_fields(
         self, fields: List[str], refinement: ServiceAdhocRefinements
     ):
@@ -189,6 +200,16 @@ class DispatchContext(RuntimeFormulaContext, ABC):
         if the `refinement` is `FILTER`, then all fields in `fields` need
         to be filterable.
 
+        Only reachable when the context declares itself publicly filterable,
+        sortable or searchable, so the default raises: a context that opts into
+        ad hoc refinements has to say which fields are allowed rather than
+        silently accepting every field.
+
         :param fields: The fields to validate.
         :param refinement: The refinement to validate.
         """
+
+        raise NotImplementedError(
+            f"{self.__class__.__name__} allows ad hoc refinements but doesn't "
+            "validate the fields they point at."
+        )

--- a/backend/src/baserow/test_utils/pytest_conftest.py
+++ b/backend/src/baserow/test_utils/pytest_conftest.py
@@ -1034,7 +1034,7 @@ class FakeDispatchContext(DispatchContext):
         return self._sortings
 
     def range(self, service):
-        return [0, self._count]
+        return 0, self._count
 
     def __getitem__(self, key: str) -> Any:
         if key == "test":
@@ -1055,6 +1055,8 @@ class FakeDispatchContext(DispatchContext):
     def validate_filter_search_sort_fields(
         self, fields: List[str], refinement: ServiceAdhocRefinements
     ):
+        # The fake context declares itself publicly refinable, so it has to
+        # accept the fields the tests refine on.
         pass
 
 

--- a/backend/tests/baserow/contrib/builder/data_sources/test_dispatch_context.py
+++ b/backend/tests/baserow/contrib/builder/data_sources/test_dispatch_context.py
@@ -23,19 +23,19 @@ def test_dispatch_context_page_range():
 
     dispatch_context = BuilderDispatchContext(request, None)
 
-    assert dispatch_context.range(None) == [42, 42]
+    assert dispatch_context.range(None) == (42, 42)
 
     request.GET = {"offset": "foo", "count": "bar"}
 
     dispatch_context = BuilderDispatchContext(request, None)
 
-    assert dispatch_context.range(None) == [0, None]
+    assert dispatch_context.range(None) == (0, None)
 
     request.GET = {"offset": "-20", "count": "-10"}
 
     dispatch_context = BuilderDispatchContext(request, None)
 
-    assert dispatch_context.range(None) == [0, 0]
+    assert dispatch_context.range(None) == (0, 0)
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/core/service/test_base_dispatch_context.py
+++ b/backend/tests/baserow/core/service/test_base_dispatch_context.py
@@ -1,0 +1,34 @@
+import pytest
+
+from baserow.core.services.dispatch_context import DispatchContext
+from baserow.core.services.utils import ServiceAdhocRefinements
+
+
+class MinimalDispatchContext(DispatchContext):
+    """A context that implements nothing but what the base class requires."""
+
+
+def test_the_default_range_is_unpaginated():
+    assert MinimalDispatchContext().range(None) == (0, None)
+
+
+def test_nothing_is_public_by_default():
+    dispatch_context = MinimalDispatchContext()
+
+    assert dispatch_context.is_publicly_searchable is False
+    assert dispatch_context.is_publicly_filterable is False
+    assert dispatch_context.is_publicly_sortable is False
+    assert dispatch_context.search_query() is None
+    assert dispatch_context.searchable_fields() == []
+    assert dispatch_context.filters() is None
+    assert dispatch_context.sortings() is None
+    assert dispatch_context.public_allowed_properties is None
+
+
+def test_validating_refinements_is_not_silently_allowed():
+    # A context that opts into adhoc refinements has to say which fields they
+    # may point at, rather than inheriting a no-op that accepts every field.
+    with pytest.raises(NotImplementedError):
+        MinimalDispatchContext().validate_filter_search_sort_fields(
+            ["field_1"], ServiceAdhocRefinements.FILTER
+        )

--- a/backend/tests/baserow/core/service/test_base_dispatch_context.py
+++ b/backend/tests/baserow/core/service/test_base_dispatch_context.py
@@ -8,7 +8,8 @@ class MinimalDispatchContext(DispatchContext):
     """A context that implements nothing but what the base class requires."""
 
 
-def test_the_default_range_is_unpaginated():
+def test_the_default_range_is_the_first_page_at_the_default_size():
+    # A `None` count leaves the page size to the service itself.
     assert MinimalDispatchContext().range(None) == (0, None)
 
 


### PR DESCRIPTION
Item 3 of #5934.

Automation, dashboard and the button field each wrote out the same empty search, filter, sort and pagination hooks. They now come from `DispatchContext` itself, so a new context only writes the ones it actually needs.

Two of those copies disagreed with each other, so this picks a winner for both:

- **`range()` returns a tuple.** That's what the base class annotation already said and what the only caller unpacks; two of the three returned a list. Builder and the test fake return tuples now too.
- **`validate_filter_search_sort_fields()` raises.** Two returned nothing, one raised. It's only ever called when a context says it is publicly filterable/sortable, and those now default to `False`, so nothing reaches it today. If a future context does turn refinements on, raising makes it say which fields are allowed instead of quietly accepting all of them.

The button field context keeps a short note about why none of this applies to it.

No behaviour change.