### PR TITLE
fix: Ensure Iterator service generates schema only when data is present

### DIFF
--- a/backend/src/baserow/contrib/integrations/core/service_types.py
+++ b/backend/src/baserow/contrib/integrations/core/service_types.py
@@ -2048,8 +2048,11 @@ class CoreIteratorServiceType(ListServiceTypeMixin, ServiceType):
         service: CoreIteratorService,
         allowed_fields: Optional[List[str]] = None,
     ) -> Optional[Dict[str, Any]]:
-        if service.sample_data and (
-            allowed_fields is None or "items" in allowed_fields
+        if (
+            service.sample_data
+            and "data" in service.sample_data
+            and "results" in service.sample_data["data"]
+            and (allowed_fields is None or "items" in allowed_fields)
         ):
             schema_builder = SchemaBuilder()
             schema_builder.add_object(service.sample_data["data"]["results"])
@@ -2061,10 +2064,8 @@ class CoreIteratorServiceType(ListServiceTypeMixin, ServiceType):
                     **schema,
                     "title": self.get_schema_name(service),
                 }
-            else:
-                return None
-        else:
-            return None
+
+        return None
 
     def formulas_to_resolve(self, service: CoreRouterService) -> list[FormulaToResolve]:
         """

--- a/backend/src/baserow/core/services/registries.py
+++ b/backend/src/baserow/core/services/registries.py
@@ -240,9 +240,17 @@ class ServiceType(
     def get_sample_data(
         self, service: ServiceSubClass, dispatch_context: DispatchContext
     ) -> Optional[Dict[Any, Any]]:
-        """Return the sample data for this service."""
+        """Return the usable sample data for this service, if any."""
 
-        return service.sample_data
+        sample_data = service.sample_data
+
+        # A failed simulated dispatch stores an `{"_error": ...}` sentinel so
+        # the frontend can display the failure. It doesn't hold `DispatchResult`
+        # fields, so it can't be replayed and counts as no sample data.
+        if sample_data is not None and "_error" in sample_data:
+            return None
+
+        return sample_data
 
     def get_context_data_schema(self, service: ServiceSubClass):
         """Return the schema for the context data."""

--- a/backend/tests/baserow/contrib/automation/api/nodes/test_nodes_views.py
+++ b/backend/tests/baserow/contrib/automation/api/nodes/test_nodes_views.py
@@ -239,6 +239,32 @@ def test_get_nodes(api_client, data_fixture):
 
 
 @pytest.mark.django_db
+def test_get_nodes_with_failed_simulated_dispatch_sample_data(api_client, data_fixture):
+    """
+    A failed simulated dispatch stores an `{"_error": ...}` sentinel as the
+    service's sample data. Listing the workflow's nodes must still work, with a
+    `None` schema and the sentinel exposed so the frontend can display it.
+    """
+
+    user, token = data_fixture.create_user_and_token()
+    workflow = data_fixture.create_automation_workflow(user)
+    node = data_fixture.create_core_iterator_action_node(workflow=workflow)
+    service = node.service.specific
+    service.sample_data = {"_error": "Value error for 'source' property"}
+    service.save()
+
+    url = reverse(API_URL_LIST, kwargs={"workflow_id": workflow.id})
+    response = api_client.get(url, **get_api_kwargs(token))
+
+    assert response.status_code == HTTP_200_OK
+    iterator_node = next(n for n in response.json() if n["id"] == node.id)
+    assert iterator_node["service"]["schema"] is None
+    assert iterator_node["service"]["sample_data"] == {
+        "_error": "Value error for 'source' property"
+    }
+
+
+@pytest.mark.django_db
 def test_get_node_invalid_workflow(api_client, data_fixture):
     _, token = data_fixture.create_user_and_token()
 

--- a/backend/tests/baserow/contrib/integrations/core/test_iterator_service_type.py
+++ b/backend/tests/baserow/contrib/integrations/core/test_iterator_service_type.py
@@ -82,3 +82,18 @@ def test_core_iterator_service_type_empty_schema(data_fixture):
 
     service_type = service.get_type()
     assert service_type.generate_schema(service) is None
+
+
+@pytest.mark.django_db
+def test_core_iterator_service_type_error_sample_data_schema(data_fixture):
+    """
+    A failed simulated dispatch stores an `{"_error": ...}` sentinel as sample
+    data. Generating the schema should return `None` instead of raising.
+    """
+
+    service = data_fixture.create_core_iterator_service(
+        sample_data={"_error": "Value error for 'source' property"}
+    )
+
+    service_type = service.get_type()
+    assert service_type.generate_schema(service) is None

--- a/backend/tests/baserow/core/service/test_service_type.py
+++ b/backend/tests/baserow/core/service/test_service_type.py
@@ -215,6 +215,23 @@ def test_get_sample_data():
     assert result == {"foo": "bar"}
 
 
+def test_get_sample_data_with_error_sentinel():
+    """
+    The `{"_error": ...}` sentinel stored by a failed simulated dispatch is not
+    replayable sample data, so `get_sample_data` should return `None`.
+    """
+
+    service_type_cls = ServiceType
+    service_type_cls.model_class = MagicMock()
+    service_type = service_type_cls()
+    service = MagicMock()
+    service.sample_data = {"_error": "Something went wrong"}
+
+    dispatch_context = FakeDispatchContext()
+
+    assert service_type.get_sample_data(service, dispatch_context) is None
+
+
 def test_dispatch_returns_sample_data_when_simulated():
     """
     Ensure that when dispatch_context.is_simulated is True, the cached sample
