### PR TITLE
fix: show optimistic field value immediately when queue has pending tasks

### DIFF
--- a/changelog/entries/unreleased/bug/5955_fixed_a_bug_where_editing_a_field_value_in_a_view_with_filte.json
+++ b/changelog/entries/unreleased/bug/5955_fixed_a_bug_where_editing_a_field_value_in_a_view_with_filte.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed a bug where editing a field value in a view with filters, sorts, or group-bys would briefly revert to the old value when another update was still in progress.",
+    "issue_origin": "github",
+    "issue_number": 5955,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-25"
+}

--- a/web-frontend/modules/database/store/view/grid.js
+++ b/web-frontend/modules/database/store/view/grid.js
@@ -4977,10 +4977,8 @@ export const actions = {
       getters.getActiveSearchTerm
     )
 
-    // Optimistically commit the value only when it can't move or hide the row.
-    // Grouped/sorted/filtered views defer to the queued lifecycle path below while the
-    // old values are still intact; the PATCH and side-effects run in the task queue.
-    if (canUpdateOptimistically && !hasViewRulesThatCanMoveOrHideRows) {
+    // Commit immediately so the cell reflects the edit; lifecycle deferred to queue.
+    if (canUpdateOptimistically) {
       const storeRow = getters.getRow(row.id)
       if (storeRow !== undefined) {
         commit('UPDATE_ROW_FIELD_VALUE', { row: storeRow, field, value })
@@ -5000,7 +4998,12 @@ export const actions = {
        * This helper function will make sure that the values of the related row are
        * updated the right way.
        */
-      const updateValues = async (row, values, optimisticUpdate) => {
+      const updateValues = async (
+        row,
+        values,
+        optimisticUpdate,
+        beforeValues = null
+      ) => {
         const rowExistsInBuffer = getters.getRow(row.id) !== undefined
 
         if (rowExistsInBuffer) {
@@ -5019,6 +5022,7 @@ export const actions = {
               fields,
               row,
               values,
+              beforeValues,
               markGroupAggregationsLoading: optimisticUpdate,
             })
           } else {
@@ -5114,7 +5118,12 @@ export const actions = {
       // it feel instant for the user. If we can't safely do it in the frontend, then
       // we have to show a loading state and update the row after the request has been
       // made.
-      await updateValues(row, newRowValues, canUpdateOptimistically)
+      await updateValues(
+        row,
+        newRowValues,
+        canUpdateOptimistically,
+        oldRowValues
+      )
       try {
         const batchResponse = await RowService($client).batchUpdate(
           table.id,
@@ -5528,6 +5537,7 @@ export const actions = {
       updatedFieldIds = [],
       markGroupAggregationsLoading = false,
       forceGroupByRowMove = false,
+      beforeValues = null,
     }
   ) {
     const { $registry } = this
@@ -5537,7 +5547,11 @@ export const actions = {
     if (baseRow === null) {
       return
     }
-    const oldRow = clone(baseRow)
+    // Overlay old field values so filter/sort transition detection
+    // compares against the pre-optimistic state.
+    const oldRow = beforeValues
+      ? Object.assign(clone(baseRow), beforeValues)
+      : clone(baseRow)
     const newRow = Object.assign(clone(baseRow), values)
     populateRow(oldRow, metadata)
     populateRow(newRow, metadata)

--- a/web-frontend/test/unit/database/store/view/grid.spec.js
+++ b/web-frontend/test/unit/database/store/view/grid.spec.js
@@ -930,6 +930,244 @@ describe('Grid view store', () => {
     expect(flatStore.getters['grid/getAllRows'][0].field_1).toBe('99')
   })
 
+  test('updateRowValue shows optimistic value immediately even when queue has pending tasks and view has filters', async () => {
+    const fields = [
+      {
+        id: 1,
+        name: 'Name',
+        type: 'text',
+        primary: true,
+        _: { type: { type: 'text' } },
+      },
+      {
+        id: 2,
+        name: 'Date',
+        type: 'date',
+        _: { type: { type: 'date' } },
+      },
+    ]
+    const flatStore = testApp.createStore({
+      modules: {
+        grid: {
+          ...gridStore,
+          actions: {
+            ...gridStore.actions,
+            fetchByScrollTopDelayed: vi.fn(),
+            fetchAllFieldAggregationData: vi.fn(),
+          },
+        },
+      },
+    })
+    const rowMetadata = {
+      selected: false,
+      selectedFieldId: -1,
+      selectedBy: [],
+      loading: false,
+      matchFilters: true,
+      matchSortings: true,
+      matchSearch: true,
+      fieldSearchMatches: [],
+      persistentId: 'r1',
+    }
+    const state = Object.assign(gridStore.state(), {
+      lastGridId: 1,
+      count: 1,
+      bufferStartIndex: 0,
+      bufferLimit: 10,
+      rows: [
+        {
+          id: 1,
+          order: '1.00',
+          field_1: 'old text',
+          field_2: null,
+          _: { ...rowMetadata },
+        },
+      ],
+    })
+    flatStore.replaceState({ ...flatStore.state, grid: state })
+
+    // View with active filter — triggers hasViewRulesThatCanMoveOrHideRows
+    const view = {
+      id: 1,
+      filters: [{ id: 1, field: 1, type: 'contains', value: '' }],
+      filter_groups: [],
+      filter_type: 'AND',
+      filters_disabled: false,
+      sortings: [],
+      group_bys: [],
+    }
+
+    // Hold the first PATCH so the second update queues behind it
+    let finishFirstPatch
+    let patchCount = 0
+    mockServer.mock.onPatch('/database/rows/table/1/batch/').reply(
+      () =>
+        new Promise((resolve) => {
+          patchCount++
+          if (patchCount === 1) {
+            finishFirstPatch = () =>
+              resolve([
+                200,
+                {
+                  items: [
+                    {
+                      id: 1,
+                      order: '1.00',
+                      field_1: 'new text',
+                      field_2: null,
+                    },
+                  ],
+                  metadata: { updated_field_ids: [1] },
+                },
+              ])
+          } else {
+            resolve([
+              200,
+              {
+                items: [
+                  {
+                    id: 1,
+                    order: '1.00',
+                    field_1: 'new text',
+                    field_2: '2025-06-15',
+                  },
+                ],
+                metadata: { updated_field_ids: [2] },
+              },
+            ])
+          }
+        })
+    )
+
+    // First update: text field — starts PATCH, holds
+    const firstUpdate = flatStore.dispatch('grid/updateRowValue', {
+      table: { id: 1 },
+      view,
+      fields,
+      row: flatStore.getters['grid/getAllRows'][0],
+      field: fields[0],
+      value: 'new text',
+      oldValue: 'old text',
+    })
+    await new Promise((resolve) => setTimeout(resolve))
+
+    // First PATCH is in flight. Now update date field — queued behind first.
+    const secondUpdate = flatStore.dispatch('grid/updateRowValue', {
+      table: { id: 1 },
+      view,
+      fields,
+      row: flatStore.getters['grid/getAllRows'][0],
+      field: fields[1],
+      value: '2025-06-15',
+      oldValue: null,
+    })
+    await new Promise((resolve) => setTimeout(resolve))
+
+    // The date value should be visible in the store immediately, even though
+    // the queue task hasn't run yet.
+    const rowAfterQueue = flatStore.getters['grid/getAllRows'][0]
+    expect(rowAfterQueue.field_2).toBe('2025-06-15')
+
+    // Finish first PATCH and let everything settle
+    finishFirstPatch()
+    await Promise.all([firstUpdate, secondUpdate])
+
+    // After both complete, value should still be correct
+    const finalRow = flatStore.getters['grid/getAllRows'][0]
+    expect(finalRow.field_2).toBe('2025-06-15')
+    expect(finalRow.field_1).toBe('new text')
+  })
+
+  test('updateRowValue with optimistic commit still hides row that violates filter', async () => {
+    const fields = [
+      {
+        id: 1,
+        name: 'Name',
+        type: 'text',
+        primary: true,
+        _: { type: { type: 'text' } },
+      },
+    ]
+    const flatStore = testApp.createStore({
+      modules: {
+        grid: {
+          ...gridStore,
+          actions: {
+            ...gridStore.actions,
+            fetchByScrollTopDelayed: vi.fn(),
+            fetchAllFieldAggregationData: vi.fn(),
+          },
+        },
+      },
+    })
+    const rowMetadata = {
+      selected: false,
+      selectedFieldId: -1,
+      selectedBy: [],
+      loading: false,
+      matchFilters: true,
+      matchSortings: true,
+      matchSearch: true,
+      fieldSearchMatches: [],
+      persistentId: 'r1',
+    }
+    const state = Object.assign(gridStore.state(), {
+      lastGridId: 1,
+      count: 2,
+      bufferStartIndex: 0,
+      bufferLimit: 10,
+      rows: [
+        {
+          id: 1,
+          order: '1.00',
+          field_1: 'hello',
+          _: { ...rowMetadata },
+        },
+        {
+          id: 2,
+          order: '2.00',
+          field_1: 'world',
+          _: { ...rowMetadata, persistentId: 'r2' },
+        },
+      ],
+    })
+    flatStore.replaceState({ ...flatStore.state, grid: state })
+
+    // Filter: field_1 must contain "hello" — changing to "bye" should hide row
+    const view = {
+      id: 1,
+      filters: [{ id: 1, field: 1, type: 'contains', value: 'hello' }],
+      filter_groups: [],
+      filter_type: 'AND',
+      filters_disabled: false,
+      sortings: [],
+      group_bys: [],
+    }
+
+    mockServer.mock.onPatch('/database/rows/table/1/batch/').reply(() => [
+      200,
+      {
+        items: [{ id: 1, order: '1.00', field_1: 'bye' }],
+        metadata: { updated_field_ids: [1] },
+      },
+    ])
+
+    await flatStore.dispatch('grid/updateRowValue', {
+      table: { id: 1 },
+      view,
+      fields,
+      row: flatStore.getters['grid/getAllRows'][0],
+      field: fields[0],
+      value: 'bye',
+      oldValue: 'hello',
+    })
+
+    // Row 1 should be removed from buffer — it no longer matches the filter
+    const remainingRows = flatStore.getters['grid/getAllRows']
+    const row1 = remainingRows.find((r) => r.id === 1)
+    expect(row1).toBeUndefined()
+  })
+
   test('updateRowValue discards a save for a row without an id (row modal closed mid-edit)', async () => {
     const fields = [{ id: 1, name: 'Name', type: 'text', primary: true }]
     const view = { id: 1, filters: [], sortings: [], group_bys: [] }


### PR DESCRIPTION
Closes #5955

## Summary
- Always commit the edited field value to the store immediately, even when the view has filters/sorts/group-bys and earlier update tasks are still queued
- Pass `beforeValues` into `updatedExistingRow` so filter/sort/group-by transition detection still compares against the pre-edit state
- No behavioral regression: row hiding, group moves, and sort repositioning should work exactly as before

## Context

Root cause: The optimistic `UPDATE_ROW_FIELD_VALUE` commit was gated behind `!hasViewRulesThatCanMoveOrHideRows`, deferring both the value display and the filter/sort lifecycle into the serial task queue. This was introduced in the collapsible group-by feature to ensure correct filter/sort transition detection in `updatedExistingRow`.

The `!hasViewRulesThatCanMoveOrHideRows` guard on the optimistic commit was added in the collapsible group-by feature to ensure `updatedExistingRow` could detect old→new transitions. This caused field values to visually revert when the serial task queue had pending operations, because the value update was deferred until the task executed.


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
