### PR TITLE
feat: Copy view configuration

### DIFF
--- a/backend/src/baserow/contrib/builder/locale/en/LC_MESSAGES/django.po
+++ b/backend/src/baserow/contrib/builder/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-06 19:38+0000\n"
+"POT-Creation-Date: 2026-08-26 15:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -175,19 +175,19 @@ msgstr ""
 msgid "Iframe"
 msgstr ""
 
-#: src/baserow/contrib/builder/elements/element_types.py:2155
+#: src/baserow/contrib/builder/elements/element_types.py:2168
 msgid "Date time picker"
 msgstr ""
 
-#: src/baserow/contrib/builder/elements/element_types.py:2299
+#: src/baserow/contrib/builder/elements/element_types.py:2312
 msgid "Shared header"
 msgstr ""
 
-#: src/baserow/contrib/builder/elements/element_types.py:2309
+#: src/baserow/contrib/builder/elements/element_types.py:2322
 msgid "Shared footer"
 msgstr ""
 
-#: src/baserow/contrib/builder/elements/element_types.py:2319
+#: src/baserow/contrib/builder/elements/element_types.py:2332
 msgid "Menu"
 msgstr ""
 

--- a/backend/src/baserow/contrib/database/api/views/errors.py
+++ b/backend/src/baserow/contrib/database/api/views/errors.py
@@ -150,3 +150,13 @@ ERROR_VIEW_OWNERSHIP_TYPE_INCOMPATIBLE_WITH_VIEW_TYPE = (
     "The ownership type {e.ownership_type} is not compatible with "
     "view type {e.view_type}.",
 )
+ERROR_VIEW_CONFIGURATION_COPY_CATEGORY_NOT_SUPPORTED = (
+    "ERROR_VIEW_CONFIGURATION_COPY_CATEGORY_NOT_SUPPORTED",
+    HTTP_400_BAD_REQUEST,
+    "The categories {e.categories} cannot be copied between the provided views.",
+)
+ERROR_CANNOT_COPY_VIEW_CONFIGURATION_TO_SAME_VIEW = (
+    "ERROR_CANNOT_COPY_VIEW_CONFIGURATION_TO_SAME_VIEW",
+    HTTP_400_BAD_REQUEST,
+    "The source and destination view of a configuration copy must be different views.",
+)

--- a/backend/src/baserow/contrib/database/api/views/serializers.py
+++ b/backend/src/baserow/contrib/database/api/views/serializers.py
@@ -20,6 +20,9 @@ from baserow.contrib.database.fields.field_filters import (
 )
 from baserow.contrib.database.fields.models import Field
 from baserow.contrib.database.fields.registries import field_type_registry
+from baserow.contrib.database.views.configuration_copy import (
+    view_configuration_copy_category_type_registry,
+)
 from baserow.contrib.database.views.exceptions import ViewOwnershipTypeDoesNotExist
 from baserow.contrib.database.views.models import (
     OWNERSHIP_TYPE_COLLABORATIVE,
@@ -618,6 +621,25 @@ class OrderViewsSerializer(serializers.Serializer):
         child=serializers.IntegerField(),
         help_text="View ids in the desired order.",
         min_length=1,
+    )
+
+
+class CopyViewConfigurationSerializer(serializers.Serializer):
+    source_view_id = serializers.IntegerField(
+        min_value=1,
+        help_text="The id of the view in the same table to copy the "
+        "configuration from.",
+    )
+    categories = serializers.ListField(
+        child=serializers.ChoiceField(
+            choices=lazy(
+                view_configuration_copy_category_type_registry.get_types, list
+            )()
+        ),
+        allow_empty=False,
+        help_text="The configuration categories that must be copied. Only "
+        "categories supported by both the source and destination view type "
+        "are accepted.",
     )
 
 