@@ -300,6 +317,36 @@ def test_dispatch_even_if_simulated_without_sample_data():
     service_type.dispatch_data.assert_called()
     service_type.dispatch_transform.assert_called()
     service_type.get_sample_data.assert_called_once()
+
+    assert result.data == {"someother": "data"}
+
+
+@pytest.mark.django_db
+def test_dispatch_even_if_simulated_with_error_sample_data():
+    """
+    Ensure that when the stored sample data is the `{"_error": ...}` sentinel
+    from a previously failed simulated dispatch, the service is dispatched
+    again instead of replaying the sentinel (which would raise a TypeError).
+    """
+
+    service_type_cls = ServiceType
+    service_type_cls.model_class = MagicMock()
+    service_type = service_type_cls()
+
+    service_type.dispatch_data = MagicMock(return_value={"data": {"other": "data"}})
+    service_type.dispatch_transform = MagicMock(
+        return_value=DispatchResult(data={"someother": "data"})
+    )
+
+    mock_service = MagicMock()
+    mock_service.sample_data = {"_error": "Something went wrong"}
+
+    dispatch_context = FakeDispatchContext(use_sample_data=True)
+
+    result = service_type.dispatch(mock_service, dispatch_context)
+
+    service_type.dispatch_data.assert_called()
+    service_type.dispatch_transform.assert_called()
 
     assert result.data == {"someother": "data"}
 

--- a/changelog/entries/unreleased/bug/fixed_a_bug_causing_a_crash_when_generating_the_schema_for_t.json
+++ b/changelog/entries/unreleased/bug/fixed_a_bug_causing_a_crash_when_generating_the_schema_for_t.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed a bug causing a crash when generating the schema for the Iterator service type.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-08-21"
+}


### PR DESCRIPTION
### What is in this PR
This PR fixes a bug in the schema generation for the core Iterator service type.

When the sample data contains `_error` (because of a failed simulation), subsequently generating the schema caused a crash because we check the data/results key without a guard.

Resolves [this Sentry issue](https://baserow-eu.sentry.io/issues/103970816/)

### How to test this PR
In `develop`, create an Iterator node and cause it to have an error in its sample data.

Easiest way is to manually update the sample data of the service:
```python
from baserow.contrib.integrations.core.models import CoreIteratorService
CoreIteratorService.objects.update(sample_data={"_error": "foo error"})
```

Navigate away from the Workflow and navigate back (or just reload the editor), and you'll see a crash:
```python
  File "/baserow/backend/src/baserow/contrib/integrations/core/service_types.py", line 2055, in generate_schema
    schema_builder.add_object(service.sample_data["data"]["results"])
                              ~~~~~~~~~~~~~~~~~~~^^^^^^^^
KeyError: 'data'
```

In this branch, the workflow should load and the Iterator should show the expected error:
> <img width="300" alt="image" src="https://github.com/user-attachments/assets/adc85001-af08-40e0-88b5-49702d3c9254" />

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
