### PR TITLE
fix: add guard for column element children position

### DIFF
--- a/backend/src/baserow/contrib/builder/elements/element_types.py
+++ b/backend/src/baserow/contrib/builder/elements/element_types.py
@@ -315,9 +315,22 @@ class ColumnElementType(ContainerElementTypeMixin, ElementType):
         self, place_in_container: str, instance: ColumnElement
     ):
         max_place_in_container = instance.column_amount - 1
-        if int(place_in_container) > max_place_in_container:
+        try:
+            place_in_container_casted = int(place_in_container)
+        except (TypeError, ValueError) as exc:
             raise DRFValidationError(
-                f"place_in_container can at most be {max_place_in_container}, ({place_in_container}, was given)"
+                f"place_in_container must be an integer between 0 and "
+                f"{max_place_in_container}, ({place_in_container!r} was given)"
+            ) from exc
+        if place_in_container_casted < 0:
+            raise DRFValidationError(
+                f"place_in_container must be at least 0, "
+                f"({place_in_container} was given)"
+            )
+        if place_in_container_casted > max_place_in_container:
+            raise DRFValidationError(
+                f"place_in_container can at most be {max_place_in_container}, "
+                f"({place_in_container}, was given)"
             )
 
     @property

--- a/backend/tests/baserow/contrib/builder/api/elements/test_column_element.py
+++ b/backend/tests/baserow/contrib/builder/api/elements/test_column_element.py
@@ -394,6 +394,103 @@ def test_column_element_invalid_child_in_container_on_create(api_client, data_fi
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    "place_in_container,error",
+    [
+        ("", "place_in_container must be an integer between 0 and 1, ('' was given)"),
+        (
+            "abc",
+            "place_in_container must be an integer between 0 and 1, ('abc' was given)",
+        ),
+        (None, "place_in_container must be an integer between 0 and 1, ('' was given)"),
+        ("-1", "place_in_container must be at least 0, (-1 was given)"),
+    ],
+)
+def test_column_element_non_numeric_child_place_in_container_on_create(
+    api_client, data_fixture, place_in_container, error
+):
+    user, token = data_fixture.create_user_and_token()
+    column_element = data_fixture.create_builder_column_element(
+        user=user, column_amount=2
+    )
+
+    url = reverse(
+        "api:builder:element:list", kwargs={"page_id": column_element.page.id}
+    )
+    response = api_client.post(
+        url,
+        {
+            "type": "text",
+            "reference_element_id": column_element.id,
+            "position": GraphPointPosition.CHILD,
+            "place_in_container": place_in_container,
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json() == [error]
+
+
+@pytest.mark.django_db
+def test_column_element_omitted_child_place_in_container_on_create(
+    api_client, data_fixture
+):
+    user, token = data_fixture.create_user_and_token()
+    column_element = data_fixture.create_builder_column_element(
+        user=user, column_amount=2
+    )
+
+    url = reverse(
+        "api:builder:element:list", kwargs={"page_id": column_element.page.id}
+    )
+    response = api_client.post(
+        url,
+        {
+            "type": "text",
+            "reference_element_id": column_element.id,
+            "position": GraphPointPosition.CHILD,
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json() == [
+        "place_in_container must be an integer between 0 and 1, ('' was given)"
+    ]
+
+
+@pytest.mark.django_db
+def test_column_element_empty_child_place_in_container_on_move(
+    api_client, data_fixture
+):
+    user, token = data_fixture.create_user_and_token()
+    column_element = data_fixture.create_builder_column_element(
+        user=user, column_amount=2
+    )
+    child = data_fixture.create_builder_text_element(page=column_element.page)
+
+    url = reverse("api:builder:element:move", kwargs={"element_id": child.id})
+    response = api_client.patch(
+        url,
+        {
+            "reference_element_id": column_element.id,
+            "position": GraphPointPosition.CHILD,
+            "place_in_container": "",
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json() == [
+        "place_in_container must be an integer between 0 and 1, ('' was given)"
+    ]
+
+
+@pytest.mark.django_db
 def test_column_element_custom_weights_validation(api_client, data_fixture):
     user, token = data_fixture.create_user_and_token()
     page = data_fixture.create_builder_page(user=user)

--- a/backend/tests/baserow/contrib/builder/elements/test_column_element_type.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_column_element_type.py
@@ -44,8 +44,11 @@ def test_get_places_in_container_removed(data_fixture):
 def test_validate_position_as_child(data_fixture):
     column_element = data_fixture.create_builder_column_element(column_amount=2)
 
-    with pytest.raises(ValidationError):
-        ColumnElementType().validate_position_as_child("5", column_element)
+    for invalid_place in ["5", "", "abc", "-1", None]:
+        with pytest.raises(ValidationError):
+            ColumnElementType().validate_position_as_child(
+                invalid_place, column_element
+            )
 
     try:
         ColumnElementType().validate_position_as_child("1", column_element)

--- a/changelog/entries/unreleased/bug/fixed_an_error_when_adding_an_element_to_a_column_with_an_in.json
+++ b/changelog/entries/unreleased/bug/fixed_an_error_when_adding_an_element_to_a_column_with_an_in.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed an error when adding an element to a column with an invalid or missing position.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-08-24"
+}


### PR DESCRIPTION
### What is in this PR
This PR fixes a bug when creating an element inside a Column element, but with a missing or invalid `place_in_container` field.

The Sentry issue shows this payload when posting to `/api/builder/page/{page_id}/elements/`:
```json
{
  "position": "child",
  "reference_element_id": <column element id>,
  "type": "text"
}
```

Notice how `place_in_container` is missing in the payload. The backend serializers makes this field optional and defaults to an empty string, and when it's missing/invalid throws:
```
ValueError
invalid literal for int() with base 10: ''
```

This isn't reproducible via the UI, so I assume the user was directly calling the API.

Fixes [this Sentry issue](https://baserow-eu.sentry.io/issues/142543179/)

### How to test this PR
In the latest `develop`, create a Builder app with a Column element, and keep track of the Column element's ID (check network tab).

Next, store your token (or just copy your access token from Chrome):
```bash
TOKEN=$(curl -s -X POST http://localhost:8000/api/user/token-auth/ \
  -H "Content-Type: application/json" \
  -d '{"email": "<your local user>", "password": "<your pass>"}' | jq -r .access_token)
```

Then try to create a child inside your Column element:
```bash
curl -i -X POST 'http://localhost:8000/api/builder/page/<your page ID>/elements/' \
  -H "Authorization: JWT $TOKEN" -H "Content-Type: application/json" \
  --data-binary @- <<'JSON'
{
  "type": "heading",
  "position": "child",
  "place_in_container": "",
  "reference_element_id": <column element id>
}
JSON
```

In `develop` this will crash:
```python
  File "/baserow/backend/src/baserow/contrib/builder/elements/element_types.py", line 314, in validate_position_as_child
    if int(place_in_container) > max_place_in_container:
       ~~~^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: ''
```

Also try using a random text value, e.g. `"place_in_container": "foo",` or just omit the field. You'll get a similar error.

In this branch, you'll get a proper 400 error.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