--- a/backend/src/baserow/contrib/database/api/views/urls.py
+++ b/backend/src/baserow/contrib/database/api/views/urls.py
@@ -3,6 +3,7 @@ from django.urls import re_path
 from baserow.contrib.database.views.registries import view_type_registry
 
 from .views import (
+    CopyViewConfigurationView,
     DuplicateViewView,
     OrderViewsView,
     PrioritizeViewGroupBysView,
@@ -68,6 +69,11 @@ urlpatterns = view_type_registry.api_urls + [
         r"(?P<view_id>[0-9]+)/duplicate/$",
         DuplicateViewView.as_view(),
         name="duplicate",
+    ),
+    re_path(
+        r"(?P<view_id>[0-9]+)/copy-configuration/$",
+        CopyViewConfigurationView.as_view(),
+        name="copy_configuration",
     ),
     re_path(
         r"(?P<view_id>[0-9]+)/filters/$", ViewFiltersView.as_view(), name="list_filters"

--- a/backend/src/baserow/contrib/database/api/views/views.py
+++ b/backend/src/baserow/contrib/database/api/views/views.py
@@ -74,6 +74,7 @@ from baserow.contrib.database.rows.exceptions import RowDoesNotExist
 from baserow.contrib.database.table.exceptions import TableDoesNotExist
 from baserow.contrib.database.table.handler import TableHandler
 from baserow.contrib.database.views.actions import (
+    CopyViewConfigurationActionType,
     CreateDecorationActionType,
     CreateViewActionType,
     CreateViewFilterActionType,
@@ -101,10 +102,12 @@ from baserow.contrib.database.views.actions import (
     UpdateViewSortActionType,
 )
 from baserow.contrib.database.views.exceptions import (
+    CannotCopyViewConfigurationToSameView,
     CannotShareViewTypeError,
     DecoratorValueProviderTypeNotCompatible,
     NoAuthorizationToPubliclySharedView,
     UnrelatedFieldError,
+    ViewConfigurationCopyCategoryNotSupported,
     ViewDecorationDoesNotExist,
     ViewDecorationNotSupported,
     ViewDoesNotExist,
@@ -152,9 +155,11 @@ from baserow.core.handler import CoreHandler
 
 from ..constants import SEARCH_MODE_API_PARAM
 from .errors import (
+    ERROR_CANNOT_COPY_VIEW_CONFIGURATION_TO_SAME_VIEW,
     ERROR_CANNOT_SHARE_VIEW_TYPE,
     ERROR_NO_AUTHORIZATION_TO_PUBLICLY_SHARED_VIEW,
     ERROR_UNRELATED_FIELD,
+    ERROR_VIEW_CONFIGURATION_COPY_CATEGORY_NOT_SUPPORTED,
     ERROR_VIEW_DECORATION_DOES_NOT_EXIST,
     ERROR_VIEW_DECORATION_NOT_SUPPORTED,
     ERROR_VIEW_DECORATION_VALUE_PROVIDER_NOT_COMPATIBLE,
@@ -181,6 +186,7 @@ from .errors import (
     ERROR_VIEW_SORT_NOT_SUPPORTED,
 )
 from .serializers import (
+    CopyViewConfigurationSerializer,
     CreateViewDecorationSerializer,
     CreateViewFilterGroupSerializer,
     CreateViewFilterSerializer,
@@ -724,6 +730,92 @@ class DuplicateViewView(APIView):
 
         serializer = view_type_registry.get_serializer(
             duplicate_view,
+            ViewSerializer,
+            filters=True,
+            sortings=True,
+            decorations=True,
+            group_bys=True,
+            default_row_values=True,
+            context={"user": request.user},
+        )
+        return Response(serializer.data)
+
+
+class CopyViewConfigurationView(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="view_id",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.INT,
+                description="The view to copy the configuration into.",
+            ),
+            CLIENT_SESSION_ID_SCHEMA_PARAMETER,
+            CLIENT_UNDO_REDO_ACTION_GROUP_ID_SCHEMA_PARAMETER,
+        ],
+        tags=["Database table views"],
+        operation_id="copy_database_table_view_configuration",
+        description=(
+            "Copies the requested configuration categories, the filters or "
+            "sorts for example, of another view in the same table into this "
+            "view, replacing this view's existing configuration of those "
+            "categories. Only categories supported by both view types can be "
+            "copied. The whole copy can be reverted with a single undo."
+        ),
+        request=CopyViewConfigurationSerializer,
+        responses={
+            200: DiscriminatorCustomFieldsMappingSerializer(
+                view_type_registry, ViewSerializer
+            ),
+            400: get_error_schema(
+                [
+                    "ERROR_USER_NOT_IN_GROUP",
+                    "ERROR_REQUEST_BODY_VALIDATION",
+                    "ERROR_VIEW_NOT_IN_TABLE",
+                    "ERROR_VIEW_CONFIGURATION_COPY_CATEGORY_NOT_SUPPORTED",
+                    "ERROR_CANNOT_COPY_VIEW_CONFIGURATION_TO_SAME_VIEW",
+                ]
+            ),
+            404: get_error_schema(["ERROR_VIEW_DOES_NOT_EXIST"]),
+        },
+    )
+    @transaction.atomic
+    @validate_body(CopyViewConfigurationSerializer)
+    @map_exceptions(
+        {
+            ViewDoesNotExist: ERROR_VIEW_DOES_NOT_EXIST,
+            UserNotInWorkspace: ERROR_USER_NOT_IN_GROUP,
+            ViewNotInTable: ERROR_VIEW_NOT_IN_TABLE,
+            ViewConfigurationCopyCategoryNotSupported: (
+                ERROR_VIEW_CONFIGURATION_COPY_CATEGORY_NOT_SUPPORTED
+            ),
+            CannotCopyViewConfigurationToSameView: (
+                ERROR_CANNOT_COPY_VIEW_CONFIGURATION_TO_SAME_VIEW
+            ),
+        }
+    )
+    def post(self, request: Request, data: Dict[str, Any], view_id: int):
+        """Copies the configuration of another view into this view."""
+
+        view_handler = ViewHandler()
+        dest_view = view_handler.get_view_for_update(request.user, view_id).specific
+        source_view = view_handler.get_view_as_user(
+            request.user, data["source_view_id"]
+        ).specific
+
+        dest_view = action_type_registry.get_by_type(
+            CopyViewConfigurationActionType
+        ).do(
+            user=request.user,
+            source_view=source_view,
+            dest_view=dest_view,
+            categories=data["categories"],
+        )
+
+        serializer = view_type_registry.get_serializer(
+            dest_view,
             ViewSerializer,
             filters=True,
             sortings=True,

--- a/backend/src/baserow/contrib/database/apps.py
+++ b/backend/src/baserow/contrib/database/apps.py
@@ -100,6 +100,7 @@ class DatabaseConfig(AppConfig):
         action_type_registry.register(UpdateRowsActionType())
 
         from baserow.contrib.database.views.actions import (
+            CopyViewConfigurationActionType,
             CreateDecorationActionType,
             CreateViewActionType,
             CreateViewFilterActionType,
@@ -131,6 +132,7 @@ class DatabaseConfig(AppConfig):
 
         action_type_registry.register(CreateViewActionType())
         action_type_registry.register(DuplicateViewActionType())
+        action_type_registry.register(CopyViewConfigurationActionType())
         action_type_registry.register(DeleteViewActionType())
         action_type_registry.register(OrderViewsActionType())
         action_type_registry.register(UpdateViewActionType())
@@ -376,6 +378,47 @@ class DatabaseConfig(AppConfig):
         view_type_registry.register(GridViewType())
         view_type_registry.register(GalleryViewType())
         view_type_registry.register(FormViewType())
+
+        from .views.configuration_copy import (
+            DecorationsViewConfigurationCopyCategoryType,
+            DefaultRowValuesViewConfigurationCopyCategoryType,
+            FieldOrderViewConfigurationCopyCategoryType,
+            FieldVisibilityViewConfigurationCopyCategoryType,
+            FieldWidthsViewConfigurationCopyCategoryType,
+            FiltersViewConfigurationCopyCategoryType,
+            GroupBysViewConfigurationCopyCategoryType,
+            SortsViewConfigurationCopyCategoryType,
+            ViewSettingsViewConfigurationCopyCategoryType,
+            view_configuration_copy_category_type_registry,
+        )
+
+        view_configuration_copy_category_type_registry.register(
+            FieldVisibilityViewConfigurationCopyCategoryType()
+        )
+        view_configuration_copy_category_type_registry.register(
+            FieldOrderViewConfigurationCopyCategoryType()
+        )
+        view_configuration_copy_category_type_registry.register(
+            FieldWidthsViewConfigurationCopyCategoryType()
+        )
+        view_configuration_copy_category_type_registry.register(
+            ViewSettingsViewConfigurationCopyCategoryType()
+        )
+        view_configuration_copy_category_type_registry.register(
+            FiltersViewConfigurationCopyCategoryType()
+        )
+        view_configuration_copy_category_type_registry.register(
+            SortsViewConfigurationCopyCategoryType()
+        )
+        view_configuration_copy_category_type_registry.register(
+            GroupBysViewConfigurationCopyCategoryType()
+        )
+        view_configuration_copy_category_type_registry.register(
+            DecorationsViewConfigurationCopyCategoryType()
+        )
+        view_configuration_copy_category_type_registry.register(
+            DefaultRowValuesViewConfigurationCopyCategoryType()
+        )
 
         from .views.view_filters import (
             BooleanViewFilterType,

--- a/backend/src/baserow/contrib/database/locale/en/LC_MESSAGES/django.po
+++ b/backend/src/baserow/contrib/database/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-21 18:19+0000\n"
+"POT-Creation-Date: 2026-08-26 15:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -69,7 +69,7 @@ msgid ""
 "\"%(airtable_share_id)s\""
 msgstr ""
 
-#: src/baserow/contrib/database/application_types.py:318
+#: src/baserow/contrib/database/application_types.py:320
 msgid "Table"
 msgstr ""
 
@@ -99,8 +99,8 @@ msgstr ""
 msgid "The data sync synchronized"
 msgstr ""
 
-#: src/baserow/contrib/database/data_sync/handler.py:255
-#: src/baserow/contrib/database/table/handler.py:478
+#: src/baserow/contrib/database/data_sync/handler.py:256
+#: src/baserow/contrib/database/table/handler.py:476
 msgid "Grid"
 msgstr ""
 
@@ -196,8 +196,8 @@ msgid ""
 "%(new_primary_field_name)s"
 msgstr ""
 
-#: src/baserow/contrib/database/fields/models.py:493
-#: src/baserow/contrib/database/fields/models.py:705
+#: src/baserow/contrib/database/fields/models.py:494
+#: src/baserow/contrib/database/fields/models.py:706
 msgid "The format of the duration."
 msgstr ""
 
@@ -230,8 +230,8 @@ msgstr ""
 
 #: src/baserow/contrib/database/plugins.py:55
 #: src/baserow/contrib/database/plugins.py:77
-#: src/baserow/contrib/database/table/handler.py:574
-#: src/baserow/contrib/database/table/handler.py:587
+#: src/baserow/contrib/database/table/handler.py:572
+#: src/baserow/contrib/database/table/handler.py:585
 msgid "Name"
 msgstr ""
 
@@ -240,13 +240,13 @@ msgid "Last name"
 msgstr ""
 
 #: src/baserow/contrib/database/plugins.py:57
-#: src/baserow/contrib/database/table/handler.py:575
+#: src/baserow/contrib/database/table/handler.py:573
 msgid "Notes"
 msgstr ""
 
 #: src/baserow/contrib/database/plugins.py:58
 #: src/baserow/contrib/database/plugins.py:79
-#: src/baserow/contrib/database/table/handler.py:576
+#: src/baserow/contrib/database/table/handler.py:574
 msgid "Active"
 msgstr ""
 
@@ -394,7 +394,7 @@ msgid ""
 "\"%(original_table_name)s\" (%(original_table_id)s) "
 msgstr ""
 
-#: src/baserow/contrib/database/table/handler.py:536
+#: src/baserow/contrib/database/table/handler.py:534
 #, python-format
 msgid "Field %d"
 msgstr ""
@@ -590,99 +590,110 @@ msgid ""
 msgstr ""
 
 #: src/baserow/contrib/database/views/actions.py:1638
+msgid "Copy view configuration"
+msgstr ""
+
+#: src/baserow/contrib/database/views/actions.py:1640
+#, python-format
+msgid ""
+"Configuration of view \"%(source_view_name)s\" (%(source_view_id)s) copied "
+"into view \"%(view_name)s\" (%(view_id)s)"
+msgstr ""
+
+#: src/baserow/contrib/database/views/actions.py:1736
 msgid "Delete view"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1639
+#: src/baserow/contrib/database/views/actions.py:1737
 #, python-format
 msgid "View \"%(view_name)s\" (%(view_id)s) deleted"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1701
+#: src/baserow/contrib/database/views/actions.py:1799
 msgid "Create decoration"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1702
+#: src/baserow/contrib/database/views/actions.py:1800
 #, python-format
 msgid "View decoration %(decorator_id)s created"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1806
+#: src/baserow/contrib/database/views/actions.py:1904
 msgid "Update decoration"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1807
+#: src/baserow/contrib/database/views/actions.py:1905
 #, python-format
 msgid "View decoration %(decorator_id)s updated"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1944
+#: src/baserow/contrib/database/views/actions.py:2042
 msgid "Delete decoration"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1945
+#: src/baserow/contrib/database/views/actions.py:2043
 #, python-format
 msgid "View decoration %(decorator_id)s deleted"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2041
+#: src/baserow/contrib/database/views/actions.py:2139
 msgid "Create a view group"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2042
+#: src/baserow/contrib/database/views/actions.py:2140
 #, python-format
 msgid "View grouped on field \"%(field_name)s\" (%(field_id)s)"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2147
+#: src/baserow/contrib/database/views/actions.py:2245
 msgid "Update a view group"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2148
+#: src/baserow/contrib/database/views/actions.py:2246
 #, python-format
 msgid "View group by updated on field \"%(field_name)s\" (%(field_id)s)"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2297
+#: src/baserow/contrib/database/views/actions.py:2395
 msgid "Delete a view group"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2298
+#: src/baserow/contrib/database/views/actions.py:2396
 #, python-format
 msgid "View group by deleted from field \"%(field_name)s\" (%(field_id)s)"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2396
+#: src/baserow/contrib/database/views/actions.py:2494
 msgid "Prioritize view group bys"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2397
+#: src/baserow/contrib/database/views/actions.py:2495
 msgid "View group bys priority changed"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2472
+#: src/baserow/contrib/database/views/actions.py:2570
 msgid "Submit form"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2473
+#: src/baserow/contrib/database/views/actions.py:2571
 #, python-format
 msgid "Row (%(row_id)s) created via form submission"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2630
+#: src/baserow/contrib/database/views/actions.py:2728
 msgid "Edit form row"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2631
+#: src/baserow/contrib/database/views/actions.py:2729
 #, python-format
 msgid "Row (%(row_id)s) updated via form edit"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2710
+#: src/baserow/contrib/database/views/actions.py:2808
 msgid "Update view default values"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2711
+#: src/baserow/contrib/database/views/actions.py:2809
 #, python-format
 msgid "Default row values updated for view (%(view_name)s)"
 msgstr ""

--- a/backend/src/baserow/contrib/database/views/actions.py
+++ b/backend/src/baserow/contrib/database/views/actions.py
@@ -1632,6 +1632,107 @@ class DuplicateViewActionType(UndoableActionType):
         TrashHandler.restore_item(user, "view", params.view_id)
 
 
+class CopyViewConfigurationActionType(UndoableActionType):
+    type = "copy_view_configuration"
+    description = ActionTypeDescription(
+        _("Copy view configuration"),
+        _(
+            'Configuration of view "%(source_view_name)s" (%(source_view_id)s) '
+            'copied into view "%(view_name)s" (%(view_id)s)'
+        ),
+        TABLE_ACTION_CONTEXT,
+    )
+    analytics_params = [
+        "view_id",
+        "table_id",
+        "database_id",
+        "source_view_id",
+        "categories",
+    ]
+
+    @dataclasses.dataclass
+    class Params:
+        view_id: int
+        view_name: str
+        table_id: int
+        table_name: str
+        database_id: int
+        database_name: str
+        source_view_id: int
+        source_view_name: str
+        categories: List[str]
+        original_configuration: Dict[str, Any]
+        new_configuration: Dict[str, Any]
+
+    @classmethod
+    def do(
+        cls,
+        user: AbstractUser,
+        source_view: View,
+        dest_view: View,
+        categories: List[str],
+    ) -> View:
+        """
+        Copies the requested configuration categories of the source view into the
+        destination view of the same table. Undoing this action restores the destination
+        view's previous configuration of those categories, redoing it applies the
+        copied configuration again.
+        """
+
+        view_handler = ViewHandler()
+        view_handler.validate_view_configuration_copy(
+            source_view, dest_view, categories
+        )
+        original_configuration = view_handler.export_view_configuration(
+            dest_view, categories
+        )
+        dest_view = view_handler.copy_view_configuration(
+            user, source_view, dest_view, categories
+        )
+        new_configuration = view_handler.export_view_configuration(
+            dest_view, categories
+        )
+
+        cls.register_action(
+            user=user,
+            params=cls.Params(
+                dest_view.id,
+                dest_view.name,
+                dest_view.table.id,
+                dest_view.table.name,
+                dest_view.table.database.id,
+                dest_view.table.database.name,
+                source_view.id,
+                source_view.name,
+                categories,
+                original_configuration,
+                new_configuration,
+            ),
+            scope=cls.scope(dest_view.id),
+            workspace=dest_view.table.database.workspace,
+        )
+
+        return dest_view
+
+    @classmethod
+    def scope(cls, view_id: int) -> ActionScopeStr:
+        return ViewActionScopeType.value(view_id)
+
+    @classmethod
+    def undo(cls, user: AbstractUser, params: Params, action_to_undo: Action):
+        view = ViewHandler().get_view_for_update(user, params.view_id).specific
+        ViewHandler().apply_view_configuration(
+            user, view, params.original_configuration, preserve_ids=True
+        )
+
+    @classmethod
+    def redo(cls, user: AbstractUser, params: Params, action_to_redo: Action):
+        view = ViewHandler().get_view_for_update(user, params.view_id).specific
+        ViewHandler().apply_view_configuration(
+            user, view, params.new_configuration, preserve_ids=True
+        )
+
+
 class DeleteViewActionType(UndoableActionType):
     type = "delete_view"
     description = ActionTypeDescription(

--- a/backend/src/baserow/contrib/database/views/actions.py
+++ b/backend/src/baserow/contrib/database/views/actions.py
@@ -1677,12 +1677,15 @@ class CopyViewConfigurationActionType(UndoableActionType):
         destination view of the same table. Undoing this action restores the destination
         view's previous configuration of those categories, redoing it applies the
         copied configuration again.
+
+        :param user: The user on whose behalf the configuration is copied.
+        :param source_view: The specific view to copy the configuration from.
+        :param dest_view: The specific view to copy the configuration into.
+        :param categories: The category types that must be copied.
+        :return: The updated destination view.
         """
 
         view_handler = ViewHandler()
-        view_handler.validate_view_configuration_copy(
-            source_view, dest_view, categories
-        )
         original_configuration = view_handler.export_view_configuration(
             dest_view, categories
         )

--- a/backend/src/baserow/contrib/database/views/configuration_copy.py
+++ b/backend/src/baserow/contrib/database/views/configuration_copy.py
@@ -1,0 +1,556 @@
+from typing import Any, Dict, Optional, Set
+
+from django.contrib.auth.models import AbstractUser
+
+from baserow.contrib.database.fields.models import Field
+from baserow.contrib.database.views.registries import (
+    ViewType,
+    decorator_type_registry,
+    decorator_value_provider_type_registry,
+    view_type_registry,
+)
+from baserow.core.registry import Instance, Registry
+
+from .exceptions import (
+    DecoratorTypeDoesNotExist,
+    DecoratorValueProviderTypeDoesNotExist,
+)
+from .models import (
+    View,
+    ViewDecoration,
+    ViewDefaultValue,
+    ViewFilter,
+    ViewFilterGroup,
+    ViewGroupBy,
+    ViewSort,
+)
+
+FieldOptionsDict = Dict[int, Dict[str, Any]]
+
+
+class ViewConfigurationCopyCategoryType(Instance):
+    """
+    One copyable piece of view configuration, the filters or sorts for example. The
+    `type` is part of the public API contract and must match the category key used by
+    the web-frontend.
+
+    Categories apply their configuration with bulk ORM operations and without sending
+    granular realtime signals, so that connected clients can be sent a single event
+    with the complete new view state after all categories have been applied.
+    """
+
+    def is_supported(self, view_type: ViewType) -> bool:
+        """
+        A category can only be copied when both the source and destination view type
+        support it.
+        """
+
+        raise NotImplementedError
+
+    def export_configuration(
+        self, view: View, cache: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """
+        Returns a JSON serializable snapshot, including primary keys so that an undo
+        can restore the exact same objects. The `cache` dict is shared by all
+        categories of one export to avoid duplicate queries.
+        """
+
+        raise NotImplementedError
+
+    def apply_configuration(
+        self,
+        view: View,
+        configuration: Dict[str, Any],
+        user: Optional[AbstractUser] = None,
+        preserve_ids: bool = False,
+        cache: Optional[Dict[str, Any]] = None,
+    ) -> Optional[FieldOptionsDict]:
+        """
+        Replaces this category's configuration of the view with an exported one. The
+        configuration can have been JSON round-tripped, so integer dict keys may have
+        become strings. With `preserve_ids` the objects are recreated with the primary
+        keys from the configuration, which undo/redo relies on so that other clients
+        keep referencing valid ids.
+
+        Returned field options are not applied by the category itself, but merged with
+        those of the other categories by the caller and applied in a single batch.
+        """
+
+        raise NotImplementedError
+
+    def after_applied(self, view: View):
+        """
+        Hook that is called after the configuration of every category has been
+        applied to the view.
+        """
+
+
+class ViewConfigurationCopyCategoryTypeRegistry(Registry):
+    name = "view_configuration_copy_category"
+
+
+view_configuration_copy_category_type_registry = (
+    ViewConfigurationCopyCategoryTypeRegistry()
+)
+
+
+def _including_trashed_fields(model, view: View):
+    """
+    The default managers of the filter, sort and group by models hide rows whose field
+    is trashed, but that configuration is deliberately kept until the field is
+    permanently deleted, so it restores together with the field. Exports must snapshot
+    those hidden rows and the replacing deletes must remove them, otherwise they would
+    either be lost by the group cascade delete or survive a copy and resurface when the
+    field is restored.
+    """
+
+    return model._base_manager.filter(view=view, view__trashed=False)
+
+
+def _existing_field_ids(view: View, cache: Optional[Dict[str, Any]]) -> Set[int]:
+    """
+    The fields that filters, sorts and field options may reference. Trashed fields are
+    included because their view configuration is kept until they are permanently
+    deleted, but fields that have been permanently deleted since a configuration was
+    exported must be skipped.
+    """
+
+    if cache is None:
+        cache = {}
+
+    cache_key = f"existing_field_ids_{view.id}"
+    if cache_key not in cache:
+        cache[cache_key] = set(
+            Field.objects_and_trash.filter(table_id=view.table_id).values_list(
+                "id", flat=True
+            )
+        )
+    return cache[cache_key]
+
+
+class FieldOptionsCopyCategoryType(ViewConfigurationCopyCategoryType):
+    """
+    Base class for categories that copy a single key of the view's field options, the
+    `hidden` state of every field for example.
+    """
+
+    field_option_key = None
+
+    def is_supported(self, view_type: ViewType) -> bool:
+        return self.field_option_key in view_type.field_options_allowed_fields
+
+    def export_configuration(
+        self, view: View, cache: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        if cache is None:
+            cache = {}
+
+        cache_key = f"field_options_{view.id}"
+        if cache_key not in cache:
+            view.get_field_options(create_if_missing=True)
+            view_type = view_type_registry.get_by_model(view.specific_class)
+            cache[cache_key] = list(
+                view_type.field_options_model_class.objects_and_trash.filter(
+                    **{
+                        view_type.model_reference_field_name: view,
+                        "field__table_id": view.table_id,
+                    }
+                )
+            )
+
+        return {
+            "field_options": {
+                field_options.field_id: {
+                    self.field_option_key: getattr(field_options, self.field_option_key)
+                }
+                for field_options in cache[cache_key]
+            }
+        }
+
+    def apply_configuration(
+        self,
+        view: View,
+        configuration: Dict[str, Any],
+        user: Optional[AbstractUser] = None,
+        preserve_ids: bool = False,
+        cache: Optional[Dict[str, Any]] = None,
+    ) -> Optional[FieldOptionsDict]:
+        return {
+            int(field_id): values
+            for field_id, values in configuration["field_options"].items()
+        }
+
+
+class FieldVisibilityViewConfigurationCopyCategoryType(FieldOptionsCopyCategoryType):
+    type = "field_visibility"
+    field_option_key = "hidden"
+
+
+class FieldOrderViewConfigurationCopyCategoryType(FieldOptionsCopyCategoryType):
+    type = "field_order"
+    field_option_key = "order"
+
+
+class FieldWidthsViewConfigurationCopyCategoryType(FieldOptionsCopyCategoryType):
+    type = "field_widths"
+    field_option_key = "width"
+
+
+class ViewSettingsViewConfigurationCopyCategoryType(ViewConfigurationCopyCategoryType):
+    """
+    Copies the plain view attributes that a view type declares in
+    `ViewType.copyable_view_attributes`, the row height and frozen column count of a
+    grid view for example. Only the attributes that both the source and the
+    destination view type declare are copied, so cross view type copies stay safe.
+    """
+
+    type = "view_settings"
+
+    def is_supported(self, view_type: ViewType) -> bool:
+        return len(view_type.copyable_view_attributes) > 0
+
+    def export_configuration(
+        self, view: View, cache: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        view_type = view_type_registry.get_by_model(view.specific_class)
+        return {
+            "view_attributes": {
+                attribute: getattr(view, attribute)
+                for attribute in view_type.copyable_view_attributes
+            }
+        }
+
+    def apply_configuration(
+        self,
+        view: View,
+        configuration: Dict[str, Any],
+        user: Optional[AbstractUser] = None,
+        preserve_ids: bool = False,
+        cache: Optional[Dict[str, Any]] = None,
+    ) -> Optional[FieldOptionsDict]:
+        view_type = view_type_registry.get_by_model(view.specific_class)
+        applied_attributes = [
+            attribute
+            for attribute in configuration["view_attributes"]
+            if attribute in view_type.copyable_view_attributes
+        ]
+        for attribute in applied_attributes:
+            setattr(view, attribute, configuration["view_attributes"][attribute])
+        if applied_attributes:
+            view.save(update_fields=applied_attributes)
+        return None
+
+
+class FiltersViewConfigurationCopyCategoryType(ViewConfigurationCopyCategoryType):
+    type = "filters"
+
+    def is_supported(self, view_type: ViewType) -> bool:
+        return view_type.can_filter
+
+    def export_configuration(
+        self, view: View, cache: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        return {
+            "filter_type": view.filter_type,
+            "filters_disabled": view.filters_disabled,
+            "filter_groups": [
+                {
+                    "id": filter_group.id,
+                    "filter_type": filter_group.filter_type,
+                    "parent_group_id": filter_group.parent_group_id,
+                }
+                for filter_group in view.filter_groups.all().order_by("id")
+            ],
+            "filters": [
+                {
+                    "id": view_filter.id,
+                    "field_id": view_filter.field_id,
+                    "type": view_filter.type,
+                    "value": view_filter.value,
+                    "group_id": view_filter.group_id,
+                }
+                for view_filter in _including_trashed_fields(ViewFilter, view).order_by(
+                    "id"
+                )
+            ],
+        }
+
+    def apply_configuration(
+        self,
+        view: View,
+        configuration: Dict[str, Any],
+        user: Optional[AbstractUser] = None,
+        preserve_ids: bool = False,
+        cache: Optional[Dict[str, Any]] = None,
+    ) -> Optional[FieldOptionsDict]:
+        _including_trashed_fields(ViewFilter, view).delete()
+        view.filter_groups.all().delete()
+
+        view.filter_type = configuration["filter_type"]
+        view.filters_disabled = configuration["filters_disabled"]
+        view.save(update_fields=["filter_type", "filters_disabled"])
+
+        # Nested filter groups always have a higher id than their parent, so creating
+        # them sorted by id guarantees that a parent's new id is already in the
+        # mapping when a child references it.
+        group_id_mapping = {}
+        for group in sorted(
+            configuration["filter_groups"], key=lambda group: group["id"]
+        ):
+            created_group = ViewFilterGroup.objects.create(
+                id=group["id"] if preserve_ids else None,
+                view=view,
+                filter_type=group["filter_type"],
+                parent_group_id=group_id_mapping.get(group["parent_group_id"]),
+            )
+            group_id_mapping[group["id"]] = created_group.id
+
+        existing_field_ids = _existing_field_ids(view, cache)
+        ViewFilter.objects.bulk_create(
+            [
+                ViewFilter(
+                    id=view_filter["id"] if preserve_ids else None,
+                    view=view,
+                    field_id=view_filter["field_id"],
+                    type=view_filter["type"],
+                    value=view_filter["value"],
+                    group_id=group_id_mapping.get(view_filter["group_id"]),
+                )
+                for view_filter in configuration["filters"]
+                if view_filter["field_id"] in existing_field_ids
+            ]
+        )
+        return None
+
+    def after_applied(self, view: View):
+        # Changed filters invalidate the view's aggregations, for example.
+        view_type_registry.get_by_model(view.specific_class).after_filter_update(view)
+
+
+class SortsViewConfigurationCopyCategoryType(ViewConfigurationCopyCategoryType):
+    type = "sorts"
+
+    def is_supported(self, view_type: ViewType) -> bool:
+        return view_type.can_sort
+
+    def export_configuration(
+        self, view: View, cache: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        return {
+            "sorts": [
+                {
+                    "id": view_sort.id,
+                    "field_id": view_sort.field_id,
+                    "order": view_sort.order,
+                    "type": view_sort.type,
+                    "priority": view_sort.priority,
+                }
+                for view_sort in _including_trashed_fields(ViewSort, view)
+            ]
+        }
+
+    def apply_configuration(
+        self,
+        view: View,
+        configuration: Dict[str, Any],
+        user: Optional[AbstractUser] = None,
+        preserve_ids: bool = False,
+        cache: Optional[Dict[str, Any]] = None,
+    ) -> Optional[FieldOptionsDict]:
+        _including_trashed_fields(ViewSort, view).delete()
+        existing_field_ids = _existing_field_ids(view, cache)
+        ViewSort.objects.bulk_create(
+            [
+                ViewSort(
+                    id=view_sort["id"] if preserve_ids else None,
+                    view=view,
+                    field_id=view_sort["field_id"],
+                    order=view_sort["order"],
+                    type=view_sort["type"],
+                    priority=view_sort["priority"],
+                )
+                for view_sort in configuration["sorts"]
+                if view_sort["field_id"] in existing_field_ids
+            ]
+        )
+        return None
+
+
+class GroupBysViewConfigurationCopyCategoryType(ViewConfigurationCopyCategoryType):
+    type = "group_bys"
+
+    def is_supported(self, view_type: ViewType) -> bool:
+        return view_type.can_group_by
+
+    def export_configuration(
+        self, view: View, cache: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        return {
+            "group_bys": [
+                {
+                    "id": view_group_by.id,
+                    "field_id": view_group_by.field_id,
+                    "order": view_group_by.order,
+                    "type": view_group_by.type,
+                    "width": view_group_by.width,
+                    "priority": view_group_by.priority,
+                }
+                for view_group_by in _including_trashed_fields(ViewGroupBy, view)
+            ]
+        }
+
+    def apply_configuration(
+        self,
+        view: View,
+        configuration: Dict[str, Any],
+        user: Optional[AbstractUser] = None,
+        preserve_ids: bool = False,
+        cache: Optional[Dict[str, Any]] = None,
+    ) -> Optional[FieldOptionsDict]:
+        _including_trashed_fields(ViewGroupBy, view).delete()
+        existing_field_ids = _existing_field_ids(view, cache)
+        ViewGroupBy.objects.bulk_create(
+            [
+                ViewGroupBy(
+                    id=view_group_by["id"] if preserve_ids else None,
+                    view=view,
+                    field_id=view_group_by["field_id"],
+                    order=view_group_by["order"],
+                    type=view_group_by["type"],
+                    width=view_group_by["width"],
+                    priority=view_group_by["priority"],
+                )
+                for view_group_by in configuration["group_bys"]
+                if view_group_by["field_id"] in existing_field_ids
+            ]
+        )
+        return None
+
+
+class DefaultRowValuesViewConfigurationCopyCategoryType(
+    ViewConfigurationCopyCategoryType
+):
+    type = "default_row_values"
+
+    def is_supported(self, view_type: ViewType) -> bool:
+        return view_type.can_set_default_values
+
+    def export_configuration(
+        self, view: View, cache: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        return {
+            "default_row_values": [
+                {
+                    "id": default_value.id,
+                    "field_id": default_value.field_id,
+                    "enabled": default_value.enabled,
+                    "value": default_value.value,
+                    "field_type": default_value.field_type,
+                    "function": default_value.function,
+                }
+                for default_value in view.view_default_values.all()
+            ]
+        }
+
+    def apply_configuration(
+        self,
+        view: View,
+        configuration: Dict[str, Any],
+        user: Optional[AbstractUser] = None,
+        preserve_ids: bool = False,
+        cache: Optional[Dict[str, Any]] = None,
+    ) -> Optional[FieldOptionsDict]:
+        view.view_default_values.all().delete()
+        existing_field_ids = _existing_field_ids(view, cache)
+        ViewDefaultValue.objects.bulk_create(
+            [
+                ViewDefaultValue(
+                    id=default_value["id"] if preserve_ids else None,
+                    view=view,
+                    field_id=default_value["field_id"],
+                    enabled=default_value["enabled"],
+                    value=default_value["value"],
+                    field_type=default_value["field_type"],
+                    function=default_value["function"],
+                )
+                for default_value in configuration["default_row_values"]
+                if default_value["field_id"] in existing_field_ids
+            ]
+        )
+        return None
+
+
+class DecorationsViewConfigurationCopyCategoryType(ViewConfigurationCopyCategoryType):
+    type = "decorations"
+
+    def is_supported(self, view_type: ViewType) -> bool:
+        return view_type.can_decorate
+
+    def export_configuration(
+        self, view: View, cache: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        return {
+            "decorations": [
+                {
+                    "id": decoration.id,
+                    "type": decoration.type,
+                    "value_provider_type": decoration.value_provider_type,
+                    "value_provider_conf": decoration.value_provider_conf,
+                    "order": decoration.order,
+                }
+                for decoration in view.viewdecoration_set.all()
+            ]
+        }
+
+    def apply_configuration(
+        self,
+        view: View,
+        configuration: Dict[str, Any],
+        user: Optional[AbstractUser] = None,
+        preserve_ids: bool = False,
+        cache: Optional[Dict[str, Any]] = None,
+    ) -> Optional[FieldOptionsDict]:
+        # The decorator and value provider types can enforce constraints, a
+        # premium license for example, so their hooks must still be called even
+        # though the decorations are bulk created. Types that are not
+        # registered, because the app providing them has been removed for
+        # example, are copied without the hook, like `duplicate_view` does.
+        decorator_type_names = {
+            decoration["type"] for decoration in configuration["decorations"]
+        }
+        for decorator_type_name in decorator_type_names:
+            try:
+                decorator_type = decorator_type_registry.get(decorator_type_name)
+            except DecoratorTypeDoesNotExist:
+                continue
+            decorator_type.before_create_decoration(view, user)
+        value_provider_type_names = {
+            decoration["value_provider_type"]
+            for decoration in configuration["decorations"]
+            if decoration["value_provider_type"]
+        }
+        for value_provider_type_name in value_provider_type_names:
+            try:
+                value_provider_type = decorator_value_provider_type_registry.get(
+                    value_provider_type_name
+                )
+            except DecoratorValueProviderTypeDoesNotExist:
+                continue
+            value_provider_type.before_create_decoration(view, user)
+
+        view.viewdecoration_set.all().delete()
+        ViewDecoration.objects.bulk_create(
+            [
+                ViewDecoration(
+                    id=decoration["id"] if preserve_ids else None,
+                    view=view,
+                    type=decoration["type"],
+                    value_provider_type=decoration["value_provider_type"],
+                    value_provider_conf=decoration["value_provider_conf"],
+                    order=decoration["order"],
+                )
+                for decoration in configuration["decorations"]
+            ]
+        )
+        return None

--- a/backend/src/baserow/contrib/database/views/configuration_copy.py
+++ b/backend/src/baserow/contrib/database/views/configuration_copy.py
@@ -65,6 +65,9 @@ class ViewConfigurationCopyCategoryType(Instance):
         """
         A category can only be copied when both the source and destination view type
         support it.
+
+        :param view_type: The view type to check the support for.
+        :return: True if the view type supports this category.
         """
 
         raise NotImplementedError
@@ -74,8 +77,12 @@ class ViewConfigurationCopyCategoryType(Instance):
     ) -> Dict[str, Any]:
         """
         Returns a JSON serializable snapshot, including primary keys so that an undo
-        can restore the exact same objects. The `cache` dict is shared by all
-        categories of one export to avoid duplicate queries.
+        can restore the exact same objects.
+
+        :param view: The specific view to export the configuration of.
+        :param cache: A dict shared by all categories of one export to avoid
+            duplicate queries.
+        :return: The exported configuration of this category.
         """
 
         raise NotImplementedError
@@ -89,14 +96,21 @@ class ViewConfigurationCopyCategoryType(Instance):
         cache: Optional[Dict[str, Any]] = None,
     ) -> Optional[FieldOptionsDict]:
         """
-        Replaces this category's configuration of the view with an exported one. The
-        configuration can have been JSON round-tripped, so integer dict keys may have
-        become strings. With `preserve_ids` the objects are recreated with the primary
-        keys from the configuration, which undo/redo relies on so that other clients
-        keep referencing valid ids.
+        Replaces this category's configuration of the view with an exported one.
 
-        Returned field options are not applied by the category itself, but merged with
-        those of the other categories by the caller and applied in a single batch.
+        :param view: The specific view to apply the configuration to.
+        :param configuration: A configuration previously returned by
+            `export_configuration`. It can have been JSON round-tripped, so integer
+            dict keys may have become strings.
+        :param user: The user on whose behalf the configuration is applied.
+        :param preserve_ids: If True, the objects are recreated with the primary keys
+            from the configuration, which undo/redo relies on so that other clients
+            keep referencing valid ids.
+        :param cache: A dict shared by all categories of one apply to avoid duplicate
+            queries.
+        :return: Optionally a field options dict that is not applied by the category
+            itself, but merged with those of the other categories by the caller and
+            applied in a single batch.
         """
 
         raise NotImplementedError
@@ -105,6 +119,8 @@ class ViewConfigurationCopyCategoryType(Instance):
         """
         Hook that is called after the configuration of every category has been
         applied to the view.
+
+        :param view: The specific view that the configuration was applied to.
         """
 
 
@@ -125,6 +141,10 @@ def _including_trashed_fields(model, view: View):
     those hidden rows and the replacing deletes must remove them, otherwise they would
     either be lost by the group cascade delete or survive a copy and resurface when the
     field is restored.
+
+    :param model: The filter, sort or group by model class to query.
+    :param view: The view to fetch the objects of.
+    :return: A trash inclusive queryset of the view's objects.
     """
 
     return model._base_manager.filter(view=view, view__trashed=False)
@@ -136,6 +156,11 @@ def _existing_field_ids(view: View, cache: Optional[Dict[str, Any]]) -> Set[int]
     included because their view configuration is kept until they are permanently
     deleted, but fields that have been permanently deleted since a configuration was
     exported must be skipped.
+
+    :param view: The view whose table's fields are returned.
+    :param cache: A dict shared within one export or apply to avoid duplicate
+        queries.
+    :return: The ids of all existing fields in the view's table.
     """
 
     if cache is None:

--- a/backend/src/baserow/contrib/database/views/configuration_copy.py
+++ b/backend/src/baserow/contrib/database/views/configuration_copy.py
@@ -1,14 +1,26 @@
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Type
 
 from django.contrib.auth.models import AbstractUser
 
 from baserow.contrib.database.fields.models import Field
+from baserow.contrib.database.views.operations import (
+    CreateViewDecorationOperationType,
+    CreateViewFilterGroupOperationType,
+    CreateViewFilterOperationType,
+    CreateViewGroupByOperationType,
+    CreateViewSortOperationType,
+    ReadViewDefaultValuesOperationType,
+    UpdateViewDefaultValuesOperationType,
+    UpdateViewFieldOptionsOperationType,
+    UpdateViewOperationType,
+)
 from baserow.contrib.database.views.registries import (
     ViewType,
     decorator_type_registry,
     decorator_value_provider_type_registry,
     view_type_registry,
 )
+from baserow.core.registries import OperationType
 from baserow.core.registry import Instance, Registry
 
 from .exceptions import (
@@ -37,6 +49,16 @@ class ViewConfigurationCopyCategoryType(Instance):
     Categories apply their configuration with bulk ORM operations and without sending
     granular realtime signals, so that connected clients can be sent a single event
     with the complete new view state after all categories have been applied.
+    """
+
+    operation_types: List[Type[OperationType]] = []
+    """
+    The operations a user needs on a view to copy this category from or into it.
+    They're checked symmetrically on the source and the destination because copying
+    is a configure level act, and because the view ownership managers hide
+    configuration from users that lack these same write operations, restricted views
+    hide the filters from users without `CreateViewFilterOperationType` for example,
+    so a read operation alone would leak configuration that the interface hides.
     """
 
     def is_supported(self, view_type: ViewType) -> bool:
@@ -136,6 +158,7 @@ class FieldOptionsCopyCategoryType(ViewConfigurationCopyCategoryType):
     """
 
     field_option_key = None
+    operation_types = [UpdateViewFieldOptionsOperationType]
 
     def is_supported(self, view_type: ViewType) -> bool:
         return self.field_option_key in view_type.field_options_allowed_fields
@@ -206,6 +229,7 @@ class ViewSettingsViewConfigurationCopyCategoryType(ViewConfigurationCopyCategor
     """
 
     type = "view_settings"
+    operation_types = [UpdateViewOperationType]
 
     def is_supported(self, view_type: ViewType) -> bool:
         return len(view_type.copyable_view_attributes) > 0
@@ -244,6 +268,15 @@ class ViewSettingsViewConfigurationCopyCategoryType(ViewConfigurationCopyCategor
 
 class FiltersViewConfigurationCopyCategoryType(ViewConfigurationCopyCategoryType):
     type = "filters"
+    # The delete operations are deliberately absent because they take the
+    # filter itself as context instead of the view, and the create operation
+    # is the gate the ownership managers hide the configuration behind.
+    operation_types = [
+        CreateViewFilterOperationType,
+        CreateViewFilterGroupOperationType,
+        # For the `filter_type` and `filters_disabled` view attributes.
+        UpdateViewOperationType,
+    ]
 
     def is_supported(self, view_type: ViewType) -> bool:
         return view_type.can_filter
@@ -330,6 +363,7 @@ class FiltersViewConfigurationCopyCategoryType(ViewConfigurationCopyCategoryType
 
 class SortsViewConfigurationCopyCategoryType(ViewConfigurationCopyCategoryType):
     type = "sorts"
+    operation_types = [CreateViewSortOperationType]
 
     def is_supported(self, view_type: ViewType) -> bool:
         return view_type.can_sort
@@ -379,6 +413,7 @@ class SortsViewConfigurationCopyCategoryType(ViewConfigurationCopyCategoryType):
 
 class GroupBysViewConfigurationCopyCategoryType(ViewConfigurationCopyCategoryType):
     type = "group_bys"
+    operation_types = [CreateViewGroupByOperationType]
 
     def is_supported(self, view_type: ViewType) -> bool:
         return view_type.can_group_by
@@ -432,6 +467,10 @@ class DefaultRowValuesViewConfigurationCopyCategoryType(
     ViewConfigurationCopyCategoryType
 ):
     type = "default_row_values"
+    operation_types = [
+        ReadViewDefaultValuesOperationType,
+        UpdateViewDefaultValuesOperationType,
+    ]
 
     def is_supported(self, view_type: ViewType) -> bool:
         return view_type.can_set_default_values
@@ -483,6 +522,7 @@ class DefaultRowValuesViewConfigurationCopyCategoryType(
 
 class DecorationsViewConfigurationCopyCategoryType(ViewConfigurationCopyCategoryType):
     type = "decorations"
+    operation_types = [CreateViewDecorationOperationType]
 
     def is_supported(self, view_type: ViewType) -> bool:
         return view_type.can_decorate

--- a/backend/src/baserow/contrib/database/views/exceptions.py
+++ b/backend/src/baserow/contrib/database/views/exceptions.py
@@ -24,6 +24,29 @@ class ViewNotInTable(Exception):
         )
 
 
+class ViewConfigurationCopyCategoryNotSupported(Exception):
+    """
+    Raised when a view configuration copy category is not supported by both the
+    source and the destination view type.
+    """
+
+    def __init__(self, categories=None, *args, **kwargs):
+        self.categories = categories or []
+        super().__init__(
+            f"The categories {self.categories} cannot be copied between the "
+            "provided views.",
+            *args,
+            **kwargs,
+        )
+
+
+class CannotCopyViewConfigurationToSameView(Exception):
+    """
+    Raised when the source and destination view of a view configuration copy
+    are the same view.
+    """
+
+
 class UnrelatedFieldError(Exception):
     """
     Raised when a field is not related to the view. For example when someone tries to

--- a/backend/src/baserow/contrib/database/views/handler.py
+++ b/backend/src/baserow/contrib/database/views/handler.py
@@ -1179,6 +1179,12 @@ class ViewHandler:
         the destination of a copy because the ownership managers hide configuration
         from users that lack these write operations, so a read check alone would
         leak configuration that the interface hides.
+
+        :param user: The user on whose behalf the permissions are checked.
+        :param view: The view that the categories are configured on.
+        :param categories: The category types that must be checked.
+        :raises PermissionException: When the user is not allowed to configure one
+            of the categories on the view.
         """
 
         checks = [
@@ -1201,6 +1207,10 @@ class ViewHandler:
         Returns a JSON serializable snapshot of the requested configuration categories
         of the given view, including primary keys so that an undo can restore the exact
         same objects via `apply_view_configuration`.
+
+        :param view: The specific view to export the configuration of.
+        :param categories: The category types that must be exported.
+        :return: The exported configuration per category.
         """
 
         cache = {}
@@ -1223,9 +1233,16 @@ class ViewHandler:
         `export_view_configuration`. All categories are applied with bulk operations
         and a single `view_configuration_changed` signal is sent afterwards, instead of
         a granular signal per created or deleted object, so that connected clients
-        receive one event with the complete new view state. `preserve_ids` recreates
-        the objects with the primary keys from the configuration, which undo/redo
-        relies on so that other clients keep referencing valid ids.
+        receive one event with the complete new view state.
+
+        :param user: The user on whose behalf the configuration is applied.
+        :param view: The specific view to apply the configuration to.
+        :param configuration: The exported configuration per category.
+        :param preserve_ids: If True, the objects are recreated with the primary keys
+            from the configuration, which undo/redo relies on so that other clients
+            keep referencing valid ids.
+        :raises PermissionException: When the user is not allowed to configure one
+            of the categories on the view.
         """
 
         self._check_view_configuration_permissions(user, view, configuration.keys())
@@ -1278,6 +1295,12 @@ class ViewHandler:
         categories: List[str],
     ):
         """
+        Validates that the requested configuration categories can be copied from the
+        source view into the destination view.
+
+        :param source_view: The specific view to copy the configuration from.
+        :param dest_view: The specific view to copy the configuration into.
+        :param categories: The category types that must be copied.
         :raises ViewNotInTable: When the source view belongs to another table.
         :raises CannotCopyViewConfigurationToSameView: When the source and
             destination view are the same view.
@@ -1316,8 +1339,20 @@ class ViewHandler:
         """
         Copies the requested configuration categories of the source view into
         the destination view of the same table, replacing the destination's
-        existing configuration of those categories. See
-        `validate_view_configuration_copy` for the raised exceptions.
+        existing configuration of those categories.
+
+        :param user: The user on whose behalf the configuration is copied.
+        :param source_view: The specific view to copy the configuration from.
+        :param dest_view: The specific view to copy the configuration into.
+        :param categories: The category types that must be copied.
+        :raises ViewNotInTable: When the source view belongs to another table.
+        :raises CannotCopyViewConfigurationToSameView: When the source and
+            destination view are the same view.
+        :raises ViewConfigurationCopyCategoryNotSupported: When a requested
+            category is not supported by both view types.
+        :raises PermissionException: When the user is not allowed to read or
+            configure one of the categories on the source or destination view.
+        :return: The updated destination view.
         """
 
         self.validate_view_configuration_copy(source_view, dest_view, categories)
@@ -1585,6 +1620,8 @@ class ViewHandler:
           no permission checking.
         :param fields: Optionally a list of fields can be provided so that they don't
             have to be fetched again.
+        :param send_signal: If False, the `view_field_options_updated` signal is not
+            sent, for when the caller broadcasts the change itself.
         :raises UnrelatedFieldError: When the provided field id is not related to the
             provided view.
         """

--- a/backend/src/baserow/contrib/database/views/handler.py
+++ b/backend/src/baserow/contrib/database/views/handler.py
@@ -59,6 +59,9 @@ from baserow.contrib.database.rows.handler import RowHandler
 from baserow.contrib.database.search.handler import SearchMode
 from baserow.contrib.database.table.cache import invalidate_table_in_model_cache
 from baserow.contrib.database.table.models import GeneratedTableModel, Table
+from baserow.contrib.database.views.configuration_copy import (
+    view_configuration_copy_category_type_registry,
+)
 from baserow.contrib.database.views.exceptions import (
     ViewOwnershipTypeDoesNotExist,
     ViewOwnershipTypeNotCompatibleWithViewType,
@@ -102,6 +105,7 @@ from baserow.contrib.database.views.operations import (
     UpdateViewFilterGroupOperationType,
     UpdateViewFilterOperationType,
     UpdateViewGroupByOperationType,
+    UpdateViewOperationType,
     UpdateViewPublicOperationType,
     UpdateViewSlugOperationType,
     UpdateViewSortOperationType,
@@ -131,11 +135,13 @@ from baserow.core.utils import (
 
 from .constants import GROUP_BY_DATA_DEFAULT_LIMIT
 from .exceptions import (
+    CannotCopyViewConfigurationToSameView,
     CannotShareViewTypeError,
     DecoratorValueProviderTypeNotCompatible,
     FieldAggregationNotSupported,
     NoAuthorizationToPubliclySharedView,
     UnrelatedFieldError,
+    ViewConfigurationCopyCategoryNotSupported,
     ViewDecorationDoesNotExist,
     ViewDecorationNotSupported,
     ViewDoesNotExist,
@@ -184,6 +190,7 @@ from .signals import (
     form_submitted,
     rows_entered_view,
     rows_exited_view,
+    view_configuration_changed,
     view_created,
     view_decoration_created,
     view_decoration_deleted,
@@ -1163,6 +1170,151 @@ class ViewHandler:
 
         return duplicated_view
 
+    def export_view_configuration(
+        self, view: View, categories: List[str]
+    ) -> Dict[str, Any]:
+        """
+        Returns a JSON serializable snapshot of the requested configuration categories
+        of the given view, including primary keys so that an undo can restore the exact
+        same objects via `apply_view_configuration`.
+        """
+
+        cache = {}
+        return {
+            category: view_configuration_copy_category_type_registry.get(
+                category
+            ).export_configuration(view, cache=cache)
+            for category in categories
+        }
+
+    def apply_view_configuration(
+        self,
+        user: AbstractUser,
+        view: View,
+        configuration: Dict[str, Any],
+        preserve_ids: bool = False,
+    ):
+        """
+        Replaces the view's configuration with one previously exported with
+        `export_view_configuration`. All categories are applied with bulk operations
+        and a single `view_configuration_changed` signal is sent afterwards, instead of
+        a granular signal per created or deleted object, so that connected clients
+        receive one event with the complete new view state. `preserve_ids` recreates
+        the objects with the primary keys from the configuration, which undo/redo
+        relies on so that other clients keep referencing valid ids.
+        """
+
+        CoreHandler().check_permissions(
+            user,
+            UpdateViewOperationType.type,
+            workspace=view.table.database.workspace,
+            context=view,
+        )
+
+        cache = {}
+        merged_field_options = {}
+        applied_category_types = []
+        for category, category_configuration in configuration.items():
+            category_type = view_configuration_copy_category_type_registry.get(category)
+            field_options = category_type.apply_configuration(
+                view,
+                category_configuration,
+                user=user,
+                preserve_ids=preserve_ids,
+                cache=cache,
+            )
+            for field_id, values in (field_options or {}).items():
+                merged_field_options.setdefault(int(field_id), {}).update(values)
+            applied_category_types.append(category_type)
+
+        if merged_field_options:
+            fields = Field.objects_and_trash.filter(table_id=view.table_id)
+            existing_field_ids = {field.id for field in fields}
+            # The `view_configuration_changed` signal sent below covers the
+            # field options change, so the granular signal is suppressed to
+            # keep this a single broadcast.
+            self.update_field_options(
+                view=view,
+                field_options={
+                    field_id: values
+                    for field_id, values in merged_field_options.items()
+                    if field_id in existing_field_ids
+                },
+                user=user,
+                fields=fields,
+                send_signal=False,
+            )
+
+        for category_type in applied_category_types:
+            category_type.after_applied(view)
+
+        view_configuration_changed.send(
+            self, view=view, user=user, categories=list(configuration.keys())
+        )
+
+    def validate_view_configuration_copy(
+        self,
+        source_view: View,
+        dest_view: View,
+        categories: List[str],
+    ):
+        """
+        :raises ViewNotInTable: When the source view belongs to another table.
+        :raises CannotCopyViewConfigurationToSameView: When the source and
+            destination view are the same view.
+        :raises ViewConfigurationCopyCategoryNotSupported: When a requested
+            category is not supported by both view types.
+        """
+
+        if source_view.id == dest_view.id:
+            raise CannotCopyViewConfigurationToSameView(
+                "The source and destination view of a configuration copy must "
+                "be different views."
+            )
+
+        if source_view.table_id != dest_view.table_id:
+            raise ViewNotInTable(source_view.id)
+
+        source_view_type = view_type_registry.get_by_model(source_view.specific_class)
+        dest_view_type = view_type_registry.get_by_model(dest_view.specific_class)
+        supported_categories = (
+            source_view_type.get_copyable_configuration_categories()
+            & dest_view_type.get_copyable_configuration_categories()
+        )
+        unsupported_categories = set(categories) - supported_categories
+        if unsupported_categories:
+            raise ViewConfigurationCopyCategoryNotSupported(
+                sorted(unsupported_categories)
+            )
+
+    def copy_view_configuration(
+        self,
+        user: AbstractUser,
+        source_view: View,
+        dest_view: View,
+        categories: List[str],
+    ) -> View:
+        """
+        Copies the requested configuration categories of the source view into
+        the destination view of the same table, replacing the destination's
+        existing configuration of those categories. See
+        `validate_view_configuration_copy` for the raised exceptions.
+        """
+
+        self.validate_view_configuration_copy(source_view, dest_view, categories)
+
+        CoreHandler().check_permissions(
+            user,
+            ReadViewOperationType.type,
+            workspace=dest_view.table.database.workspace,
+            context=source_view,
+        )
+
+        configuration = self.export_view_configuration(source_view, categories)
+        self.apply_view_configuration(user, dest_view, configuration)
+
+        return dest_view
+
     def update_view(
         self, user: AbstractUser, view: View, **data: Dict[str, Any]
     ) -> UpdatedViewWithChangedAttributes:
@@ -1391,6 +1543,7 @@ class ViewHandler:
         field_options: FieldOptionsDict,
         user: Optional[AbstractUser] = None,
         fields: Optional[QuerySet[Field]] = None,
+        send_signal: bool = True,
     ):
         """
         Updates the field options with the provided values if the field id exists in
@@ -1508,7 +1661,8 @@ class ViewHandler:
             view, field_options, fields, updated_instances
         )
 
-        view_field_options_updated.send(self, view=view, user=user)
+        if send_signal:
+            view_field_options_updated.send(self, view=view, user=user)
 
     def after_field_moved_between_tables(self, field: Field, original_table_id: int):
         """

--- a/backend/src/baserow/contrib/database/views/handler.py
+++ b/backend/src/baserow/contrib/database/views/handler.py
@@ -105,7 +105,6 @@ from baserow.contrib.database.views.operations import (
     UpdateViewFilterGroupOperationType,
     UpdateViewFilterOperationType,
     UpdateViewGroupByOperationType,
-    UpdateViewOperationType,
     UpdateViewPublicOperationType,
     UpdateViewSlugOperationType,
     UpdateViewSortOperationType,
@@ -122,6 +121,7 @@ from baserow.core.models import Workspace
 from baserow.core.registries import ImportExportConfig
 from baserow.core.telemetry.utils import baserow_trace, baserow_trace_handler
 from baserow.core.trash.handler import TrashHandler
+from baserow.core.types import PermissionCheck
 from baserow.core.utils import (
     MirrorDict,
     atomic_if_not_already,
@@ -1170,6 +1170,30 @@ class ViewHandler:
 
         return duplicated_view
 
+    def _check_view_configuration_permissions(
+        self, user: AbstractUser, view: View, categories: Iterable[str]
+    ):
+        """
+        Checks in one batch that the user is allowed to configure all the requested
+        categories on the given view. The same check is applied to the source and
+        the destination of a copy because the ownership managers hide configuration
+        from users that lack these write operations, so a read check alone would
+        leak configuration that the interface hides.
+        """
+
+        checks = [
+            PermissionCheck(user, operation_type.type, view)
+            for category in categories
+            for operation_type in view_configuration_copy_category_type_registry.get(
+                category
+            ).operation_types
+        ]
+        CoreHandler().check_multiple_permissions(
+            checks,
+            workspace=view.table.database.workspace,
+            raise_exception=True,
+        )
+
     def export_view_configuration(
         self, view: View, categories: List[str]
     ) -> Dict[str, Any]:
@@ -1204,12 +1228,7 @@ class ViewHandler:
         relies on so that other clients keep referencing valid ids.
         """
 
-        CoreHandler().check_permissions(
-            user,
-            UpdateViewOperationType.type,
-            workspace=view.table.database.workspace,
-            context=view,
-        )
+        self._check_view_configuration_permissions(user, view, configuration.keys())
 
         cache = {}
         merged_field_options = {}
@@ -1309,6 +1328,7 @@ class ViewHandler:
             workspace=dest_view.table.database.workspace,
             context=source_view,
         )
+        self._check_view_configuration_permissions(user, source_view, categories)
 
         configuration = self.export_view_configuration(source_view, categories)
         self.apply_view_configuration(user, dest_view, configuration)

--- a/backend/src/baserow/contrib/database/views/receivers.py
+++ b/backend/src/baserow/contrib/database/views/receivers.py
@@ -13,6 +13,7 @@ from baserow.contrib.database.rows.signals import (
 from baserow.contrib.database.table.models import GeneratedTableModel, Table
 from baserow.contrib.database.views.models import View
 from baserow.contrib.database.views.signals import (
+    view_configuration_changed,
     view_filter_created,
     view_filter_deleted,
     view_filter_group_created,
@@ -67,6 +68,12 @@ def notify_view_updated(sender, view, user, old_view, **kwargs):
 @receiver([view_filter_created, view_filter_updated, view_filter_deleted])
 def notify_view_filter_created_or_updated(sender, view_filter, user, **kwargs):
     _notify_view_results_updated(view_filter.view)
+
+
+@receiver(view_configuration_changed)
+def notify_view_configuration_changed(sender, view, user, categories, **kwargs):
+    if "filters" in categories:
+        _notify_view_results_updated(view)
 
 
 @receiver(

--- a/backend/src/baserow/contrib/database/views/registries.py
+++ b/backend/src/baserow/contrib/database/views/registries.py
@@ -197,6 +197,34 @@ class ViewType(
     options
     """
 
+    copyable_view_attributes = []
+    """
+    The view attributes that the `view_settings` configuration copy category copies
+    from one view into another. Only attributes that both the source and the
+    destination view type declare are copied, so a view type can safely declare its
+    own specific attributes here.
+    """
+
+    def get_copyable_configuration_categories(self) -> Set[str]:
+        """
+        A configuration category can only be copied between two views when both view
+        types support it.
+        """
+
+        # Imported here because `configuration_copy` imports this module at the top
+        # level, which would otherwise be a circular import.
+        from baserow.contrib.database.views.configuration_copy import (
+            view_configuration_copy_category_type_registry,
+        )
+
+        return {
+            category_type.type
+            for category_type in (
+                view_configuration_copy_category_type_registry.get_all()
+            )
+            if category_type.is_supported(self)
+        }
+
     def get_public_url_path(self, view: "View") -> str:
         """
         Returns the web frontend path where the publicly shared view can be visited.

--- a/backend/src/baserow/contrib/database/views/registries.py
+++ b/backend/src/baserow/contrib/database/views/registries.py
@@ -209,6 +209,8 @@ class ViewType(
         """
         A configuration category can only be copied between two views when both view
         types support it.
+
+        :return: The configuration copy category types that this view type supports.
         """
 
         # Imported here because `configuration_copy` imports this module at the top

--- a/backend/src/baserow/contrib/database/views/signals.py
+++ b/backend/src/baserow/contrib/database/views/signals.py
@@ -98,6 +98,14 @@ def update_view_index_if_view_group_bys_prioritized(sender, view, **kwargs):
     ViewIndexingHandler.schedule_index_update(view)
 
 
+@receiver(view_configuration_changed)
+def update_view_index_if_configuration_changed(sender, view, categories, **kwargs):
+    if "sorts" in categories or "group_bys" in categories:
+        from baserow.contrib.database.views.handler import ViewIndexingHandler
+
+        ViewIndexingHandler.schedule_index_update(view)
+
+
 @receiver(view_loaded)
 def view_loaded_create_indexes_and_columns(sender, view, table_model, **kwargs):
     from baserow.contrib.database.table.tasks import (

--- a/backend/src/baserow/contrib/database/views/signals.py
+++ b/backend/src/baserow/contrib/database/views/signals.py
@@ -33,6 +33,12 @@ view_decoration_deleted = Signal()
 
 view_field_options_updated = Signal()
 
+# Sent when multiple parts of a view's configuration have been replaced at once, for
+# example when the configuration of another view is copied into it. Granular signals
+# are deliberately not sent in that case so that connected clients receive a single
+# event with the complete new view state.
+view_configuration_changed = Signal()
+
 rows_entered_view = Signal()
 rows_exited_view = Signal()
 

--- a/backend/src/baserow/contrib/database/views/view_types.py
+++ b/backend/src/baserow/contrib/database/views/view_types.py
@@ -86,6 +86,11 @@ class GridViewType(ViewType):
     can_group_by = True
     when_shared_publicly_requires_realtime_events = True
     allowed_fields = ["row_identifier_type", "row_height_size", "frozen_column_count"]
+    copyable_view_attributes = [
+        "row_height_size",
+        "frozen_column_count",
+        "row_identifier_type",
+    ]
     field_options_allowed_fields = [
         "width",
         "hidden",
@@ -673,6 +678,12 @@ class FormViewType(ViewType):
         FormViewFieldOptionsConditionGroupDoesNotExist: ERROR_FORM_VIEW_FIELD_OPTIONS_CONDITION_GROUP_DOES_NOT_EXIST,
         SelectOptionDoesNotBelongToField: ERROR_SELECT_OPTION_DOES_NOT_BELONG_TO_FIELD,
     }
+
+    def get_copyable_configuration_categories(self) -> Set[str]:
+        # Even though the form view has an `order` field option, none of its
+        # configuration is interchangeable with the other view types, its field
+        # options describe form fields instead of table columns.
+        return set()
 
     def get_api_urls(self):
         from baserow.contrib.database.api.views.form import urls as api_urls

--- a/backend/src/baserow/contrib/database/ws/public/views/signals.py
+++ b/backend/src/baserow/contrib/database/ws/public/views/signals.py
@@ -102,3 +102,8 @@ def public_view_group_by_deleted(
 @receiver(view_signals.view_field_options_updated)
 def public_view_field_options_updated(sender, view, user, **kwargs):
     _send_force_view_refresh_if_view_public(view)
+
+
+@receiver(view_signals.view_configuration_changed)
+def public_view_configuration_changed(sender, view, user, **kwargs):
+    _send_force_view_refresh_if_view_public(view)

--- a/backend/src/baserow/contrib/database/ws/views/signals.py
+++ b/backend/src/baserow/contrib/database/ws/views/signals.py
@@ -390,6 +390,27 @@ def view_decoration_deleted(
     broadcast_to(user, view_decoration.view, payload)
 
 
+@receiver(view_signals.view_configuration_changed)
+def view_configuration_changed(sender, view, user, categories, **kwargs):
+    _prefetch_view_default_values(view)
+    payload = {
+        "type": "view_configuration_changed",
+        "view_id": view.id,
+        "categories": categories,
+        "view": view_type_registry.get_serializer(
+            view,
+            ViewSerializer,
+            filters=True,
+            sortings=True,
+            decorations=True,
+            group_bys=True,
+            default_row_values=True,
+            context={"user": user},
+        ).data,
+    }
+    broadcast_to(user, view, payload)
+
+
 @receiver(view_signals.view_field_options_updated)
 def view_field_options_updated(sender, view, user, **kwargs):
     view_type = view_type_registry.get_by_model(view.specific_class)

--- a/backend/src/baserow/core/locale/en/LC_MESSAGES/django.po
+++ b/backend/src/baserow/core/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-24 14:17+0000\n"
+"POT-Creation-Date: 2026-08-26 15:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/baserow/core/abuse_reports/actions.py:23
+#: src/baserow/core/abuse_reports/actions.py:22
 msgid "Submit abuse report"
 msgstr ""
 
-#: src/baserow/core/abuse_reports/actions.py:25
+#: src/baserow/core/abuse_reports/actions.py:24
 #, python-format
 msgid ""
 "Publicly shared %(resource_type)s \"%(resource_name)s\" (%(resource_id)s) "
@@ -34,7 +34,7 @@ msgstr ""
 msgid "%(resource_name)s has been reported for abuse"
 msgstr ""
 
-#: src/baserow/core/abuse_reports/notification_types.py:95
+#: src/baserow/core/abuse_reports/notification_types.py:90
 #, python-format
 msgid ""
 "%(public_url)s — %(reporter_name)s (%(reporter_email)s) wrote: "
@@ -279,7 +279,7 @@ msgstr ""
 msgid "Unlabeled"
 msgstr ""
 
-#: src/baserow/core/handler.py:2227 src/baserow/core/user/handler.py:276
+#: src/baserow/core/handler.py:2239 src/baserow/core/user/handler.py:276
 #, python-format
 msgid "%(name)s's workspace"
 msgstr ""

--- a/backend/src/baserow/locale/en/LC_MESSAGES/django.po
+++ b/backend/src/baserow/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-06 19:38+0000\n"
+"POT-Creation-Date: 2026-08-26 15:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -54,135 +54,135 @@ msgstr ""
 msgid "Local Baserow"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/actions.py:25
+#: src/baserow/contrib/automation/nodes/actions.py:26
 msgid "Create automation node"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/actions.py:26
+#: src/baserow/contrib/automation/nodes/actions.py:27
 #, python-format
 msgid "Node (%(node_id)s) created"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/actions.py:90
+#: src/baserow/contrib/automation/nodes/actions.py:91
 msgid "Update automation node"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/actions.py:91
+#: src/baserow/contrib/automation/nodes/actions.py:92
 #, python-format
 msgid "Node (%(node_id)s) updated"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/actions.py:159
+#: src/baserow/contrib/automation/nodes/actions.py:160
 msgid "Delete automation node"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/actions.py:160
+#: src/baserow/contrib/automation/nodes/actions.py:161
 #, python-format
 msgid "Node (%(node_id)s) deleted"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/actions.py:217
+#: src/baserow/contrib/automation/nodes/actions.py:218
 msgid "Duplicate automation node"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/actions.py:218
+#: src/baserow/contrib/automation/nodes/actions.py:219
 #, python-format
 msgid "Node (%(node_id)s) duplicated"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/actions.py:289
+#: src/baserow/contrib/automation/nodes/actions.py:290
 msgid "Replace automation node"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/actions.py:291
+#: src/baserow/contrib/automation/nodes/actions.py:292
 #, python-format
 msgid ""
 "Node (%(node_id)s) changed from a type of %(original_node_type)s to "
 "%(node_type)s"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/actions.py:377
+#: src/baserow/contrib/automation/nodes/actions.py:378
 msgid "Moved automation node"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/actions.py:378
+#: src/baserow/contrib/automation/nodes/actions.py:379
 #, python-format
 msgid "Node (%(node_id)s) moved"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/node_types.py:143
+#: src/baserow/contrib/automation/nodes/node_types.py:153
 msgid "Local Baserow create row"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/node_types.py:160
+#: src/baserow/contrib/automation/nodes/node_types.py:170
 msgid "Local Baserow update row"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/node_types.py:177
+#: src/baserow/contrib/automation/nodes/node_types.py:187
 msgid "Local Baserow delete row"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/node_types.py:185
+#: src/baserow/contrib/automation/nodes/node_types.py:195
 msgid "Local Baserow get row"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/node_types.py:193
+#: src/baserow/contrib/automation/nodes/node_types.py:203
 msgid "Local Baserow list rows"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/node_types.py:201
+#: src/baserow/contrib/automation/nodes/node_types.py:211
 msgid "Local Baserow aggregate rows"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/node_types.py:209
+#: src/baserow/contrib/automation/nodes/node_types.py:219
 msgid "HTTP request"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/node_types.py:216
+#: src/baserow/contrib/automation/nodes/node_types.py:226
 msgid "Iterator"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/node_types.py:229
+#: src/baserow/contrib/automation/nodes/node_types.py:239
 msgid "Send email"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/node_types.py:242
+#: src/baserow/contrib/automation/nodes/node_types.py:252
 msgid "AI agent"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/node_types.py:249
+#: src/baserow/contrib/automation/nodes/node_types.py:259
 msgid "Router"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/node_types.py:315
+#: src/baserow/contrib/automation/nodes/node_types.py:325
 msgid "Branch"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/node_types.py:444
+#: src/baserow/contrib/automation/nodes/node_types.py:712
 msgid "Local Baserow rows created"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/node_types.py:452
+#: src/baserow/contrib/automation/nodes/node_types.py:720
 msgid "Local Baserow rows updated"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/node_types.py:460
+#: src/baserow/contrib/automation/nodes/node_types.py:728
 msgid "Local Baserow rows deleted"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/node_types.py:476
+#: src/baserow/contrib/automation/nodes/node_types.py:744
 msgid "Periodic trigger"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/node_types.py:483
+#: src/baserow/contrib/automation/nodes/node_types.py:751
 msgid "HTTP trigger"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/node_types.py:496
+#: src/baserow/contrib/automation/nodes/node_types.py:764
 msgid "Slack write message"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/registries.py:47
+#: src/baserow/contrib/automation/nodes/registries.py:48
 msgid "Unnamed node"
 msgstr ""
 
@@ -282,36 +282,44 @@ msgstr ""
 msgid "Widget \"%(widget_title)s\" (%(widget_id)s) deleted"
 msgstr ""
 
-#: src/baserow/contrib/integrations/core/service_types.py:1175
+#: src/baserow/contrib/integrations/core/service_types.py:1176
 msgid "Branch taken"
 msgstr ""
 
-#: src/baserow/contrib/integrations/core/service_types.py:1180
+#: src/baserow/contrib/integrations/core/service_types.py:1181
 msgid "Label"
 msgstr ""
 
-#: src/baserow/contrib/integrations/core/service_types.py:1182
+#: src/baserow/contrib/integrations/core/service_types.py:1183
 msgid "The label of the branch that matched the condition."
 msgstr ""
 
-#: src/baserow/contrib/integrations/core/service_types.py:1593
+#: src/baserow/contrib/integrations/core/service_types.py:1376
+msgid "Condition"
+msgstr ""
+
+#: src/baserow/contrib/integrations/core/service_types.py:1378
+msgid "Whether the condition evaluated to true and the jump was followed."
+msgstr ""
+
+#: src/baserow/contrib/integrations/core/service_types.py:1785
 msgid "Previous scheduled run"
 msgstr ""
 
-#: src/baserow/contrib/integrations/core/service_types.py:1597
+#: src/baserow/contrib/integrations/core/service_types.py:1789
 msgid "Next scheduled run"
 msgstr ""
 
-#: src/baserow/contrib/integrations/local_baserow/service_types.py:1711
+#: src/baserow/contrib/integrations/local_baserow/service_types.py:1783
 msgid "No rows found"
 msgstr ""
 
-#: src/baserow/contrib/integrations/local_baserow/service_types.py:2290
+#: src/baserow/contrib/integrations/local_baserow/service_types.py:2408
 #, python-format
 msgid "The %(operation)s action can process at most %(limit)s rows at once."
 msgstr ""
 
-#: src/baserow/contrib/integrations/local_baserow/service_types.py:2653
+#: src/baserow/contrib/integrations/local_baserow/service_types.py:2774
 #, python-format
 msgid ""
 "The batch delete rows action can process at most %(limit)s rows at once."

--- a/backend/tests/baserow/contrib/database/api/views/test_view_copy_configuration.py
+++ b/backend/tests/baserow/contrib/database/api/views/test_view_copy_configuration.py
@@ -1,0 +1,210 @@
+from django.shortcuts import reverse
+
+import pytest
+from rest_framework.status import (
+    HTTP_200_OK,
+    HTTP_400_BAD_REQUEST,
+    HTTP_401_UNAUTHORIZED,
+    HTTP_404_NOT_FOUND,
+)
+
+from baserow.contrib.database.action.scopes import ViewActionScopeType
+from baserow.core.action.handler import ActionHandler
+
+
+@pytest.mark.django_db
+def test_copy_view_configuration(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_text_field(table=table)
+    source_view = data_fixture.create_grid_view(
+        table=table,
+        filter_type="OR",
+        row_height_size="large",
+        frozen_column_count=2,
+    )
+    dest_view = data_fixture.create_grid_view(table=table)
+
+    filter_group = data_fixture.create_view_filter_group(view=source_view)
+    data_fixture.create_view_filter(
+        view=source_view, field=field, type="equal", value="a", group=filter_group
+    )
+    data_fixture.create_view_sort(view=source_view, field=field, order="DESC")
+    data_fixture.create_view_group_by(view=source_view, field=field)
+    data_fixture.create_view_decoration(view=source_view)
+
+    response = api_client.post(
+        reverse(
+            "api:database:views:copy_configuration",
+            kwargs={"view_id": dest_view.id},
+        ),
+        {
+            "source_view_id": source_view.id,
+            "categories": [
+                "filters",
+                "sorts",
+                "group_bys",
+                "decorations",
+                "view_settings",
+            ],
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    response_json = response.json()
+    assert response.status_code == HTTP_200_OK
+    assert response_json["id"] == dest_view.id
+    assert response_json["filter_type"] == "OR"
+    assert response_json["row_height_size"] == "large"
+    assert response_json["frozen_column_count"] == 2
+    assert len(response_json["filters"]) == 1
+    assert response_json["filters"][0]["value"] == "a"
+    assert len(response_json["filter_groups"]) == 1
+    assert (
+        response_json["filters"][0]["group"] == response_json["filter_groups"][0]["id"]
+    )
+    assert len(response_json["sortings"]) == 1
+    assert len(response_json["group_bys"]) == 1
+    assert len(response_json["decorations"]) == 1
+
+
+@pytest.mark.django_db
+def test_copy_view_configuration_errors(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    other_user, other_token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    other_table = data_fixture.create_database_table(user=user)
+    source_view = data_fixture.create_grid_view(table=table)
+    dest_view = data_fixture.create_grid_view(table=table)
+    gallery_view = data_fixture.create_gallery_view(table=table)
+    other_table_view = data_fixture.create_grid_view(table=other_table)
+
+    def post(view_id, body, token_to_use=None):
+        return api_client.post(
+            reverse(
+                "api:database:views:copy_configuration", kwargs={"view_id": view_id}
+            ),
+            body,
+            format="json",
+            HTTP_AUTHORIZATION=f"JWT {token_to_use or token}",
+        )
+
+    response = post(9999, {"source_view_id": source_view.id, "categories": ["filters"]})
+    assert response.status_code == HTTP_404_NOT_FOUND
+    assert response.json()["error"] == "ERROR_VIEW_DOES_NOT_EXIST"
+
+    response = post(dest_view.id, {"source_view_id": 9999, "categories": ["filters"]})
+    assert response.status_code == HTTP_404_NOT_FOUND
+    assert response.json()["error"] == "ERROR_VIEW_DOES_NOT_EXIST"
+
+    response = post(dest_view.id, {"source_view_id": source_view.id, "categories": []})
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+
+    response = post(
+        dest_view.id, {"source_view_id": dest_view.id, "categories": ["filters"]}
+    )
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert (
+        response.json()["error"] == "ERROR_CANNOT_COPY_VIEW_CONFIGURATION_TO_SAME_VIEW"
+    )
+
+    response = post(
+        dest_view.id,
+        {"source_view_id": other_table_view.id, "categories": ["filters"]},
+    )
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_VIEW_NOT_IN_TABLE"
+
+    response = post(
+        gallery_view.id,
+        {"source_view_id": source_view.id, "categories": ["view_settings"]},
+    )
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert (
+        response.json()["error"]
+        == "ERROR_VIEW_CONFIGURATION_COPY_CATEGORY_NOT_SUPPORTED"
+    )
+
+    response = post(
+        dest_view.id,
+        {"source_view_id": source_view.id, "categories": ["unknown"]},
+    )
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+
+    response = post(
+        dest_view.id,
+        {"source_view_id": source_view.id, "categories": ["filters"]},
+        token_to_use=other_token,
+    )
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_USER_NOT_IN_GROUP"
+
+
+@pytest.mark.django_db
+def test_cannot_copy_configuration_from_another_users_personal_view(
+    api_client, data_fixture
+):
+    user, token = data_fixture.create_user_and_token()
+    other_user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    data_fixture.create_user_workspace(
+        workspace=table.database.workspace, user=other_user
+    )
+    field = data_fixture.create_text_field(table=table)
+    personal_view = data_fixture.create_grid_view(
+        table=table, ownership_type="personal", owned_by=other_user
+    )
+    data_fixture.create_view_filter(
+        view=personal_view, field=field, type="equal", value="secret"
+    )
+    dest_view = data_fixture.create_grid_view(table=table)
+
+    response = api_client.post(
+        reverse(
+            "api:database:views:copy_configuration",
+            kwargs={"view_id": dest_view.id},
+        ),
+        {"source_view_id": personal_view.id, "categories": ["filters"]},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_401_UNAUTHORIZED
+    assert response.json()["error"] == "PERMISSION_DENIED"
+    assert dest_view.viewfilter_set.count() == 0
+
+
+@pytest.mark.django_db
+def test_copy_view_configuration_is_a_single_undoable_action(api_client, data_fixture):
+    session_id = "session-id"
+    user, token = data_fixture.create_user_and_token(session_id=session_id)
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_text_field(table=table)
+    source_view = data_fixture.create_grid_view(table=table)
+    dest_view = data_fixture.create_grid_view(table=table)
+    for value in ["a", "b", "c"]:
+        data_fixture.create_view_filter(
+            view=source_view, field=field, type="equal", value=value
+        )
+
+    response = api_client.post(
+        reverse(
+            "api:database:views:copy_configuration",
+            kwargs={"view_id": dest_view.id},
+        ),
+        {"source_view_id": source_view.id, "categories": ["filters"]},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+        HTTP_CLIENTSESSIONID=session_id,
+    )
+    assert response.status_code == HTTP_200_OK
+    assert dest_view.viewfilter_set.count() == 3
+
+    undone_actions = ActionHandler.undo(
+        user, [ViewActionScopeType.value(dest_view.id)], session_id
+    )
+    assert len(undone_actions) == 1
+    assert dest_view.viewfilter_set.count() == 0

--- a/backend/tests/baserow/contrib/database/view/actions/test_view_copy_configuration_actions.py
+++ b/backend/tests/baserow/contrib/database/view/actions/test_view_copy_configuration_actions.py
@@ -1,0 +1,123 @@
+import pytest
+
+from baserow.contrib.database.action.scopes import ViewActionScopeType
+from baserow.contrib.database.views.actions import CopyViewConfigurationActionType
+from baserow.contrib.database.views.models import ViewFilter, ViewSort
+from baserow.core.action.handler import ActionHandler
+from baserow.core.action.registries import action_type_registry
+
+
+@pytest.mark.django_db
+def test_can_undo_redo_copy_view_configuration(data_fixture):
+    session_id = "session-id"
+    user = data_fixture.create_user(session_id=session_id)
+    table = data_fixture.create_database_table(user)
+    field = data_fixture.create_text_field(table=table)
+    source_view = data_fixture.create_grid_view(table=table, filter_type="OR")
+    dest_view = data_fixture.create_grid_view(table=table, filter_type="AND")
+
+    data_fixture.create_view_filter(
+        view=source_view, field=field, type="equal", value="copied"
+    )
+    data_fixture.create_view_sort(view=source_view, field=field, order="DESC")
+    original_filter = data_fixture.create_view_filter(
+        view=dest_view, field=field, type="equal", value="original"
+    )
+    original_sort = data_fixture.create_view_sort(
+        view=dest_view, field=field, order="ASC"
+    )
+
+    action_type_registry.get_by_type(CopyViewConfigurationActionType).do(
+        user, source_view, dest_view, ["filters", "sorts"]
+    )
+
+    dest_view.refresh_from_db()
+    assert dest_view.filter_type == "OR"
+    copied_filter = ViewFilter.objects.get(view=dest_view)
+    assert copied_filter.value == "copied"
+    copied_sort = ViewSort.objects.get(view=dest_view)
+    assert copied_sort.order == "DESC"
+
+    # A single undo reverts the whole copy and restores the original objects
+    # with their original ids.
+    ActionHandler.undo(user, [ViewActionScopeType.value(dest_view.id)], session_id)
+
+    dest_view.refresh_from_db()
+    assert dest_view.filter_type == "AND"
+    restored_filter = ViewFilter.objects.get(view=dest_view)
+    assert restored_filter.id == original_filter.id
+    assert restored_filter.value == "original"
+    restored_sort = ViewSort.objects.get(view=dest_view)
+    assert restored_sort.id == original_sort.id
+    assert restored_sort.order == "ASC"
+
+    # Redo applies the copied configuration again, with the ids created by the
+    # original copy.
+    ActionHandler.redo(user, [ViewActionScopeType.value(dest_view.id)], session_id)
+
+    dest_view.refresh_from_db()
+    assert dest_view.filter_type == "OR"
+    redone_filter = ViewFilter.objects.get(view=dest_view)
+    assert redone_filter.id == copied_filter.id
+    assert redone_filter.value == "copied"
+    redone_sort = ViewSort.objects.get(view=dest_view)
+    assert redone_sort.id == copied_sort.id
+
+
+@pytest.mark.django_db
+def test_undo_copy_view_configuration_with_deleted_field(data_fixture):
+    session_id = "session-id"
+    user = data_fixture.create_user(session_id=session_id)
+    table = data_fixture.create_database_table(user)
+    field = data_fixture.create_text_field(table=table)
+    field_to_delete = data_fixture.create_text_field(table=table)
+    source_view = data_fixture.create_grid_view(table=table)
+    dest_view = data_fixture.create_grid_view(table=table)
+
+    data_fixture.create_view_filter(
+        view=source_view, field=field, type="equal", value="a"
+    )
+    data_fixture.create_view_filter(
+        view=dest_view, field=field, type="equal", value="original"
+    )
+    data_fixture.create_view_filter(
+        view=dest_view, field=field_to_delete, type="equal", value="doomed"
+    )
+
+    action_type_registry.get_by_type(CopyViewConfigurationActionType).do(
+        user, source_view, dest_view, ["filters"]
+    )
+
+    # Permanently delete a field that the original configuration references.
+    field_to_delete.delete()
+
+    ActionHandler.undo(user, [ViewActionScopeType.value(dest_view.id)], session_id)
+
+    # The filter on the deleted field is skipped, the other one is restored.
+    assert [view_filter.value for view_filter in dest_view.viewfilter_set.all()] == [
+        "original"
+    ]
+
+
+@pytest.mark.django_db
+def test_copy_view_configuration_action_is_scoped_to_dest_view(data_fixture):
+    session_id = "session-id"
+    user = data_fixture.create_user(session_id=session_id)
+    table = data_fixture.create_database_table(user)
+    field = data_fixture.create_text_field(table=table)
+    source_view = data_fixture.create_grid_view(table=table)
+    dest_view = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_filter(
+        view=source_view, field=field, type="equal", value="a"
+    )
+
+    action_type_registry.get_by_type(CopyViewConfigurationActionType).do(
+        user, source_view, dest_view, ["filters"]
+    )
+
+    # Undoing in the scope of the source view does nothing.
+    undone = ActionHandler.undo(
+        user, [ViewActionScopeType.value(source_view.id)], session_id
+    )
+    assert undone == []
+    assert dest_view.viewfilter_set.count() == 1

--- a/backend/tests/baserow/contrib/database/view/test_view_configuration_copy.py
+++ b/backend/tests/baserow/contrib/database/view/test_view_configuration_copy.py
@@ -499,6 +499,37 @@ def test_copy_view_configuration_notifies_view_subscriptions(data_fixture):
 
 
 @pytest.mark.django_db
+def test_copy_view_configuration_schedules_index_update(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_text_field(table=table)
+    source_view = data_fixture.create_grid_view(table=table)
+    dest_view = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_sort(view=source_view, field=field)
+    data_fixture.create_view_filter(
+        view=source_view, field=field, type="equal", value="a"
+    )
+
+    # The granular sort and group by signals normally schedule the index
+    # update, but they're suppressed by the copy.
+    with patch(
+        "baserow.contrib.database.views.handler.ViewIndexingHandler"
+        ".schedule_index_update"
+    ) as schedule_mock:
+        ViewHandler().copy_view_configuration(user, source_view, dest_view, ["sorts"])
+
+    schedule_mock.assert_called_once_with(dest_view)
+
+    with patch(
+        "baserow.contrib.database.views.handler.ViewIndexingHandler"
+        ".schedule_index_update"
+    ) as schedule_mock:
+        ViewHandler().copy_view_configuration(user, source_view, dest_view, ["filters"])
+
+    schedule_mock.assert_not_called()
+
+
+@pytest.mark.django_db
 def test_copy_view_configuration_sends_single_signal(data_fixture):
     from baserow.contrib.database.views.signals import view_configuration_changed
 

--- a/backend/tests/baserow/contrib/database/view/test_view_configuration_copy.py
+++ b/backend/tests/baserow/contrib/database/view/test_view_configuration_copy.py
@@ -1,0 +1,529 @@
+from unittest.mock import patch
+
+import pytest
+
+from baserow.contrib.database.views.exceptions import (
+    CannotCopyViewConfigurationToSameView,
+    ViewConfigurationCopyCategoryNotSupported,
+    ViewNotInTable,
+)
+from baserow.contrib.database.views.handler import ViewHandler
+from baserow.contrib.database.views.models import (
+    ViewDefaultValue,
+    ViewFilter,
+    ViewGroupBy,
+    ViewSort,
+)
+from baserow.contrib.database.views.registries import (
+    decorator_type_registry,
+    view_type_registry,
+)
+from baserow.core.exceptions import UserNotInWorkspace
+
+
+def test_get_copyable_configuration_categories_per_view_type():
+    grid = view_type_registry.get("grid")
+    gallery = view_type_registry.get("gallery")
+    form = view_type_registry.get("form")
+
+    assert grid.get_copyable_configuration_categories() == {
+        "field_visibility",
+        "field_order",
+        "field_widths",
+        "view_settings",
+        "filters",
+        "sorts",
+        "group_bys",
+        "decorations",
+        "default_row_values",
+    }
+    assert gallery.get_copyable_configuration_categories() == {
+        "field_visibility",
+        "field_order",
+        "filters",
+        "sorts",
+        "decorations",
+        "default_row_values",
+    }
+    assert form.get_copyable_configuration_categories() == set()
+
+
+@pytest.mark.django_db
+def test_copy_view_configuration_filters(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_text_field(table=table)
+    source_view = data_fixture.create_grid_view(
+        table=table, filter_type="OR", filters_disabled=True
+    )
+    dest_view = data_fixture.create_grid_view(table=table)
+
+    root_group = data_fixture.create_view_filter_group(
+        view=source_view, filter_type="OR"
+    )
+    nested_group = data_fixture.create_view_filter_group(
+        view=source_view, parent_group=root_group
+    )
+    data_fixture.create_view_filter(
+        view=source_view, field=field, type="equal", value="a"
+    )
+    data_fixture.create_view_filter(
+        view=source_view, field=field, type="equal", value="b", group=root_group
+    )
+    data_fixture.create_view_filter(
+        view=source_view, field=field, type="equal", value="c", group=nested_group
+    )
+
+    # The destination has an existing filter that must be replaced.
+    existing_filter = data_fixture.create_view_filter(
+        view=dest_view, field=field, type="equal", value="old"
+    )
+
+    ViewHandler().copy_view_configuration(user, source_view, dest_view, ["filters"])
+
+    dest_view.refresh_from_db()
+    assert dest_view.filter_type == "OR"
+    assert dest_view.filters_disabled is True
+
+    assert not ViewFilter.objects.filter(id=existing_filter.id).exists()
+
+    dest_groups = list(dest_view.filter_groups.all().order_by("id"))
+    assert len(dest_groups) == 2
+    assert dest_groups[0].filter_type == "OR"
+    assert dest_groups[0].parent_group_id is None
+    assert dest_groups[1].parent_group_id == dest_groups[0].id
+    # New ids are generated, the source objects are not reused.
+    source_group_ids = {root_group.id, nested_group.id}
+    assert source_group_ids.isdisjoint({group.id for group in dest_groups})
+
+    dest_filters = list(dest_view.viewfilter_set.all().order_by("id"))
+    assert [
+        (view_filter.value, view_filter.group_id) for view_filter in dest_filters
+    ] == [
+        ("a", None),
+        ("b", dest_groups[0].id),
+        ("c", dest_groups[1].id),
+    ]
+
+    # The source view is untouched.
+    assert source_view.viewfilter_set.count() == 3
+    assert source_view.filter_groups.count() == 2
+
+
+@pytest.mark.django_db
+def test_copy_view_configuration_sorts_group_bys_and_decorations(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_text_field(table=table)
+    other_field = data_fixture.create_text_field(table=table)
+    source_view = data_fixture.create_grid_view(table=table)
+    dest_view = data_fixture.create_grid_view(table=table)
+
+    data_fixture.create_view_sort(view=source_view, field=field, order="DESC")
+    data_fixture.create_view_group_by(
+        view=source_view, field=field, order="ASC", width=250
+    )
+    data_fixture.create_view_decoration(
+        view=source_view, value_provider_conf={"config": 1}
+    )
+
+    data_fixture.create_view_sort(view=dest_view, field=other_field, order="ASC")
+    data_fixture.create_view_group_by(view=dest_view, field=other_field)
+    data_fixture.create_view_decoration(view=dest_view)
+
+    ViewHandler().copy_view_configuration(
+        user, source_view, dest_view, ["sorts", "group_bys", "decorations"]
+    )
+
+    dest_sorts = list(dest_view.viewsort_set.all())
+    assert [(sort.field_id, sort.order) for sort in dest_sorts] == [(field.id, "DESC")]
+    dest_group_bys = list(dest_view.viewgroupby_set.all())
+    assert [
+        (group_by.field_id, group_by.order, group_by.width)
+        for group_by in dest_group_bys
+    ] == [(field.id, "ASC", 250)]
+    dest_decorations = list(dest_view.viewdecoration_set.all())
+    assert [
+        (decoration.type, decoration.value_provider_conf)
+        for decoration in dest_decorations
+    ] == [("tmp_decorator_type_1", {"config": 1})]
+
+    assert source_view.viewsort_set.count() == 1
+    assert source_view.viewgroupby_set.count() == 1
+    assert source_view.viewdecoration_set.count() == 1
+
+
+@pytest.mark.django_db
+def test_copy_view_configuration_field_options_and_row_height(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_text_field(table=table)
+    source_view = data_fixture.create_grid_view(
+        table=table,
+        row_height_size="large",
+        frozen_column_count=3,
+        row_identifier_type="count",
+    )
+    dest_view = data_fixture.create_grid_view(table=table, row_height_size="small")
+
+    source_view.get_field_options(create_if_missing=True)
+    source_options = source_view.gridviewfieldoptions_set.get(field=field)
+    source_options.hidden = True
+    source_options.order = 2
+    source_options.width = 300
+    source_options.save()
+
+    ViewHandler().copy_view_configuration(
+        user,
+        source_view,
+        dest_view,
+        ["field_visibility", "field_widths", "view_settings"],
+    )
+
+    dest_view.refresh_from_db()
+    assert dest_view.row_height_size == "large"
+    assert dest_view.frozen_column_count == 3
+    assert dest_view.row_identifier_type == "count"
+    dest_options = dest_view.gridviewfieldoptions_set.get(field=field)
+    assert dest_options.hidden is True
+    assert dest_options.width == 300
+    # The `field_order` category was not requested, so the order is untouched.
+    assert dest_options.order != 2
+
+
+@pytest.mark.django_db
+def test_copy_view_configuration_default_row_values(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_text_field(table=table)
+    source_view = data_fixture.create_grid_view(table=table)
+    dest_view = data_fixture.create_grid_view(table=table)
+
+    ViewDefaultValue.objects.create(
+        view=source_view, field=field, value="default", field_type="text"
+    )
+    ViewDefaultValue.objects.create(
+        view=dest_view, field=field, value="old", field_type="text"
+    )
+
+    ViewHandler().copy_view_configuration(
+        user, source_view, dest_view, ["default_row_values"]
+    )
+
+    dest_default_values = list(dest_view.view_default_values.all())
+    assert [
+        (default_value.field_id, default_value.value)
+        for default_value in dest_default_values
+    ] == [(field.id, "default")]
+
+
+@pytest.mark.django_db
+def test_copy_view_configuration_validation(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    other_table = data_fixture.create_database_table(user=user)
+    grid_view = data_fixture.create_grid_view(table=table)
+    other_grid_view = data_fixture.create_grid_view(table=table)
+    gallery_view = data_fixture.create_gallery_view(table=table)
+    other_table_view = data_fixture.create_grid_view(table=other_table)
+
+    handler = ViewHandler()
+
+    with pytest.raises(CannotCopyViewConfigurationToSameView):
+        handler.copy_view_configuration(user, grid_view, grid_view, ["filters"])
+
+    with pytest.raises(ViewNotInTable):
+        handler.copy_view_configuration(user, other_table_view, grid_view, ["filters"])
+
+    # The gallery view doesn't support the grid specific categories, in either
+    # direction.
+    with pytest.raises(ViewConfigurationCopyCategoryNotSupported) as exc:
+        handler.copy_view_configuration(
+            user, grid_view, gallery_view, ["filters", "view_settings", "unknown"]
+        )
+    assert exc.value.categories == ["unknown", "view_settings"]
+
+    with pytest.raises(ViewConfigurationCopyCategoryNotSupported):
+        handler.copy_view_configuration(
+            user, gallery_view, other_grid_view, ["field_widths"]
+        )
+
+
+@pytest.mark.django_db
+def test_copy_view_configuration_replaces_config_on_trashed_fields(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_text_field(table=table)
+    trashed_field = data_fixture.create_text_field(table=table, trashed=True)
+    source_view = data_fixture.create_grid_view(table=table)
+    dest_view = data_fixture.create_grid_view(table=table)
+
+    # Configuration on trashed fields is hidden by the default managers, but
+    # deliberately kept so that it restores together with the field.
+    hidden_source_filter = data_fixture.create_view_filter(
+        view=source_view, field=trashed_field, type="equal", value="hidden"
+    )
+    hidden_dest_group = data_fixture.create_view_filter_group(view=dest_view)
+    hidden_dest_filter = data_fixture.create_view_filter(
+        view=dest_view,
+        field=trashed_field,
+        type="equal",
+        value="old hidden",
+        group=hidden_dest_group,
+    )
+    hidden_dest_sort = data_fixture.create_view_sort(
+        view=dest_view, field=trashed_field
+    )
+
+    handler = ViewHandler()
+    original_configuration = handler.export_view_configuration(
+        dest_view, ["filters", "sorts"]
+    )
+    handler.copy_view_configuration(user, source_view, dest_view, ["filters", "sorts"])
+
+    # The destination's hidden configuration is replaced too, and the source's
+    # hidden filter is copied along, staying hidden until the field restores.
+    dest_filters = ViewFilter._base_manager.filter(view=dest_view)
+    assert not dest_filters.filter(id=hidden_dest_filter.id).exists()
+    assert not ViewSort._base_manager.filter(id=hidden_dest_sort.id).exists()
+    assert list(dest_filters.values_list("value", flat=True)) == ["hidden"]
+
+    # Restoring the previous configuration brings the hidden objects back with
+    # their original ids.
+    handler.apply_view_configuration(
+        user, dest_view, original_configuration, preserve_ids=True
+    )
+    assert ViewFilter._base_manager.filter(id=hidden_dest_filter.id).exists()
+    assert ViewSort._base_manager.filter(id=hidden_dest_sort.id).exists()
+
+
+@pytest.mark.django_db
+def test_copy_view_configuration_restores_field_options_of_trashed_fields(
+    data_fixture,
+):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    trashed_field = data_fixture.create_text_field(table=table, trashed=True)
+    source_view = data_fixture.create_grid_view(table=table)
+    dest_view = data_fixture.create_grid_view(table=table)
+
+    options_model = dest_view.gridviewfieldoptions_set.model
+    options_model.objects_and_trash.create(
+        grid_view=source_view, field=trashed_field, hidden=False
+    )
+    dest_options = options_model.objects_and_trash.create(
+        grid_view=dest_view, field=trashed_field, hidden=True
+    )
+
+    handler = ViewHandler()
+    original_configuration = handler.export_view_configuration(
+        dest_view, ["field_visibility"]
+    )
+    handler.copy_view_configuration(user, source_view, dest_view, ["field_visibility"])
+
+    dest_options.refresh_from_db()
+    assert dest_options.hidden is False
+
+    # Undoing restores the trashed field's option, so it is still correct when
+    # the field is restored from the trash.
+    handler.apply_view_configuration(
+        user, dest_view, original_configuration, preserve_ids=True
+    )
+    dest_options.refresh_from_db()
+    assert dest_options.hidden is True
+
+
+@pytest.mark.django_db
+def test_copy_view_configuration_cross_view_type(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_text_field(table=table)
+    source_view = data_fixture.create_grid_view(table=table)
+    dest_view = data_fixture.create_gallery_view(table=table)
+
+    data_fixture.create_view_filter(
+        view=source_view, field=field, type="equal", value="a"
+    )
+    source_view.get_field_options(create_if_missing=True)
+    source_options = source_view.gridviewfieldoptions_set.get(field=field)
+    source_options.hidden = True
+    source_options.save()
+
+    ViewHandler().copy_view_configuration(
+        user, source_view, dest_view, ["filters", "field_visibility"]
+    )
+
+    assert dest_view.viewfilter_set.count() == 1
+    dest_options = dest_view.galleryviewfieldoptions_set.get(field=field)
+    assert dest_options.hidden is True
+
+
+@pytest.mark.django_db
+def test_copy_view_configuration_without_permissions(data_fixture):
+    user = data_fixture.create_user()
+    other_user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    source_view = data_fixture.create_grid_view(table=table)
+    dest_view = data_fixture.create_grid_view(table=table)
+
+    with pytest.raises(UserNotInWorkspace):
+        ViewHandler().copy_view_configuration(
+            other_user, source_view, dest_view, ["filters"]
+        )
+
+
+@pytest.mark.django_db
+def test_apply_view_configuration_without_permissions(data_fixture):
+    user = data_fixture.create_user()
+    other_user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    view = data_fixture.create_grid_view(table=table)
+
+    handler = ViewHandler()
+    configuration = handler.export_view_configuration(view, ["filters"])
+
+    # The permission is checked in `apply_view_configuration` itself so that
+    # undoing and redoing a copy also re-checks it.
+    with pytest.raises(UserNotInWorkspace):
+        handler.apply_view_configuration(other_user, view, configuration)
+
+
+@pytest.mark.django_db
+def test_apply_view_configuration_preserve_ids(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_text_field(table=table)
+    view = data_fixture.create_grid_view(table=table)
+
+    view_filter = data_fixture.create_view_filter(
+        view=view, field=field, type="equal", value="a"
+    )
+    view_sort = data_fixture.create_view_sort(view=view, field=field)
+    view_group_by = data_fixture.create_view_group_by(view=view, field=field)
+
+    handler = ViewHandler()
+    categories = ["filters", "sorts", "group_bys"]
+    configuration = handler.export_view_configuration(view, categories)
+
+    # Change the configuration so that the restore is observable.
+    view.viewfilter_set.all().delete()
+    view.viewsort_set.all().delete()
+    view.viewgroupby_set.all().delete()
+
+    handler.apply_view_configuration(user, view, configuration, preserve_ids=True)
+
+    assert ViewFilter.objects.get(view=view).id == view_filter.id
+    assert ViewSort.objects.get(view=view).id == view_sort.id
+    assert ViewGroupBy.objects.get(view=view).id == view_group_by.id
+
+
+@pytest.mark.django_db
+def test_apply_view_configuration_skips_deleted_fields(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_text_field(table=table)
+    deleted_field = data_fixture.create_text_field(table=table)
+    view = data_fixture.create_grid_view(table=table)
+
+    data_fixture.create_view_filter(view=view, field=field, type="equal", value="a")
+    data_fixture.create_view_filter(
+        view=view, field=deleted_field, type="equal", value="b"
+    )
+
+    handler = ViewHandler()
+    configuration = handler.export_view_configuration(view, ["filters"])
+
+    deleted_field.delete()
+
+    handler.apply_view_configuration(user, view, configuration, preserve_ids=True)
+
+    assert [view_filter.field_id for view_filter in view.viewfilter_set.all()] == [
+        field.id
+    ]
+
+
+@pytest.mark.django_db
+def test_copy_view_configuration_calls_decorator_type_hook(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    source_view = data_fixture.create_grid_view(table=table)
+    dest_view = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_decoration(view=source_view)
+
+    # The decorations are bulk created without the handler's create method, but
+    # the decorator type hook must still run because it can enforce
+    # constraints, a premium license for example.
+    with patch.object(
+        decorator_type_registry.get("tmp_decorator_type_1"),
+        "before_create_decoration",
+    ) as before_create_mock:
+        ViewHandler().copy_view_configuration(
+            user, source_view, dest_view, ["decorations"]
+        )
+
+    before_create_mock.assert_called_once_with(dest_view, user)
+
+
+@pytest.mark.django_db
+def test_copy_view_configuration_notifies_view_subscriptions(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_text_field(table=table)
+    source_view = data_fixture.create_grid_view(table=table)
+    dest_view = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_filter(
+        view=source_view, field=field, type="equal", value="a"
+    )
+
+    # Copying filters changes which rows match the view, so the view
+    # subscriptions must be notified for the rows entered/exited webhooks.
+    with patch(
+        "baserow.contrib.database.views.receivers.ViewSubscriptionHandler"
+        ".notify_table_views_updates"
+    ) as notify_mock:
+        ViewHandler().copy_view_configuration(user, source_view, dest_view, ["filters"])
+
+    notify_mock.assert_called_once_with([dest_view])
+
+    # The other categories can't change which rows are in the view, so no
+    # recomputation is triggered for them.
+    with patch(
+        "baserow.contrib.database.views.receivers.ViewSubscriptionHandler"
+        ".notify_table_views_updates"
+    ) as notify_mock:
+        ViewHandler().copy_view_configuration(
+            user, source_view, dest_view, ["sorts", "field_visibility"]
+        )
+
+    notify_mock.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_copy_view_configuration_sends_single_signal(data_fixture):
+    from baserow.contrib.database.views.signals import view_configuration_changed
+
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_text_field(table=table)
+    source_view = data_fixture.create_grid_view(table=table)
+    dest_view = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_filter(
+        view=source_view, field=field, type="equal", value="a"
+    )
+    data_fixture.create_view_sort(view=source_view, field=field)
+
+    received = []
+
+    def receiver(sender, view, user, **kwargs):
+        received.append(view)
+
+    view_configuration_changed.connect(receiver)
+    try:
+        ViewHandler().copy_view_configuration(
+            user, source_view, dest_view, ["filters", "sorts"]
+        )
+    finally:
+        view_configuration_changed.disconnect(receiver)
+
+    assert len(received) == 1
+    assert received[0].id == dest_view.id

--- a/backend/tests/baserow/contrib/database/ws/test_ws_view_configuration_copy_signals.py
+++ b/backend/tests/baserow/contrib/database/ws/test_ws_view_configuration_copy_signals.py
@@ -1,0 +1,68 @@
+from unittest.mock import patch
+
+from django.db import transaction
+
+import pytest
+
+from baserow.contrib.database.views.handler import ViewHandler
+
+
+@pytest.mark.django_db(transaction=True)
+@patch("baserow.ws.registries.broadcast_to_channel_group")
+def test_copy_view_configuration_broadcasts_once(
+    mock_broadcast_to_channel_group, data_fixture
+):
+    user = data_fixture.create_user(web_socket_id="web-socket-id")
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_text_field(table=table)
+    source_view = data_fixture.create_grid_view(table=table)
+    dest_view = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_filter(
+        view=source_view, field=field, type="equal", value="a"
+    )
+    data_fixture.create_view_sort(view=source_view, field=field)
+    data_fixture.create_view_filter(
+        view=dest_view, field=field, type="equal", value="old"
+    )
+
+    ViewHandler().copy_view_configuration(
+        user, source_view, dest_view, ["filters", "sorts"]
+    )
+
+    # Even though multiple filters and sorts were deleted and created, only a
+    # single event is broadcast, and the requester is excluded.
+    mock_broadcast_to_channel_group.delay.assert_called_once()
+    args = mock_broadcast_to_channel_group.delay.call_args
+    assert args[0][0] == f"table-{table.id}"
+    assert args[0][1]["type"] == "view_configuration_changed"
+    assert args[0][1]["view_id"] == dest_view.id
+    assert args[0][1]["view"]["id"] == dest_view.id
+    assert len(args[0][1]["view"]["filters"]) == 1
+    assert args[0][1]["view"]["filters"][0]["value"] == "a"
+    assert len(args[0][1]["view"]["sortings"]) == 1
+    assert args[0][1]["categories"] == ["filters", "sorts"]
+    assert args[0][2] == "web-socket-id"
+
+
+@pytest.mark.django_db(transaction=True)
+@patch("baserow.ws.registries.broadcast_to_channel_group")
+def test_copy_view_configuration_field_options_broadcast(
+    mock_broadcast_to_channel_group, data_fixture
+):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    data_fixture.create_text_field(table=table)
+    source_view = data_fixture.create_grid_view(table=table)
+    dest_view = data_fixture.create_grid_view(table=table)
+
+    with transaction.atomic():
+        ViewHandler().copy_view_configuration(
+            user, source_view, dest_view, ["field_visibility", "field_order"]
+        )
+
+    # The granular field options signal is suppressed, the single
+    # `view_configuration_changed` event covers the change.
+    mock_broadcast_to_channel_group.delay.assert_called_once()
+    args = mock_broadcast_to_channel_group.delay.call_args
+    assert args[0][1]["type"] == "view_configuration_changed"
+    assert args[0][1]["categories"] == ["field_visibility", "field_order"]

--- a/changelog/entries/unreleased/feature/copy_view_configuration_from_another_view.json
+++ b/changelog/entries/unreleased/feature/copy_view_configuration_from_another_view.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Copy the configuration of another view, filters and sorts for example, into a view.",
+    "issue_origin": "github",
+    "issue_number": 2762,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-25"
+}

--- a/enterprise/backend/src/baserow_enterprise/ws/restricted_view/views/signals.py
+++ b/enterprise/backend/src/baserow_enterprise/ws/restricted_view/views/signals.py
@@ -64,5 +64,24 @@ def restricted_view_filter_deleted(sender, view_filter_id, view_filter, user, **
 
 
 @receiver(view_signals.view_configuration_changed)
-def restricted_view_configuration_changed(sender, view, user, **kwargs):
-    _send_force_rows_refresh_if_view_restricted(view)
+def restricted_view_configuration_changed(sender, view, user, categories, **kwargs):
+    if (
+        "default_row_values" in categories
+        and view.ownership_type == RestrictedViewOwnershipType.type
+    ):
+        # The default values are filtered per user permission, so the clients
+        # have to fetch them again themselves, like the `view_updated` receiver
+        # above does.
+        view_page_type = page_registry.get("restricted_view")
+        transaction.on_commit(
+            lambda: view_page_type.broadcast(
+                {
+                    "type": "force_view_refresh_and_default_values",
+                    "view_id": view.id,
+                },
+                None,
+                restricted_view_id=view.id,
+            )
+        )
+    else:
+        _send_force_rows_refresh_if_view_restricted(view)

--- a/enterprise/backend/src/baserow_enterprise/ws/restricted_view/views/signals.py
+++ b/enterprise/backend/src/baserow_enterprise/ws/restricted_view/views/signals.py
@@ -61,3 +61,8 @@ def restricted_view_filter_updated(sender, view_filter, user, **kwargs):
 @receiver(view_signals.view_filter_deleted)
 def restricted_view_filter_deleted(sender, view_filter_id, view_filter, user, **kwargs):
     _send_force_rows_refresh_if_view_restricted(view_filter.view)
+
+
+@receiver(view_signals.view_configuration_changed)
+def restricted_view_configuration_changed(sender, view, user, **kwargs):
+    _send_force_rows_refresh_if_view_restricted(view)

--- a/enterprise/backend/tests/baserow_enterprise_tests/views/test_view_configuration_copy_permissions.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/views/test_view_configuration_copy_permissions.py
@@ -1,0 +1,155 @@
+from django.test.utils import override_settings
+
+import pytest
+
+from baserow.contrib.database.views.handler import ViewHandler
+from baserow.contrib.database.views.models import View
+from baserow.contrib.database.views.operations import UpdateViewOperationType
+from baserow.core.exceptions import PermissionDenied
+from baserow.core.models import Operation
+from baserow_enterprise.role.handler import RoleAssignmentHandler
+from baserow_enterprise.role.models import Role
+from baserow_enterprise.view_ownership_types import RestrictedViewOwnershipType
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_editor_cannot_copy_filters_from_restricted_view(enterprise_data_fixture):
+    """
+    Restricted views hide their filters from users without the create filter
+    permission, so those users must not be able to read them by copying them
+    into another view either.
+    """
+
+    enterprise_data_fixture.enable_enterprise()
+
+    user = enterprise_data_fixture.create_user()
+    user2 = enterprise_data_fixture.create_user()
+    workspace = enterprise_data_fixture.create_workspace(user=user, members=[user2])
+    database = enterprise_data_fixture.create_database_application(workspace=workspace)
+    table = enterprise_data_fixture.create_database_table(database=database)
+    field = enterprise_data_fixture.create_text_field(table=table)
+
+    restricted_view = enterprise_data_fixture.create_grid_view(
+        table=table, ownership_type=RestrictedViewOwnershipType.type
+    )
+    enterprise_data_fixture.create_view_filter(
+        view=restricted_view, field=field, type="equal", value="secret"
+    )
+    dest_view = enterprise_data_fixture.create_grid_view(table=table)
+
+    no_access_role = Role.objects.get(uid="NO_ACCESS")
+    editor_role = Role.objects.get(uid="EDITOR")
+    builder_role = Role.objects.get(uid="BUILDER")
+    RoleAssignmentHandler().assign_role(
+        user2, workspace, role=no_access_role, scope=workspace
+    )
+    RoleAssignmentHandler().assign_role(
+        user2,
+        workspace,
+        role=editor_role,
+        scope=View.objects.get(id=restricted_view.id),
+    )
+    RoleAssignmentHandler().assign_role(
+        user2, workspace, role=builder_role, scope=View.objects.get(id=dest_view.id)
+    )
+
+    with pytest.raises(PermissionDenied):
+        ViewHandler().copy_view_configuration(
+            user2, restricted_view, dest_view, ["filters"]
+        )
+
+    assert dest_view.viewfilter_set.count() == 0
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_cannot_copy_filters_with_role_that_can_only_update_the_view(
+    enterprise_data_fixture,
+):
+    """
+    A role can allow updating a view without allowing filter creation, so the
+    copy must check the category's own operations instead of only the view
+    update operation.
+    """
+
+    enterprise_data_fixture.enable_enterprise()
+
+    user = enterprise_data_fixture.create_user()
+    user2 = enterprise_data_fixture.create_user()
+    workspace = enterprise_data_fixture.create_workspace(user=user, members=[user2])
+    database = enterprise_data_fixture.create_database_application(workspace=workspace)
+    table = enterprise_data_fixture.create_database_table(database=database)
+    field = enterprise_data_fixture.create_text_field(table=table)
+
+    source_view = enterprise_data_fixture.create_grid_view(table=table)
+    enterprise_data_fixture.create_view_filter(
+        view=source_view, field=field, type="equal", value="a"
+    )
+    dest_view = enterprise_data_fixture.create_grid_view(table=table)
+
+    editor_role = Role.objects.get(uid="EDITOR")
+    update_only_role = Role.objects.create(
+        uid="view_update_only", name="View update only", workspace=workspace
+    )
+    update_only_role.operations.set(editor_role.operations.all())
+    update_only_role.operations.add(
+        Operation.objects.get(name=UpdateViewOperationType.type)
+    )
+    # The handler caches the roles per process, so it must pick up the newly
+    # created custom role.
+    RoleAssignmentHandler._init = False
+
+    no_access_role = Role.objects.get(uid="NO_ACCESS")
+    builder_role = Role.objects.get(uid="BUILDER")
+    RoleAssignmentHandler().assign_role(
+        user2, workspace, role=no_access_role, scope=workspace
+    )
+    RoleAssignmentHandler().assign_role(
+        user2, workspace, role=builder_role, scope=View.objects.get(id=source_view.id)
+    )
+    RoleAssignmentHandler().assign_role(
+        user2,
+        workspace,
+        role=update_only_role,
+        scope=View.objects.get(id=dest_view.id),
+    )
+
+    with pytest.raises(PermissionDenied):
+        ViewHandler().copy_view_configuration(
+            user2, source_view, dest_view, ["filters"]
+        )
+
+    # The view settings category only needs the view update operation, so that
+    # one is allowed for this role.
+    ViewHandler().copy_view_configuration(
+        user2, source_view, dest_view, ["view_settings"]
+    )
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_builder_can_copy_configuration(enterprise_data_fixture):
+    enterprise_data_fixture.enable_enterprise()
+
+    user = enterprise_data_fixture.create_user()
+    user2 = enterprise_data_fixture.create_user()
+    workspace = enterprise_data_fixture.create_workspace(user=user, members=[user2])
+    database = enterprise_data_fixture.create_database_application(workspace=workspace)
+    table = enterprise_data_fixture.create_database_table(database=database)
+    field = enterprise_data_fixture.create_text_field(table=table)
+
+    source_view = enterprise_data_fixture.create_grid_view(table=table)
+    enterprise_data_fixture.create_view_filter(
+        view=source_view, field=field, type="equal", value="a"
+    )
+    dest_view = enterprise_data_fixture.create_grid_view(table=table)
+
+    builder_role = Role.objects.get(uid="BUILDER")
+    RoleAssignmentHandler().assign_role(
+        user2, workspace, role=builder_role, scope=workspace
+    )
+
+    ViewHandler().copy_view_configuration(user2, source_view, dest_view, ["filters"])
+
+    assert dest_view.viewfilter_set.count() == 1

--- a/web-frontend/modules/core/assets/scss/components/header.scss
+++ b/web-frontend/modules/core/assets/scss/components/header.scss
@@ -94,6 +94,10 @@
     margin-right: 10px;
   }
 
+  &.header__filter-item--only-margin-right {
+    margin-right: 10px;
+  }
+
   &.header__filter-item--full-width {
     flex-grow: 1;
     display: flex;
@@ -109,10 +113,6 @@
 
   &.header__filter-item--no-margin-left {
     margin-left: 0;
-  }
-
-  &:last-child {
-    margin-right: 10px;
   }
 }
 

--- a/web-frontend/modules/core/registry.js
+++ b/web-frontend/modules/core/registry.js
@@ -44,9 +44,9 @@ export class Registerable {
     return 0
   }
 
-  $t(key) {
+  $t(key, ...args) {
     const { $i18n: i18n } = this.app
-    return i18n.t(key)
+    return i18n.t(key, ...args)
   }
 }
 

--- a/web-frontend/modules/database/components/view/CopyViewConfigurationModal.vue
+++ b/web-frontend/modules/database/components/view/CopyViewConfigurationModal.vue
@@ -1,0 +1,214 @@
+<template>
+  <Modal ref="modal">
+    <h2 class="box__title">
+      {{ $t('copyViewConfigurationModal.title', { name: view.name }) }}
+    </h2>
+    <Error :error="error"></Error>
+    <div class="control margin-bottom-2">
+      <label class="control__label control__label--small">
+        {{ $t('copyViewConfigurationModal.sourceView') }}
+      </label>
+      <Dropdown
+        v-model="sourceViewId"
+        :show-search="true"
+        :disabled="loading"
+        @input="sourceViewChanged($event)"
+      >
+        <DropdownItem
+          v-for="sourceViewItem in sourceViews"
+          :key="sourceViewItem.id"
+          :name="sourceViewItem.name"
+          :value="sourceViewItem.id"
+          :icon="sourceViewItem._.type.iconClass"
+        ></DropdownItem>
+      </Dropdown>
+    </div>
+    <div class="flex margin-bottom-2">
+      <ButtonText
+        size="small"
+        :disabled="sourceView === undefined || loading"
+        @click="selectAll()"
+      >
+        {{ $t('copyViewConfigurationModal.selectAll') }}
+      </ButtonText>
+      <ButtonText
+        size="small"
+        :disabled="sourceView === undefined || loading"
+        @click="clearAll()"
+      >
+        {{ $t('copyViewConfigurationModal.clearAll') }}
+      </ButtonText>
+    </div>
+    <SwitchInput
+      v-for="option in destOptions"
+      :key="option.getType()"
+      small
+      class="margin-bottom-1"
+      :value="selected.includes(option.getType())"
+      :disabled="!enabledKeys.includes(option.getType()) || loading"
+      @input="toggle(option.getType(), $event)"
+      >{{ option.getName(view) }}</SwitchInput
+    >
+    <div class="actions margin-bottom-0">
+      <div class="align-right">
+        <Button
+          type="primary"
+          size="large"
+          :loading="loading"
+          :disabled="loading || !canSubmit"
+          @click="submit()"
+        >
+          {{ $t('copyViewConfigurationModal.copy') }}
+        </Button>
+      </div>
+    </div>
+  </Modal>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import modal from '@baserow/modules/core/mixins/modal'
+import error from '@baserow/modules/core/mixins/error'
+import {
+  getCompatibleSourceViews,
+  getDestinationCopyOptions,
+  getEnabledCopyOptionKeys,
+  copyViewConfiguration,
+} from '@baserow/modules/database/utils/copyViewConfiguration'
+
+export default {
+  name: 'CopyViewConfigurationModal',
+  mixins: [modal, error],
+  props: {
+    view: {
+      type: Object,
+      required: true,
+    },
+    database: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      loading: false,
+      sourceViewId: null,
+      selected: [],
+      selectionChangedByUser: false,
+      initialSelection: null,
+    }
+  },
+  computed: {
+    ...mapGetters({
+      allViews: 'view/getAll',
+    }),
+    destOptions() {
+      return getDestinationCopyOptions(this.$registry, this.view)
+    },
+    sourceViews() {
+      // Views from which nothing can be copied, form views for example, are
+      // excluded because selecting them would be a dead end.
+      return getCompatibleSourceViews(
+        this.$registry,
+        this.allViews,
+        this.view,
+        this.database.workspace.id
+      )
+    },
+    sourceView() {
+      return this.sourceViews.find((view) => view.id === this.sourceViewId)
+    },
+    enabledKeys() {
+      if (this.sourceView === undefined) {
+        return []
+      }
+      return getEnabledCopyOptionKeys(
+        this.$registry,
+        this.sourceView,
+        this.view,
+        this.database.workspace.id
+      )
+    },
+    canSubmit() {
+      return (
+        this.sourceView !== undefined &&
+        this.selected.some((key) => this.enabledKeys.includes(key))
+      )
+    },
+  },
+  methods: {
+    /**
+     * The optional `initialSelection` array controls which options are checked
+     * once a source view is chosen. When it's `null`, all enabled options are
+     * checked.
+     */
+    show(initialSelection = null, ...args) {
+      this.loading = false
+      this.sourceViewId = null
+      this.selected = []
+      this.selectionChangedByUser = false
+      this.initialSelection = initialSelection
+      this.hideError()
+      return modal.methods.show.call(this, ...args)
+    },
+    sourceViewChanged(viewId) {
+      const sourceView = this.sourceViews.find((view) => view.id === viewId)
+      if (sourceView === undefined) {
+        return
+      }
+      const enabledKeys = getEnabledCopyOptionKeys(
+        this.$registry,
+        sourceView,
+        this.view,
+        this.database.workspace.id
+      )
+      if (!this.selectionChangedByUser) {
+        this.selected = enabledKeys.filter(
+          (key) =>
+            this.initialSelection === null ||
+            this.initialSelection.includes(key)
+        )
+      } else {
+        // Keep the user's explicit selection when switching the source view,
+        // but drop the options that the new source view doesn't support.
+        this.selected = this.selected.filter((key) => enabledKeys.includes(key))
+      }
+    },
+    toggle(key, value) {
+      this.selectionChangedByUser = true
+      if (value && !this.selected.includes(key)) {
+        this.selected = [...this.selected, key]
+      } else if (!value) {
+        this.selected = this.selected.filter((k) => k !== key)
+      }
+    },
+    selectAll() {
+      this.selectionChangedByUser = true
+      this.selected = [...this.enabledKeys]
+    },
+    clearAll() {
+      this.selectionChangedByUser = true
+      this.selected = []
+    },
+    async submit() {
+      this.loading = true
+      this.hideError()
+      try {
+        await copyViewConfiguration(this, {
+          sourceView: this.sourceView,
+          destView: this.view,
+          categories: this.selected.filter((key) =>
+            this.enabledKeys.includes(key)
+          ),
+          workspaceId: this.database.workspace.id,
+        })
+        this.hide()
+      } catch (err) {
+        this.handleError(err, 'view')
+      } finally {
+        this.loading = false
+      }
+    },
+  },
+}
+</script>

--- a/web-frontend/modules/database/components/view/ViewContext.vue
+++ b/web-frontend/modules/database/components/view/ViewContext.vue
@@ -63,6 +63,25 @@
         </a>
       </li>
       <li
+        v-if="
+          canCopyConfiguration &&
+          $hasPermission(
+            'database.table.view.update',
+            view,
+            database.workspace.id
+          )
+        "
+        class="context__menu-item"
+      >
+        <a
+          class="context__menu-item-link"
+          @click="openCopyConfigurationModal()"
+        >
+          <i class="context__menu-item-icon iconoir-multiple-pages"></i>
+          {{ $t('viewContext.copyConfiguration') }}
+        </a>
+      </li>
+      <li
         v-for="(
           changeViewOwnershipTypeComponent, index
         ) in changeViewOwnershipTypeMenuItems"
@@ -166,6 +185,11 @@
       :database="database"
       :store-prefix="storePrefix"
     />
+    <CopyViewConfigurationModal
+      ref="copyViewConfigurationModal"
+      :view="view"
+      :database="database"
+    />
   </Context>
 </template>
 
@@ -178,6 +202,8 @@ import { notifyIf } from '@baserow/modules/core/utils/error'
 import ExportTableModal from '@baserow/modules/database/components/export/ExportTableModal'
 import WebhookModal from '@baserow/modules/database/components/webhook/WebhookModal.vue'
 import DefaultValuesModal from '@baserow/modules/database/components/view/DefaultValuesModal.vue'
+import CopyViewConfigurationModal from '@baserow/modules/database/components/view/CopyViewConfigurationModal.vue'
+import { getCompatibleSourceViews } from '@baserow/modules/database/utils/copyViewConfiguration'
 
 export default {
   name: 'ViewContext',
@@ -186,6 +212,7 @@ export default {
     WebhookModal,
     ImportFileModal,
     DefaultValuesModal,
+    CopyViewConfigurationModal,
   },
   mixins: [context],
   props: {
@@ -224,7 +251,21 @@ export default {
     },
     ...mapGetters({
       fields: 'field/getAll',
+      allViews: 'view/getAll',
     }),
+    canCopyConfiguration() {
+      // Without a compatible source view, a form view or a table with a
+      // single view for example, the copy configuration modal would be a dead
+      // end.
+      return (
+        getCompatibleSourceViews(
+          this.$registry,
+          this.allViews,
+          this.view,
+          this.database.workspace.id
+        ).length > 0
+      )
+    },
     changeViewOwnershipTypeMenuItems() {
       const activeOwnershipTypes = Object.values(
         this.$registry.getAll('viewOwnershipType')
@@ -311,6 +352,10 @@ export default {
     openDefaultValuesModal() {
       this.$refs.context.hide()
       this.$refs.defaultValuesModal.show()
+    },
+    openCopyConfigurationModal() {
+      this.$refs.context.hide()
+      this.$refs.copyViewConfigurationModal.show()
     },
   },
 }

--- a/web-frontend/modules/database/components/view/ViewFilterForm.vue
+++ b/web-frontend/modules/database/components/view/ViewFilterForm.vue
@@ -55,6 +55,14 @@
         {{ $t('viewFilterContext.addFilterGroup') }}</ButtonText
       >
 
+      <ButtonText
+        v-if="canCopyConfiguration"
+        icon="iconoir-copy"
+        @click.prevent="$refs.copyViewConfigurationModal.show(['filters'])"
+      >
+        {{ $t('viewFilterContext.copyFromView') }}</ButtonText
+      >
+
       <div v-if="view.filters.length > 0" class="margin-left-auto">
         <SwitchInput
           small
@@ -64,6 +72,11 @@
         >
       </div>
     </div>
+    <CopyViewConfigurationModal
+      ref="copyViewConfigurationModal"
+      :view="view"
+      :database="database"
+    ></CopyViewConfigurationModal>
   </div>
 </template>
 
@@ -71,6 +84,8 @@
 import { notifyIf } from '@baserow/modules/core/utils/error'
 import { ulid } from 'ulid'
 import ViewFieldConditionsForm from '@baserow/modules/database/components/view/ViewFieldConditionsForm'
+import CopyViewConfigurationModal from '@baserow/modules/database/components/view/CopyViewConfigurationModal'
+import { getCompatibleSourceViews } from '@baserow/modules/database/utils/copyViewConfiguration'
 import { hasCompatibleFilterTypes } from '@baserow/modules/database/utils/field'
 import viewFilterTypes from '@baserow/modules/database/mixins/viewFilterTypes'
 
@@ -78,6 +93,7 @@ export default {
   name: 'ViewFilterForm',
   components: {
     ViewFieldConditionsForm,
+    CopyViewConfigurationModal,
   },
   mixins: [viewFilterTypes],
   props: {
@@ -109,6 +125,23 @@ export default {
   },
   emits: ['changed'],
   computed: {
+    canCopyConfiguration() {
+      return (
+        !this.readOnly &&
+        !this.isPublicView &&
+        this.$hasPermission(
+          'database.table.view.update',
+          this.view,
+          this.database.workspace.id
+        ) &&
+        getCompatibleSourceViews(
+          this.$registry,
+          this.$store.getters['view/getAll'],
+          this.view,
+          this.database.workspace.id
+        ).length > 0
+      )
+    },
     filterContextComponent() {
       if (!this.view.ownership_type || !this.database) return null
       const ownershipType = this.$registry.get(

--- a/web-frontend/modules/database/components/view/grid/GridViewHeader.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewHeader.vue
@@ -33,7 +33,10 @@
     <li
       :class="[
         'header__filter-item',
-        { 'header__filter-item--right': !presenceEnabled },
+        {
+          'header__filter-item--right': !presenceEnabled,
+          'header__filter-item--only-margin-right': presenceEnabled,
+        },
       ]"
     >
       <ViewSearch

--- a/web-frontend/modules/database/copyViewConfigurationOptionTypes.js
+++ b/web-frontend/modules/database/copyViewConfigurationOptionTypes.js
@@ -19,12 +19,27 @@ export class CopyViewConfigurationOptionType extends Registerable {
   }
 
   /**
+   * The backend checks the same operations on both views, so without them the
+   * copy request would be rejected, and the ownership managers hide
+   * configuration from users that lack these write operations, restricted
+   * views hide the filters from users without `create_filter` for example.
+   * Must mirror the backend category type's `operation_types`.
+   */
+  getPermissionOperations() {
+    return []
+  }
+
+  /**
    * Additional check on top of both view types declaring the option, for
    * constraints that depend on the concrete source and destination view or
    * the workspace, a required license for example.
    */
   isEnabled(sourceView, destView, workspaceId) {
-    return true
+    return this.getPermissionOperations().every(
+      (operation) =>
+        this.app.$hasPermission(operation, sourceView, workspaceId) &&
+        this.app.$hasPermission(operation, destView, workspaceId)
+    )
   }
 
   /**
@@ -49,6 +64,10 @@ export class FieldVisibilityCopyOptionType extends CopyViewConfigurationOptionTy
     return 'field_visibility'
   }
 
+  getPermissionOperations() {
+    return ['database.table.view.update_field_options']
+  }
+
   getOrder() {
     return 10
   }
@@ -69,6 +88,10 @@ export class FieldVisibilityCopyOptionType extends CopyViewConfigurationOptionTy
 export class FieldOrderCopyOptionType extends CopyViewConfigurationOptionType {
   static getType() {
     return 'field_order'
+  }
+
+  getPermissionOperations() {
+    return ['database.table.view.update_field_options']
   }
 
   getOrder() {
@@ -93,6 +116,10 @@ export class FieldWidthsCopyOptionType extends CopyViewConfigurationOptionType {
     return 'field_widths'
   }
 
+  getPermissionOperations() {
+    return ['database.table.view.update_field_options']
+  }
+
   getOrder() {
     return 30
   }
@@ -113,6 +140,10 @@ export class FieldWidthsCopyOptionType extends CopyViewConfigurationOptionType {
 export class ViewSettingsCopyOptionType extends CopyViewConfigurationOptionType {
   static getType() {
     return 'view_settings'
+  }
+
+  getPermissionOperations() {
+    return ['database.table.view.update']
   }
 
   getOrder() {
@@ -153,16 +184,27 @@ export class ViewSettingsCopyOptionType extends CopyViewConfigurationOptionType 
     const sourceSettings = registry
       .get('view', sourceView.type)
       .getCopyableViewSettings()
-    return registry
-      .get('view', destView.type)
-      .getCopyableViewSettings()
-      .some((attribute) => sourceSettings.includes(attribute))
+    return (
+      super.isEnabled(sourceView, destView, workspaceId) &&
+      registry
+        .get('view', destView.type)
+        .getCopyableViewSettings()
+        .some((attribute) => sourceSettings.includes(attribute))
+    )
   }
 }
 
 export class FiltersCopyOptionType extends CopyViewConfigurationOptionType {
   static getType() {
     return 'filters'
+  }
+
+  getPermissionOperations() {
+    return [
+      'database.table.view.create_filter',
+      'database.table.view.create_filter_group',
+      'database.table.view.update',
+    ]
   }
 
   getOrder() {
@@ -179,6 +221,10 @@ export class SortsCopyOptionType extends CopyViewConfigurationOptionType {
     return 'sorts'
   }
 
+  getPermissionOperations() {
+    return ['database.table.view.create_sort']
+  }
+
   getOrder() {
     return 60
   }
@@ -193,6 +239,10 @@ export class GroupBysCopyOptionType extends CopyViewConfigurationOptionType {
     return 'group_bys'
   }
 
+  getPermissionOperations() {
+    return ['database.table.view.create_group_by']
+  }
+
   getOrder() {
     return 70
   }
@@ -205,6 +255,10 @@ export class GroupBysCopyOptionType extends CopyViewConfigurationOptionType {
 export class DecorationsCopyOptionType extends CopyViewConfigurationOptionType {
   static getType() {
     return 'decorations'
+  }
+
+  getPermissionOperations() {
+    return ['database.table.view.create_decoration']
   }
 
   getOrder() {
@@ -224,11 +278,14 @@ export class DecorationsCopyOptionType extends CopyViewConfigurationOptionType {
     // Deactivated decorator types, because the workspace has no premium
     // license for example, are excluded so that the copy can't fail on the
     // backend's license check.
-    return Object.values(this.app.$registry.getAll('viewDecorator')).some(
-      (decoratorType) =>
-        !decoratorType.isDeactivated(workspaceId) &&
-        decoratorType.isCompatible(sourceView) &&
-        decoratorType.isCompatible(destView)
+    return (
+      super.isEnabled(sourceView, destView, workspaceId) &&
+      Object.values(this.app.$registry.getAll('viewDecorator')).some(
+        (decoratorType) =>
+          !decoratorType.isDeactivated(workspaceId) &&
+          decoratorType.isCompatible(sourceView) &&
+          decoratorType.isCompatible(destView)
+      )
     )
   }
 }
@@ -236,6 +293,13 @@ export class DecorationsCopyOptionType extends CopyViewConfigurationOptionType {
 export class DefaultRowValuesCopyOptionType extends CopyViewConfigurationOptionType {
   static getType() {
     return 'default_row_values'
+  }
+
+  getPermissionOperations() {
+    return [
+      'database.table.view.read_default_values',
+      'database.table.view.update_default_values',
+    ]
   }
 
   getOrder() {

--- a/web-frontend/modules/database/copyViewConfigurationOptionTypes.js
+++ b/web-frontend/modules/database/copyViewConfigurationOptionTypes.js
@@ -1,0 +1,253 @@
+import { Registerable } from '@baserow/modules/core/registry'
+
+/**
+ * One copyable piece of view configuration. The actual copying is done by the
+ * backend copy-configuration endpoint, so these registered types only provide
+ * the UI metadata for the copy configuration modal, and `getType()` must
+ * match a backend category type exactly. A view type declares which options
+ * it supports via `ViewType.getCopyableViewConfigurationOptions()`, and an
+ * option can only be copied when both the source and destination view type
+ * declare it.
+ */
+export class CopyViewConfigurationOptionType extends Registerable {
+  /**
+   * The `destView` is provided so that the label can describe what the option
+   * copies into this specific view.
+   */
+  getName(destView) {
+    throw new Error('The name of a copy view configuration option must be set.')
+  }
+
+  /**
+   * Additional check on top of both view types declaring the option, for
+   * constraints that depend on the concrete source and destination view or
+   * the workspace, a required license for example.
+   */
+  isEnabled(sourceView, destView, workspaceId) {
+    return true
+  }
+
+  /**
+   * Whether copying this option changes which rows are visible or how they
+   * are ordered, so that an open destination view only refetches when it must.
+   */
+  refreshesRows() {
+    return true
+  }
+
+  /**
+   * Whether copying this option changes the view's field options, so that an
+   * open destination view only refetches those when it must.
+   */
+  refreshesFieldOptions() {
+    return false
+  }
+}
+
+export class FieldVisibilityCopyOptionType extends CopyViewConfigurationOptionType {
+  static getType() {
+    return 'field_visibility'
+  }
+
+  getOrder() {
+    return 10
+  }
+
+  getName() {
+    return this.$t('copyViewConfigurationOption.fieldVisibility')
+  }
+
+  refreshesRows() {
+    return false
+  }
+
+  refreshesFieldOptions() {
+    return true
+  }
+}
+
+export class FieldOrderCopyOptionType extends CopyViewConfigurationOptionType {
+  static getType() {
+    return 'field_order'
+  }
+
+  getOrder() {
+    return 20
+  }
+
+  getName() {
+    return this.$t('copyViewConfigurationOption.fieldOrder')
+  }
+
+  refreshesRows() {
+    return false
+  }
+
+  refreshesFieldOptions() {
+    return true
+  }
+}
+
+export class FieldWidthsCopyOptionType extends CopyViewConfigurationOptionType {
+  static getType() {
+    return 'field_widths'
+  }
+
+  getOrder() {
+    return 30
+  }
+
+  getName() {
+    return this.$t('copyViewConfigurationOption.fieldWidths')
+  }
+
+  refreshesRows() {
+    return false
+  }
+
+  refreshesFieldOptions() {
+    return true
+  }
+}
+
+export class ViewSettingsCopyOptionType extends CopyViewConfigurationOptionType {
+  static getType() {
+    return 'view_settings'
+  }
+
+  getOrder() {
+    return 40
+  }
+
+  getName(destView) {
+    // The copied attributes differ per view type, so the label enumerates the
+    // destination's ones, the row height and frozen columns of a grid view for
+    // example, because a plain "View settings" doesn't tell the user what will
+    // be copied. The translation key is derived from the attribute name so
+    // that a view type can add an attribute together with its own translation.
+    const settings = this.app.$registry
+      .get('view', destView.type)
+      .getCopyableViewSettings()
+      .map((attribute) => {
+        const suffix = attribute
+          .split('_')
+          .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+          .join('')
+        return this.$t(`copyViewConfigurationOption.viewSettings${suffix}`)
+      })
+    return this.$t('copyViewConfigurationOption.viewSettings', {
+      settings: settings.join(', '),
+    })
+  }
+
+  // The view components render these attributes, the grid row height and
+  // frozen column count for example, reactively from the view object.
+  refreshesRows() {
+    return false
+  }
+
+  isEnabled(sourceView, destView, workspaceId) {
+    // Only attributes that both view types declare are copied, so there must
+    // be at least one in common.
+    const registry = this.app.$registry
+    const sourceSettings = registry
+      .get('view', sourceView.type)
+      .getCopyableViewSettings()
+    return registry
+      .get('view', destView.type)
+      .getCopyableViewSettings()
+      .some((attribute) => sourceSettings.includes(attribute))
+  }
+}
+
+export class FiltersCopyOptionType extends CopyViewConfigurationOptionType {
+  static getType() {
+    return 'filters'
+  }
+
+  getOrder() {
+    return 50
+  }
+
+  getName() {
+    return this.$t('copyViewConfigurationOption.filters')
+  }
+}
+
+export class SortsCopyOptionType extends CopyViewConfigurationOptionType {
+  static getType() {
+    return 'sorts'
+  }
+
+  getOrder() {
+    return 60
+  }
+
+  getName() {
+    return this.$t('copyViewConfigurationOption.sorts')
+  }
+}
+
+export class GroupBysCopyOptionType extends CopyViewConfigurationOptionType {
+  static getType() {
+    return 'group_bys'
+  }
+
+  getOrder() {
+    return 70
+  }
+
+  getName() {
+    return this.$t('copyViewConfigurationOption.groupBys')
+  }
+}
+
+export class DecorationsCopyOptionType extends CopyViewConfigurationOptionType {
+  static getType() {
+    return 'decorations'
+  }
+
+  getOrder() {
+    return 80
+  }
+
+  getName() {
+    return this.$t('copyViewConfigurationOption.decorations')
+  }
+
+  // Decorations only change how the already loaded rows are decorated.
+  refreshesRows() {
+    return false
+  }
+
+  isEnabled(sourceView, destView, workspaceId) {
+    // Deactivated decorator types, because the workspace has no premium
+    // license for example, are excluded so that the copy can't fail on the
+    // backend's license check.
+    return Object.values(this.app.$registry.getAll('viewDecorator')).some(
+      (decoratorType) =>
+        !decoratorType.isDeactivated(workspaceId) &&
+        decoratorType.isCompatible(sourceView) &&
+        decoratorType.isCompatible(destView)
+    )
+  }
+}
+
+export class DefaultRowValuesCopyOptionType extends CopyViewConfigurationOptionType {
+  static getType() {
+    return 'default_row_values'
+  }
+
+  getOrder() {
+    return 90
+  }
+
+  getName() {
+    return this.$t('copyViewConfigurationOption.defaultRowValues')
+  }
+
+  // Default row values only affect newly created rows.
+  refreshesRows() {
+    return false
+  }
+}

--- a/web-frontend/modules/database/locales/en.json
+++ b/web-frontend/modules/database/locales/en.json
@@ -583,7 +583,29 @@
     "relatedFieldNotFound": "The related field is not found.",
     "filterTypeNotFound": "The filter type is not compatible.",
     "noCompatibleFilterTypesErrorTitle": "No compatible filter types",
-    "noCompatibleFilterTypesErrorMessage": "None of your fields have any compatible filter types"
+    "noCompatibleFilterTypesErrorMessage": "None of your fields have any compatible filter types",
+    "copyFromView": "Copy from another view"
+  },
+  "copyViewConfigurationModal": {
+    "title": "Copy configuration to {name}",
+    "sourceView": "Copy from view",
+    "selectAll": "Select all",
+    "clearAll": "Clear all",
+    "copy": "Copy configuration"
+  },
+  "copyViewConfigurationOption": {
+    "fieldVisibility": "Field visibility",
+    "fieldOrder": "Field order",
+    "fieldWidths": "Field widths",
+    "viewSettings": "Settings ({settings})",
+    "viewSettingsRowHeightSize": "row height",
+    "viewSettingsFrozenColumnCount": "frozen columns",
+    "viewSettingsRowIdentifierType": "row identifier",
+    "filters": "Filters",
+    "sorts": "Sorts",
+    "groupBys": "Groups",
+    "decorations": "Decorations",
+    "defaultRowValues": "Default row values"
   },
   "viewFilterTypeFileTypeDropdown": {
     "image": "image",
@@ -698,6 +720,7 @@
   "viewContext": {
     "exportView": "Export view",
     "duplicateView": "Duplicate view",
+    "copyConfiguration": "Copy configuration from view",
     "defaultRowValues": "Default row values",
     "renameView": "Rename view",
     "toPersonal": "To personal",

--- a/web-frontend/modules/database/plugin.js
+++ b/web-frontend/modules/database/plugin.js
@@ -14,6 +14,17 @@ import {
   FormViewType,
 } from '@baserow/modules/database/viewTypes'
 import {
+  DecorationsCopyOptionType,
+  DefaultRowValuesCopyOptionType,
+  FieldOrderCopyOptionType,
+  FieldVisibilityCopyOptionType,
+  FieldWidthsCopyOptionType,
+  FiltersCopyOptionType,
+  GroupBysCopyOptionType,
+  ViewSettingsCopyOptionType,
+  SortsCopyOptionType,
+} from '@baserow/modules/database/copyViewConfigurationOptionTypes'
+import {
   TextFieldType,
   LongTextFieldType,
   URLFieldType,
@@ -409,6 +420,7 @@ export default defineNuxtPlugin({
     $registry.registerNamespace('onboardingTrackFields')
     $registry.registerNamespace('configureDataSync')
     $registry.registerNamespace('databaseOnboardingStep')
+    $registry.registerNamespace('copyViewConfigurationOption')
 
     $registry.register('plugin', new DatabasePlugin(context))
     $registry.register('application', new DatabaseApplicationType(context))
@@ -423,6 +435,43 @@ export default defineNuxtPlugin({
     $registry.register('view', new GridViewType(context))
     $registry.register('view', new GalleryViewType(context))
     $registry.register('view', new FormViewType(context))
+
+    $registry.register(
+      'copyViewConfigurationOption',
+      new FieldVisibilityCopyOptionType(context)
+    )
+    $registry.register(
+      'copyViewConfigurationOption',
+      new FieldOrderCopyOptionType(context)
+    )
+    $registry.register(
+      'copyViewConfigurationOption',
+      new FieldWidthsCopyOptionType(context)
+    )
+    $registry.register(
+      'copyViewConfigurationOption',
+      new ViewSettingsCopyOptionType(context)
+    )
+    $registry.register(
+      'copyViewConfigurationOption',
+      new FiltersCopyOptionType(context)
+    )
+    $registry.register(
+      'copyViewConfigurationOption',
+      new SortsCopyOptionType(context)
+    )
+    $registry.register(
+      'copyViewConfigurationOption',
+      new GroupBysCopyOptionType(context)
+    )
+    $registry.register(
+      'copyViewConfigurationOption',
+      new DecorationsCopyOptionType(context)
+    )
+    $registry.register(
+      'copyViewConfigurationOption',
+      new DefaultRowValuesCopyOptionType(context)
+    )
     $registry.register('viewFilter', new EqualViewFilterType(context))
     $registry.register('viewFilter', new NotEqualViewFilterType(context))
     $registry.register(

--- a/web-frontend/modules/database/realtime.js
+++ b/web-frontend/modules/database/realtime.js
@@ -1,6 +1,10 @@
 import { clone } from '@baserow/modules/core/utils/object'
 import { anyFieldsNeedFetch } from '@baserow/modules/database/store/field'
 import { generateHash } from '@baserow/modules/core/utils/hashing'
+import {
+  forceUpdateViewConfiguration,
+  getRefreshFlags,
+} from '@baserow/modules/database/utils/copyViewConfiguration'
 
 /**
  * Registers the real time events related to the database module. When a message comes
@@ -366,6 +370,21 @@ export const registerRealtimeEvents = (realtime) => {
       }
     }
   })
+
+  realtime.registerEvent(
+    'view_configuration_changed',
+    async ({ store, app }, data) => {
+      const view = store.getters['view/get'](data.view_id)
+      if (view !== undefined) {
+        await forceUpdateViewConfiguration(
+          { $store: store, $bus: app.$bus },
+          view,
+          data.view,
+          getRefreshFlags(app.$registry, view, data.categories)
+        )
+      }
+    }
+  )
 
   realtime.registerEvent(
     'force_view_refresh_and_default_values',

--- a/web-frontend/modules/database/services/view.js
+++ b/web-frontend/modules/database/services/view.js
@@ -103,6 +103,12 @@ export default (client) => {
     duplicate(viewId) {
       return client.post(`/database/views/${viewId}/duplicate/`)
     },
+    copyConfiguration(viewId, { sourceViewId, categories }) {
+      return client.post(`/database/views/${viewId}/copy-configuration/`, {
+        source_view_id: sourceViewId,
+        categories,
+      })
+    },
     order(tableId, ownershipType, order) {
       return client.post(`/database/views/table/${tableId}/order/`, {
         view_ids: order,

--- a/web-frontend/modules/database/utils/copyViewConfiguration.js
+++ b/web-frontend/modules/database/utils/copyViewConfiguration.js
@@ -1,0 +1,138 @@
+import ViewService from '@baserow/modules/database/services/view'
+
+/**
+ * The copy view configuration options offered when copying into the given destination
+ * view, sorted by order. Options the destination view type can never receive are not
+ * included.
+ */
+export function getDestinationCopyOptions(registry, destView) {
+  return registry
+    .get('view', destView.type)
+    .getCopyableViewConfigurationOptions()
+    .sort((a, b) => a.getOrder() - b.getOrder())
+}
+
+/**
+ * The option keys that are enabled for the concrete source and destination view pair:
+ * the intersection of both view types' option keys, refined by each option's own
+ * `isEnabled` check.
+ */
+export function getEnabledCopyOptionKeys(
+  registry,
+  sourceView,
+  destView,
+  workspaceId
+) {
+  const sourceKeys = new Set(
+    registry
+      .get('view', sourceView.type)
+      .getCopyableViewConfigurationOptions()
+      .map((option) => option.getType())
+  )
+  return getDestinationCopyOptions(registry, destView)
+    .filter(
+      (option) =>
+        sourceKeys.has(option.getType()) &&
+        option.isEnabled(sourceView, destView, workspaceId)
+    )
+    .map((option) => option.getType())
+}
+
+/**
+ * The views that can act as the source of a configuration copy into the given
+ * destination view: every other view that has at least one enabled option in common
+ * with the destination. When this is empty, the copy configuration modal would be a
+ * dead end and shouldn't be offered at all, for a form view or a table with a single
+ * view for example.
+ */
+export function getCompatibleSourceViews(
+  registry,
+  views,
+  destView,
+  workspaceId
+) {
+  return views.filter(
+    (view) =>
+      view.id !== destView.id &&
+      getEnabledCopyOptionKeys(registry, view, destView, workspaceId).length > 0
+  )
+}
+
+/**
+ * Whether the destination view must refetch its rows and/or field options
+ * after the given categories have been copied into it, so that both the
+ * initiating client and the realtime event handler make the same
+ * option-driven refresh decision.
+ */
+export function getRefreshFlags(registry, destView, categories) {
+  const appliedOptions = getDestinationCopyOptions(registry, destView).filter(
+    (option) => categories.includes(option.getType())
+  )
+  return {
+    refreshRows: appliedOptions.some((option) => option.refreshesRows()),
+    includeFieldOptions: appliedOptions.some((option) =>
+      option.refreshesFieldOptions()
+    ),
+  }
+}
+
+/**
+ * Applies a complete new view payload, filters, sortings, group bys, decorations and
+ * scalar properties included, to the view store in a single mutation, and refreshes
+ * the table once if the view is currently open. Used after the copy configuration
+ * endpoint responds and by the matching realtime event, so both paths behave
+ * identically and the open view updates without flickering.
+ */
+export async function forceUpdateViewConfiguration(
+  { $store, $bus },
+  view,
+  values,
+  { refreshRows = true, includeFieldOptions = true } = {}
+) {
+  await $store.dispatch('view/forceUpdate', {
+    view,
+    values,
+    repopulate: true,
+  })
+
+  if (
+    (refreshRows || includeFieldOptions) &&
+    $store.getters['view/getSelectedId'] === view.id
+  ) {
+    $bus.$emit('table-refresh', {
+      tableId: view.table_id,
+      includeFieldOptions,
+    })
+  }
+}
+
+/**
+ * Copies the checked configuration options of the source view into the destination
+ * view via the backend endpoint. The whole copy is a single undoable action, and the
+ * store is only updated once the endpoint responds, so the open view never shows a
+ * partially copied configuration. Both views must belong to the same table.
+ */
+export async function copyViewConfiguration(
+  { $store, $client, $registry, $bus },
+  { sourceView, destView, categories, workspaceId }
+) {
+  const enabledKeys = getEnabledCopyOptionKeys(
+    $registry,
+    sourceView,
+    destView,
+    workspaceId
+  )
+  categories = categories.filter((category) => enabledKeys.includes(category))
+
+  const { data } = await ViewService($client).copyConfiguration(destView.id, {
+    sourceViewId: sourceView.id,
+    categories,
+  })
+
+  await forceUpdateViewConfiguration(
+    { $store, $bus },
+    destView,
+    data,
+    getRefreshFlags($registry, destView, categories)
+  )
+}

--- a/web-frontend/modules/database/viewTypes.js
+++ b/web-frontend/modules/database/viewTypes.js
@@ -20,6 +20,17 @@ import { clone } from '@baserow/modules/core/utils/object'
 import { getDefaultSearchModeFromEnv } from '@baserow/modules/database/utils/search'
 import { GRID_VIEW_SIZE_TO_ROW_HEIGHT_MAPPING } from '@baserow/modules/database/constants'
 import { waitFor } from '@baserow/modules/core/utils/queue'
+import {
+  DecorationsCopyOptionType,
+  DefaultRowValuesCopyOptionType,
+  FieldOrderCopyOptionType,
+  FieldVisibilityCopyOptionType,
+  FieldWidthsCopyOptionType,
+  FiltersCopyOptionType,
+  GroupBysCopyOptionType,
+  SortsCopyOptionType,
+  ViewSettingsCopyOptionType,
+} from '@baserow/modules/database/copyViewConfigurationOptionTypes'
 
 export class ViewType extends Registerable {
   /**
@@ -82,6 +93,55 @@ export class ViewType extends Registerable {
    */
   canShowRowModal() {
     return false
+  }
+
+  /**
+   * The copy view configuration options, registered in the
+   * `copyViewConfigurationOption` registry, that this view type supports as
+   * the source or destination of the "copy view configuration" feature. An
+   * option is only offered in the modal when both the source and destination
+   * view type return an option with the same type. Subclasses can append
+   * their own registered options, the way the grid view adds the field
+   * widths, and other modules can do the same for their own view types.
+   *
+   * Must only be called at runtime because the `canFilter`, `canSort`,
+   * `canGroupBy` and `canSetDefaultValues` properties are snapshotted in the
+   * constructor.
+   */
+  getCopyableViewConfigurationOptions() {
+    const keys = [
+      FieldVisibilityCopyOptionType.getType(),
+      FieldOrderCopyOptionType.getType(),
+      DecorationsCopyOptionType.getType(),
+    ]
+    if (this.canFilter) {
+      keys.push(FiltersCopyOptionType.getType())
+    }
+    if (this.canSort) {
+      keys.push(SortsCopyOptionType.getType())
+    }
+    if (this.canGroupBy) {
+      keys.push(GroupBysCopyOptionType.getType())
+    }
+    if (this.canSetDefaultValues) {
+      keys.push(DefaultRowValuesCopyOptionType.getType())
+    }
+    if (this.getCopyableViewSettings().length > 0) {
+      keys.push(ViewSettingsCopyOptionType.getType())
+    }
+    return keys.map((key) =>
+      this.app.$registry.get('copyViewConfigurationOption', key)
+    )
+  }
+
+  /**
+   * The plain view attributes that the `view_settings` copy option copies from
+   * one view into another. Must mirror the backend view type's
+   * `copyable_view_attributes`, and only attributes that both the source and
+   * destination view type declare are copied.
+   */
+  getCopyableViewSettings() {
+    return []
   }
 
   /**
@@ -540,6 +600,21 @@ export class GridViewType extends ViewType {
 
   canGroupBy() {
     return true
+  }
+
+  getCopyableViewConfigurationOptions() {
+    const registry = this.app.$registry
+    return [
+      ...super.getCopyableViewConfigurationOptions(),
+      registry.get(
+        'copyViewConfigurationOption',
+        FieldWidthsCopyOptionType.getType()
+      ),
+    ]
+  }
+
+  getCopyableViewSettings() {
+    return ['row_height_size', 'frozen_column_count', 'row_identifier_type']
   }
 
   getName() {
@@ -1284,6 +1359,10 @@ export class FormViewType extends ViewType {
 
   canSort() {
     return false
+  }
+
+  getCopyableViewConfigurationOptions() {
+    return []
   }
 
   canShare() {

--- a/web-frontend/test/unit/database/__snapshots__/table.spec.js.snap
+++ b/web-frontend/test/unit/database/__snapshots__/table.spec.js.snap
@@ -120,7 +120,7 @@ exports[`Table Component Tests > Adding a row to a table increases the row count
           <!--v-if-->
         </li>
         <!--v-if-->
-        <li class="header__filter-item">
+        <li class="header__filter-item header__filter-item--only-margin-right">
           <div class="header__search"><a class="header__filter-link"><i class="header__search-icon iconoir-search"></i> </a><a class="header__search-clear" aria-label="viewSearch.clearSearch" style="display: none;"><i class="iconoir-cancel"></i></a>
             <teleport-stub to="body">
               <div class="context visibility-hidden context--overflow-scroll">
@@ -459,7 +459,7 @@ exports[`Table Component Tests > Adding a row to a table increases the row count
           <!--v-if-->
         </li>
         <!--v-if-->
-        <li class="header__filter-item">
+        <li class="header__filter-item header__filter-item--only-margin-right">
           <div class="header__search"><a class="header__filter-link"><i class="header__search-icon iconoir-search"></i> </a><a class="header__search-clear" aria-label="viewSearch.clearSearch" style="display: none;"><i class="iconoir-cancel"></i></a>
             <teleport-stub to="body">
               <div class="context visibility-hidden context--overflow-scroll">

--- a/web-frontend/test/unit/database/components/view/__snapshots__/viewFilterForm.spec.js.snap
+++ b/web-frontend/test/unit/database/components/view/__snapshots__/viewFilterForm.spec.js.snap
@@ -53,7 +53,13 @@ exports[`ViewFilterForm match snapshots > Default view filter component 1`] = `
       </span>
     </button>
     <!--v-if-->
+    <!--v-if-->
   </div>
+  <teleport-stub
+    to="body"
+  >
+    <!--v-if-->
+  </teleport-stub>
 </div>
 `;
 
@@ -1170,6 +1176,7 @@ exports[`ViewFilterForm match snapshots > Full view filter component 1`] = `
         
       </span>
     </button>
+    <!--v-if-->
     <div
       class="margin-left-auto"
     >
@@ -1186,6 +1193,11 @@ exports[`ViewFilterForm match snapshots > Full view filter component 1`] = `
       </div>
     </div>
   </div>
+  <teleport-stub
+    to="body"
+  >
+    <!--v-if-->
+  </teleport-stub>
 </div>
 `;
 
@@ -1671,6 +1683,7 @@ exports[`ViewFilterForm match snapshots > rating filter 1`] = `
         
       </span>
     </button>
+    <!--v-if-->
     <div
       class="margin-left-auto"
     >
@@ -1687,5 +1700,10 @@ exports[`ViewFilterForm match snapshots > rating filter 1`] = `
       </div>
     </div>
   </div>
+  <teleport-stub
+    to="body"
+  >
+    <!--v-if-->
+  </teleport-stub>
 </div>
 `;

--- a/web-frontend/test/unit/database/components/view/copyViewConfigurationModal.spec.js
+++ b/web-frontend/test/unit/database/components/view/copyViewConfigurationModal.spec.js
@@ -1,0 +1,276 @@
+import flushPromises from 'flush-promises'
+
+import { TestApp } from '@baserow/test/helpers/testApp'
+import CopyViewConfigurationModal from '@baserow/modules/database/components/view/CopyViewConfigurationModal'
+
+describe('CopyViewConfigurationModal', () => {
+  let testApp = null
+
+  const database = { id: 1, workspace: { id: 1 } }
+  const destViewId = 2
+  const galleryViewId = 3
+
+  beforeEach(() => {
+    testApp = new TestApp()
+
+    const baseValues = {
+      table_id: 10,
+      filter_type: 'AND',
+      filters_disabled: false,
+    }
+    testApp.store.dispatch('view/forceCreate', {
+      data: { id: 1, type: 'grid', name: 'Source grid', ...baseValues },
+    })
+    testApp.store.dispatch('view/forceCreate', {
+      data: {
+        id: destViewId,
+        type: 'grid',
+        name: 'Destination',
+        ...baseValues,
+      },
+    })
+    testApp.store.dispatch('view/forceCreate', {
+      data: {
+        id: galleryViewId,
+        type: 'gallery',
+        name: 'Gallery',
+        ...baseValues,
+      },
+    })
+    testApp.store.dispatch('view/forceCreate', {
+      data: { id: 4, type: 'form', name: 'Form', ...baseValues },
+    })
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  const mountModal = async (viewId = destViewId) => {
+    const destView = testApp.store.getters['view/get'](viewId)
+    const wrapper = await testApp.mount(CopyViewConfigurationModal, {
+      propsData: { view: destView, database },
+    })
+    return wrapper
+  }
+
+  // The test environment resolves every i18n key to itself, so the switch
+  // labels are the raw `copyViewConfigurationOption.*` keys here.
+  const label = (name) => `copyViewConfigurationOption.${name}`
+
+  // The teleported modal element is replaced on re-render, so it must be
+  // fetched freshly for every assertion.
+  const element = (wrapper) => wrapper.vm.getTeleportedElement()
+  const getSwitches = (wrapper) => [
+    ...element(wrapper).querySelectorAll('.switch'),
+  ]
+  const switchLabels = (wrapper) =>
+    getSwitches(wrapper).map((s) => s.textContent.trim())
+  const activeSwitchLabels = (wrapper) =>
+    getSwitches(wrapper)
+      .filter((s) => s.classList.contains('switch--active'))
+      .map((s) => s.textContent.trim())
+  const disabledSwitchLabels = (wrapper) =>
+    getSwitches(wrapper)
+      .filter((s) => s.classList.contains('switch--disabled'))
+      .map((s) => s.textContent.trim())
+  const getCopyButton = (wrapper) => {
+    const buttons = [...element(wrapper).querySelectorAll('button')]
+    return buttons[buttons.length - 1]
+  }
+
+  const selectSourceView = async (wrapper, name) => {
+    const item = [...element(wrapper).querySelectorAll('.select__item a')].find(
+      (a) => a.textContent.includes(name)
+    )
+    item.click()
+    await flushPromises()
+  }
+
+  test('the dropdown excludes the destination view and form views', async () => {
+    const wrapper = await mountModal()
+    wrapper.vm.show()
+    await flushPromises()
+
+    const names = [
+      ...element(wrapper).querySelectorAll('.select__item-name-text'),
+    ].map((node) => node.textContent.trim())
+    expect(names).toEqual(['Source grid', 'Gallery'])
+  })
+
+  test('a grid destination renders every option of the view type', async () => {
+    const wrapper = await mountModal()
+    wrapper.vm.show()
+    await flushPromises()
+
+    expect(switchLabels(wrapper)).toEqual([
+      label('fieldVisibility'),
+      label('fieldOrder'),
+      label('fieldWidths'),
+      label('viewSettings'),
+      label('filters'),
+      label('sorts'),
+      label('groupBys'),
+      label('decorations'),
+      label('defaultRowValues'),
+    ])
+  })
+
+  test('a gallery destination does not render the grid specific options', async () => {
+    const wrapper = await mountModal(galleryViewId)
+    wrapper.vm.show()
+    await flushPromises()
+
+    expect(switchLabels(wrapper)).toEqual([
+      label('fieldVisibility'),
+      label('fieldOrder'),
+      label('filters'),
+      label('sorts'),
+      label('decorations'),
+      label('defaultRowValues'),
+    ])
+  })
+
+  test('only the initial selection is checked after picking a source view', async () => {
+    const wrapper = await mountModal()
+    wrapper.vm.show(['filters'])
+    await flushPromises()
+
+    expect(activeSwitchLabels(wrapper)).toEqual([])
+
+    await selectSourceView(wrapper, 'Source grid')
+    expect(activeSwitchLabels(wrapper)).toEqual([label('filters')])
+  })
+
+  test('all enabled options are checked when shown without initial selection', async () => {
+    const wrapper = await mountModal()
+    wrapper.vm.show()
+    await flushPromises()
+
+    await selectSourceView(wrapper, 'Gallery')
+
+    // The gallery source doesn't support column widths, row height and
+    // groups, and the premium decorators are deactivated without a license,
+    // so those switches stay disabled and unchecked.
+    expect(activeSwitchLabels(wrapper)).toEqual([
+      label('fieldVisibility'),
+      label('fieldOrder'),
+      label('filters'),
+      label('sorts'),
+      label('defaultRowValues'),
+    ])
+    expect(disabledSwitchLabels(wrapper)).toEqual([
+      label('fieldWidths'),
+      label('viewSettings'),
+      label('groupBys'),
+      label('decorations'),
+    ])
+  })
+
+  test('select all and clear all toggle the enabled switches', async () => {
+    const wrapper = await mountModal()
+    wrapper.vm.show(['filters'])
+    await flushPromises()
+
+    await selectSourceView(wrapper, 'Source grid')
+
+    expect(getCopyButton(wrapper).disabled).toBe(false)
+
+    const [selectAllButton] = [...element(wrapper).querySelectorAll('button')]
+    selectAllButton.click()
+    await flushPromises()
+    expect(activeSwitchLabels(wrapper)).toEqual([
+      label('fieldVisibility'),
+      label('fieldOrder'),
+      label('fieldWidths'),
+      label('viewSettings'),
+      label('filters'),
+      label('sorts'),
+      label('groupBys'),
+      label('defaultRowValues'),
+    ])
+
+    const clearAllButton = [...element(wrapper).querySelectorAll('button')][1]
+    clearAllButton.click()
+    await flushPromises()
+    expect(activeSwitchLabels(wrapper)).toEqual([])
+    expect(getCopyButton(wrapper).disabled).toBe(true)
+  })
+
+  test('the copy button is disabled until a source view is selected', async () => {
+    const wrapper = await mountModal()
+    wrapper.vm.show()
+    await flushPromises()
+
+    expect(getCopyButton(wrapper).disabled).toBe(true)
+
+    await selectSourceView(wrapper, 'Source grid')
+    expect(getCopyButton(wrapper).disabled).toBe(false)
+  })
+
+  test('submitting disables the modal and hides it on success', async () => {
+    const wrapper = await mountModal()
+    wrapper.vm.show(['filters'])
+    await flushPromises()
+
+    await selectSourceView(wrapper, 'Source grid')
+
+    let resolveRequest
+    testApp.mockServer.mock
+      .onPost(`/database/views/${destViewId}/copy-configuration/`)
+      .reply(() => {
+        return new Promise((resolve) => {
+          resolveRequest = () =>
+            resolve([
+              200,
+              {
+                id: destViewId,
+                table_id: 10,
+                filter_type: 'AND',
+                filters: [],
+                filter_groups: [],
+                sortings: [],
+                group_bys: [],
+                decorations: [],
+              },
+            ])
+        })
+      })
+
+    getCopyButton(wrapper).click()
+    await flushPromises()
+
+    // While the request is pending, the whole modal is in a loading state.
+    expect(wrapper.vm.loading).toBe(true)
+    expect(getCopyButton(wrapper).disabled).toBe(true)
+    expect(disabledSwitchLabels(wrapper).length).toBe(9)
+
+    resolveRequest()
+    await flushPromises()
+
+    expect(wrapper.vm.loading).toBe(false)
+    expect(wrapper.vm.$refs.modal.open).toBe(false)
+  })
+
+  test('a failing request shows the error and keeps the modal open', async () => {
+    const wrapper = await mountModal()
+    wrapper.vm.show(['filters'])
+    await flushPromises()
+
+    await selectSourceView(wrapper, 'Source grid')
+
+    testApp.mockServer.mock
+      .onPost(`/database/views/${destViewId}/copy-configuration/`)
+      .reply(400, {
+        error: 'ERROR_VIEW_CONFIGURATION_COPY_CATEGORY_NOT_SUPPORTED',
+        detail: '',
+      })
+
+    getCopyButton(wrapper).click()
+    await flushPromises()
+
+    expect(wrapper.vm.loading).toBe(false)
+    expect(wrapper.vm.$refs.modal.open).toBe(true)
+    expect(wrapper.vm.error.visible).toBe(true)
+  })
+})

--- a/web-frontend/test/unit/database/components/view/viewFilterForm.spec.js
+++ b/web-frontend/test/unit/database/components/view/viewFilterForm.spec.js
@@ -97,7 +97,7 @@ const view = {
   ownership_type: 'collaborative',
 }
 
-const database = { id: 1, workspace_id: 1 }
+const database = { id: 1, workspace_id: 1, workspace: { id: 1 } }
 
 describe('ViewFilterForm match snapshots', () => {
   let testApp = null

--- a/web-frontend/test/unit/database/utils/copyViewConfiguration.spec.js
+++ b/web-frontend/test/unit/database/utils/copyViewConfiguration.spec.js
@@ -7,6 +7,11 @@ import {
   getEnabledCopyOptionKeys,
   copyViewConfiguration,
 } from '@baserow/modules/database/utils/copyViewConfiguration'
+import {
+  FiltersCopyOptionType,
+  SortsCopyOptionType,
+  ViewSettingsCopyOptionType,
+} from '@baserow/modules/database/copyViewConfigurationOptionTypes'
 
 describe('getEnabledCopyOptionKeys', () => {
   let testApp = null
@@ -87,6 +92,43 @@ describe('getEnabledCopyOptionKeys', () => {
     // with a single view has no compatible sources at all.
     expect(getCompatibleSourceViews(registry, [grid, form], form)).toEqual([])
     expect(getCompatibleSourceViews(registry, [grid], grid)).toEqual([])
+  })
+
+  test('options are disabled without the required permissions', () => {
+    // The backend checks the same operations on both the source and the
+    // destination, so the switch must be disabled when one of them is missing.
+    const appWithout = (deniedOperation) => ({
+      $hasPermission: (operation) => operation !== deniedOperation,
+    })
+
+    const filtersOption = new FiltersCopyOptionType({
+      app: appWithout('database.table.view.create_filter'),
+    })
+    expect(filtersOption.isEnabled(view('grid'), view('grid'), 1)).toBe(false)
+
+    const sortsOption = new SortsCopyOptionType({
+      app: appWithout('database.table.view.create_filter'),
+    })
+    expect(sortsOption.isEnabled(view('grid'), view('grid'), 1)).toBe(true)
+
+    const deniedSortsOption = new SortsCopyOptionType({
+      app: appWithout('database.table.view.create_sort'),
+    })
+    expect(deniedSortsOption.isEnabled(view('grid'), view('grid'), 1)).toBe(
+      false
+    )
+
+    // The view settings option has its own attribute overlap check, but must
+    // still respect the permission check of the base class.
+    const viewSettingsOption = new ViewSettingsCopyOptionType({
+      app: {
+        ...appWithout('database.table.view.update'),
+        $registry: testApp.getRegistry(),
+      },
+    })
+    expect(viewSettingsOption.isEnabled(view('grid'), view('grid'), 1)).toBe(
+      false
+    )
   })
 
   test('destination options are sorted by order', () => {

--- a/web-frontend/test/unit/database/utils/copyViewConfiguration.spec.js
+++ b/web-frontend/test/unit/database/utils/copyViewConfiguration.spec.js
@@ -1,0 +1,364 @@
+import { TestApp } from '@baserow/test/helpers/testApp'
+import { expect } from 'vitest'
+
+import {
+  getCompatibleSourceViews,
+  getDestinationCopyOptions,
+  getEnabledCopyOptionKeys,
+  copyViewConfiguration,
+} from '@baserow/modules/database/utils/copyViewConfiguration'
+
+describe('getEnabledCopyOptionKeys', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+  })
+
+  afterEach(() => testApp.afterEach())
+
+  const view = (type) => ({ id: 1, type })
+
+  // The TestApp registers the premium view decorators, but the test workspace
+  // has no premium license, so they are deactivated and the `decorations`
+  // option is disabled to prevent a copy that the backend would reject.
+  test('grid to grid enables every option with an available decorator', () => {
+    const registry = testApp.getRegistry()
+    expect(
+      getEnabledCopyOptionKeys(registry, view('grid'), view('grid'))
+    ).toEqual([
+      'field_visibility',
+      'field_order',
+      'field_widths',
+      'view_settings',
+      'filters',
+      'sorts',
+      'group_bys',
+      'default_row_values',
+    ])
+
+    const decorator = Object.values(registry.getAll('viewDecorator'))[0]
+    const isDeactivatedSpy = vi
+      .spyOn(Object.getPrototypeOf(decorator), 'isDeactivated')
+      .mockReturnValue(false)
+    expect(
+      getEnabledCopyOptionKeys(registry, view('grid'), view('grid'))
+    ).toContain('decorations')
+    isDeactivatedSpy.mockRestore()
+  })
+
+  test('grid to gallery disables grid specific options', () => {
+    const registry = testApp.getRegistry()
+    expect(
+      getEnabledCopyOptionKeys(registry, view('grid'), view('gallery'))
+    ).toEqual([
+      'field_visibility',
+      'field_order',
+      'filters',
+      'sorts',
+      'default_row_values',
+    ])
+    // The intersection is symmetric on the option keys.
+    expect(
+      getEnabledCopyOptionKeys(registry, view('gallery'), view('grid'))
+    ).toEqual(getEnabledCopyOptionKeys(registry, view('grid'), view('gallery')))
+  })
+
+  test('form views support no options at all', () => {
+    const registry = testApp.getRegistry()
+    expect(
+      getEnabledCopyOptionKeys(registry, view('form'), view('grid'))
+    ).toEqual([])
+    expect(
+      getEnabledCopyOptionKeys(registry, view('grid'), view('form'))
+    ).toEqual([])
+  })
+
+  test('compatible source views exclude the destination and dead ends', () => {
+    const registry = testApp.getRegistry()
+    const grid = { id: 1, type: 'grid' }
+    const otherGrid = { id: 2, type: 'grid' }
+    const form = { id: 3, type: 'form' }
+
+    expect(
+      getCompatibleSourceViews(registry, [grid, otherGrid, form], grid)
+    ).toEqual([otherGrid])
+    // A form view can neither receive nor provide configuration, and a table
+    // with a single view has no compatible sources at all.
+    expect(getCompatibleSourceViews(registry, [grid, form], form)).toEqual([])
+    expect(getCompatibleSourceViews(registry, [grid], grid)).toEqual([])
+  })
+
+  test('destination options are sorted by order', () => {
+    const registry = testApp.getRegistry()
+    const options = getDestinationCopyOptions(registry, view('grid'))
+    const orders = options.map((option) => option.getOrder())
+    expect(orders).toEqual([...orders].sort((a, b) => a - b))
+    expect(options.map((option) => option.getType())).toContain('field_widths')
+    expect(
+      getDestinationCopyOptions(registry, view('gallery')).map((option) =>
+        option.getType()
+      )
+    ).not.toContain('field_widths')
+  })
+})
+
+describe('copyViewConfiguration', () => {
+  let testApp = null
+  let mockServer = null
+
+  const sourceViewId = 1
+  const destViewId = 2
+
+  beforeEach(() => {
+    testApp = new TestApp()
+    mockServer = testApp.mockServer
+
+    testApp.store.dispatch('view/forceCreate', {
+      data: {
+        id: sourceViewId,
+        type: 'grid',
+        table_id: 10,
+        filter_type: 'OR',
+        filters_disabled: true,
+        row_height_size: 'large',
+      },
+    })
+    testApp.store.dispatch('view/forceCreate', {
+      data: {
+        id: destViewId,
+        type: 'grid',
+        table_id: 10,
+        filter_type: 'AND',
+        filters_disabled: false,
+        row_height_size: 'small',
+      },
+    })
+  })
+
+  afterEach(() => testApp.afterEach())
+
+  const getContext = () => {
+    const app = testApp.getApp()
+    return {
+      $store: testApp.store,
+      $client: app.$client,
+      $registry: app.$registry,
+      $bus: app.$bus,
+    }
+  }
+
+  const getView = (id) => testApp.store.getters['view/get'](id)
+
+  const mockCopyResponse = (responseView, requests = []) => {
+    mockServer.mock
+      .onPost(`/database/views/${destViewId}/copy-configuration/`)
+      .reply((config) => {
+        requests.push(JSON.parse(config.data))
+        return [200, responseView]
+      })
+    return requests
+  }
+
+  test('makes a single request and applies the response atomically', async () => {
+    const sourceView = getView(sourceViewId)
+    const destView = getView(destViewId)
+
+    // Existing destination configuration that the response replaces.
+    await testApp.store.dispatch('view/forceCreateFilter', {
+      view: destView,
+      values: { id: 70, field: 100, type: 'equal', value: 'old', group: null },
+    })
+
+    const requests = mockCopyResponse({
+      id: destViewId,
+      table_id: 10,
+      filter_type: 'OR',
+      filters_disabled: true,
+      filters: [
+        {
+          id: 90,
+          view: destViewId,
+          field: 100,
+          type: 'equal',
+          value: 'a',
+          group: 80,
+        },
+      ],
+      filter_groups: [
+        { id: 80, view: destViewId, filter_type: 'OR', parent_group: null },
+      ],
+      sortings: [
+        {
+          id: 91,
+          view: destViewId,
+          field: 100,
+          order: 'DESC',
+          type: 'default',
+        },
+      ],
+      group_bys: [],
+      decorations: [],
+    })
+
+    await copyViewConfiguration(getContext(), {
+      sourceView,
+      destView,
+      categories: ['filters', 'sorts'],
+    })
+
+    expect(requests).toEqual([
+      { source_view_id: sourceViewId, categories: ['filters', 'sorts'] },
+    ])
+
+    // The whole payload has been applied to the store in one go.
+    expect(destView.filter_type).toBe('OR')
+    expect(destView.filters_disabled).toBe(true)
+    expect(destView.filters.map((f) => f.id)).toEqual([90])
+    expect(destView.filter_groups.map((g) => g.id)).toEqual([80])
+    expect(destView.sortings.map((s) => s.id)).toEqual([91])
+
+    // The source view is untouched.
+    const sourceView2 = getView(sourceViewId)
+    expect(sourceView2.filters).toEqual([])
+  })
+
+  test('categories not supported by the views are not requested', async () => {
+    testApp.store.dispatch('view/forceCreate', {
+      data: {
+        id: 3,
+        type: 'gallery',
+        table_id: 10,
+        filter_type: 'AND',
+        filters_disabled: false,
+      },
+    })
+    const sourceView = getView(sourceViewId)
+    const destView = getView(3)
+
+    const requests = []
+    mockServer.mock
+      .onPost(`/database/views/3/copy-configuration/`)
+      .reply((config) => {
+        requests.push(JSON.parse(config.data))
+        return [
+          200,
+          {
+            id: 3,
+            table_id: 10,
+            filters: [],
+            filter_groups: [],
+            sortings: [],
+            group_bys: [],
+            decorations: [],
+          },
+        ]
+      })
+
+    await copyViewConfiguration(getContext(), {
+      sourceView,
+      destView,
+      categories: ['filters', 'field_widths', 'view_settings', 'group_bys'],
+    })
+
+    // The grid specific categories are stripped from the request.
+    expect(requests).toEqual([
+      { source_view_id: sourceViewId, categories: ['filters'] },
+    ])
+  })
+
+  test('table-refresh is only emitted when the destination view is selected', async () => {
+    const sourceView = getView(sourceViewId)
+    const destView = getView(destViewId)
+    const app = testApp.getApp()
+    const emitSpy = vi.spyOn(app.$bus, '$emit')
+
+    mockCopyResponse({
+      id: destViewId,
+      table_id: 10,
+      filters: [],
+      filter_groups: [],
+      sortings: [],
+      group_bys: [],
+      decorations: [],
+    })
+
+    await copyViewConfiguration(getContext(), {
+      sourceView,
+      destView,
+      categories: ['filters'],
+    })
+    expect(emitSpy).not.toHaveBeenCalledWith('table-refresh', expect.anything())
+
+    testApp.store.commit('view/SET_SELECTED', destView)
+    await copyViewConfiguration(getContext(), {
+      sourceView,
+      destView,
+      categories: ['filters'],
+    })
+    expect(emitSpy).toHaveBeenCalledWith('table-refresh', {
+      tableId: 10,
+      includeFieldOptions: false,
+    })
+  })
+
+  test('field option categories refresh the field options', async () => {
+    const sourceView = getView(sourceViewId)
+    const destView = getView(destViewId)
+    const app = testApp.getApp()
+    const emitSpy = vi.spyOn(app.$bus, '$emit')
+    testApp.store.commit('view/SET_SELECTED', destView)
+
+    mockCopyResponse({
+      id: destViewId,
+      table_id: 10,
+      filters: [],
+      filter_groups: [],
+      sortings: [],
+      group_bys: [],
+      decorations: [],
+    })
+
+    await copyViewConfiguration(getContext(), {
+      sourceView,
+      destView,
+      categories: ['field_visibility', 'field_widths'],
+    })
+    expect(emitSpy).toHaveBeenCalledWith('table-refresh', {
+      tableId: 10,
+      includeFieldOptions: true,
+    })
+
+    // Options that neither refresh rows nor field options don't emit at all.
+    emitSpy.mockClear()
+    await copyViewConfiguration(getContext(), {
+      sourceView,
+      destView,
+      categories: ['view_settings'],
+    })
+    expect(emitSpy).not.toHaveBeenCalledWith('table-refresh', expect.anything())
+  })
+
+  test('a failing request leaves the store untouched', async () => {
+    const sourceView = getView(sourceViewId)
+    const destView = getView(destViewId)
+
+    mockServer.mock
+      .onPost(`/database/views/${destViewId}/copy-configuration/`)
+      .reply(400, {
+        error: 'ERROR_VIEW_CONFIGURATION_COPY_CATEGORY_NOT_SUPPORTED',
+        detail: '',
+      })
+
+    await expect(
+      copyViewConfiguration(getContext(), {
+        sourceView,
+        destView,
+        categories: ['filters'],
+      })
+    ).rejects.toThrow()
+
+    expect(destView.filter_type).toBe('AND')
+    expect(destView.filters).toEqual([])
+  })
+})


### PR DESCRIPTION
### What is in this PR

This PR introduces the ability to copy the view configuration from one view to another. The view context (three dots next to view) has a new option named "Copy configuration from view". When clicked, it opens a modal where a collaborative source view can be chosen. Based on the view type, it shows a couple of like "field visibility", "field order", "filters", etc. The user can choose which configuration they want to copy. Clicking the button makes a backend request to correctly copy the chosen view configuration.

<img width="1581" height="627" alt="image" src="https://github.com/user-attachments/assets/45cbd0b4-95e7-44d1-abdb-b596ad402c8d" />

### Doubts

I'm doubting a bit whether this custom approach makes sense. I wanted to go in the direction of reusing the serialized export/import system, but it felt quite hacky to use that for the individual components. This also because of the permissions that would need to be respected. Anyway, would love to hear some thoughts on the current approach.

### How to test this PR

- Confirm that when a gallery view wants to copy configuration from a grid view, that grid view specific options like "Field widths" is not visible.
- Confirm that when a grid view wants to copy configuration from a gallery view, that grid view specific switched like "Field widths" are deactivated.
- Create a view with filters, filter groups, sorts, groups, colors, hidden fields, large height, count identifiers, different field order, field widths, and frozen column. Try to copy the confirmation of that view into another one and observe that everything is copied correctly.
- After copying the configuration try to undo and redo and confirm that the state is correctly restored.
- Confirm that the real-time update broadcasts all the changes. Also check that it's correctly refreshed in the publicly shared view and the restricted view.
- Confirm that the "Copy configuration from view" is only visible for users with view update permissions.
- Confirm that an editor does not have the ability to copy the configuration of a collaborative view because of the permissions, but does have the ability within the personal views.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered

Closes #2762 