### PR TITLE
fix: Ensure only valid event types are persisted for workflow actions

### DIFF
--- a/backend/src/baserow/contrib/builder/api/workflow_actions/errors.py
+++ b/backend/src/baserow/contrib/builder/api/workflow_actions/errors.py
@@ -18,6 +18,12 @@ ERROR_WORKFLOW_ACTION_CANNOT_BE_DISPATCHED = (
     "The requested workflow action cannot be dispatched.",
 )
 
+ERROR_INVALID_WORKFLOW_ACTION_EVENT = (
+    "ERROR_INVALID_WORKFLOW_ACTION_EVENT",
+    HTTP_400_BAD_REQUEST,
+    "The event is not valid for the element the workflow action is attached to.",
+)
+
 
 ERROR_DATA_DOES_NOT_EXIST = (
     "ERROR_DATA_DOES_NOT_EXIST",

--- a/backend/src/baserow/contrib/builder/api/workflow_actions/views.py
+++ b/backend/src/baserow/contrib/builder/api/workflow_actions/views.py
@@ -32,6 +32,7 @@ from baserow.contrib.builder.api.elements.errors import ERROR_ELEMENT_DOES_NOT_E
 from baserow.contrib.builder.api.pages.errors import ERROR_PAGE_DOES_NOT_EXIST
 from baserow.contrib.builder.api.workflow_actions.errors import (
     ERROR_DATA_DOES_NOT_EXIST,
+    ERROR_INVALID_WORKFLOW_ACTION_EVENT,
     ERROR_WORKFLOW_ACTION_CANNOT_BE_DISPATCHED,
     ERROR_WORKFLOW_ACTION_DOES_NOT_EXIST,
     ERROR_WORKFLOW_ACTION_NOT_IN_ELEMENT,
@@ -52,6 +53,7 @@ from baserow.contrib.builder.pages.exceptions import PageDoesNotExist
 from baserow.contrib.builder.pages.handler import PageHandler
 from baserow.contrib.builder.workflow_actions.exceptions import (
     BuilderWorkflowActionCannotBeDispatched,
+    InvalidWorkflowActionEvent,
     WorkflowActionNotInElement,
 )
 from baserow.contrib.builder.workflow_actions.handler import (
@@ -110,6 +112,7 @@ class BuilderWorkflowActionsView(APIView):
             400: get_error_schema(
                 [
                     "ERROR_REQUEST_BODY_VALIDATION",
+                    "ERROR_INVALID_WORKFLOW_ACTION_EVENT",
                 ]
             ),
             404: get_error_schema(["ERROR_PAGE_DOES_NOT_EXIST"]),
@@ -120,6 +123,7 @@ class BuilderWorkflowActionsView(APIView):
         {
             PageDoesNotExist: ERROR_PAGE_DOES_NOT_EXIST,
             ElementDoesNotExist: ERROR_ELEMENT_DOES_NOT_EXIST,
+            InvalidWorkflowActionEvent: ERROR_INVALID_WORKFLOW_ACTION_EVENT,
         }
     )
     @validate_body_custom_fields(
@@ -258,6 +262,7 @@ class BuilderWorkflowActionView(APIView):
             400: get_error_schema(
                 [
                     "ERROR_REQUEST_BODY_VALIDATION",
+                    "ERROR_INVALID_WORKFLOW_ACTION_EVENT",
                 ]
             ),
             404: get_error_schema(
@@ -271,6 +276,7 @@ class BuilderWorkflowActionView(APIView):
     @map_exceptions(
         {
             WorkflowActionDoesNotExist: ERROR_WORKFLOW_ACTION_DOES_NOT_EXIST,
+            InvalidWorkflowActionEvent: ERROR_INVALID_WORKFLOW_ACTION_EVENT,
         }
     )
     @require_request_data_type(dict)

--- a/backend/src/baserow/contrib/builder/elements/collection_field_types.py
+++ b/backend/src/baserow/contrib/builder/elements/collection_field_types.py
@@ -7,7 +7,10 @@ from rest_framework import serializers
 from baserow.contrib.builder.elements.element_types import NavigationElementManager
 from baserow.contrib.builder.elements.models import CollectionField, LinkElement
 from baserow.contrib.builder.elements.registries import CollectionFieldType
-from baserow.contrib.builder.workflow_actions.models import BuilderWorkflowAction
+from baserow.contrib.builder.workflow_actions.models import (
+    BuilderWorkflowAction,
+    EventTypes,
+)
 from baserow.core.constants import RatingStyleChoices
 from baserow.core.formula.serializers import FormulaSerializerField
 from baserow.core.formula.types import BASEROW_FORMULA_MODE_RAW, BaserowFormulaObject
@@ -286,6 +289,7 @@ class TagsCollectionFieldType(CollectionFieldType):
 
 class ButtonCollectionFieldType(CollectionFieldType):
     type = "button"
+    event_names = [EventTypes.CLICK.value]
     allowed_fields = ["label"]
     serializer_field_names = ["label"]
     simple_formula_fields = ["label"]

--- a/backend/src/baserow/contrib/builder/elements/element_types.py
+++ b/backend/src/baserow/contrib/builder/elements/element_types.py
@@ -81,7 +81,10 @@ from baserow.contrib.builder.theme.theme_config_block_types import (
     TableThemeConfigBlockType,
 )
 from baserow.contrib.builder.types import ElementDict
-from baserow.contrib.builder.workflow_actions.models import BuilderWorkflowAction
+from baserow.contrib.builder.workflow_actions.models import (
+    BuilderWorkflowAction,
+    EventTypes,
+)
 from baserow.core.constants import (
     DATE_FORMAT,
     DATE_FORMAT_CHOICES,
@@ -347,6 +350,9 @@ class FormContainerElementType(ContainerElementTypeMixin, ElementType):
     class SerializedDict(ContainerElementTypeMixin.SerializedDict):
         submit_button_label: BaserowFormulaObject
         reset_initial_values_post_submission: bool
+
+    def get_event_names(self, instance: FormContainerElement) -> List[str]:
+        return [EventTypes.SUBMIT.value]
 
     def get_pytest_params(self, pytest_data_fixture) -> Dict[str, Any]:
         return {
@@ -1671,6 +1677,9 @@ class ButtonElementType(ElementType):
     class SerializedDict(ElementDict):
         value: BaserowFormulaObject
 
+    def get_event_names(self, instance: ButtonElement) -> List[str]:
+        return [EventTypes.CLICK.value]
+
     @property
     def serializer_field_overrides(self):
         from baserow.contrib.builder.api.theme.serializers import (
@@ -2343,6 +2352,17 @@ class MenuElementType(ElementType):
         alignment: str
         menu_items: List[Dict]
         variant: Dict[str, str]
+
+    def get_event_names(self, instance: MenuElement) -> List[str]:
+        """
+        Only the menu items of type `button` can fire a `click` event.
+        """
+
+        return [
+            f"{item.uid}_{EventTypes.CLICK.value}"
+            for item in instance.menu_items.all()
+            if item.type == MenuItemElement.TYPES.BUTTON
+        ]
 
     @property
     def serializer_field_overrides(self) -> Dict[str, Any]:

--- a/backend/src/baserow/contrib/builder/elements/mixins.py
+++ b/backend/src/baserow/contrib/builder/elements/mixins.py
@@ -672,6 +672,18 @@ class CollectionElementWithFieldsTypeMixin(CollectionElementTypeMixin):
     class SerializedDict(CollectionElementTypeMixin.SerializedDict):
         fields: List[Dict]
 
+    def get_event_names(self, instance: CollectionElementSubClass) -> List[str]:
+        """
+        The events of an element with fields are the events of its collection
+        fields, prefixed with the field's uid.
+        """
+
+        return [
+            f"{field.uid}_{event_name}"
+            for field in instance.fields.all()
+            for event_name in collection_field_type_registry.get(field.type).event_names
+        ]
+
     def serialize_property(
         self,
         element: CollectionElementSubClass,

--- a/backend/src/baserow/contrib/builder/elements/registries.py
+++ b/backend/src/baserow/contrib/builder/elements/registries.py
@@ -90,6 +90,19 @@ class ElementType(
 
         return False
 
+    def get_event_names(self, instance: ElementSubClass) -> List[str]:
+        """
+        Returns the names of the events the given element can fire, which are the
+        only `event` values a workflow action attached to it may use. This mirrors
+        the `getEvents()` method of the frontend element types. By default an
+        element cannot fire any event.
+
+        :param instance: The (specific) element instance.
+        :return: The list of valid event names for this element.
+        """
+
+        return []
+
     def prepare_value_for_db(self, values: Dict, instance: Optional[Element] = None):
         """
         This function allows you to hook into the moment an element is created or
@@ -548,6 +561,10 @@ class CollectionFieldType(
     SerializedDict: TypedDict
 
     model_class = CollectionField
+
+    # The events a collection field of this type can fire. They are exposed on the
+    # collection element as `<field uid>_<event name>` workflow action events.
+    event_names: List[str] = []
 
     def serialize_property(self, config: Dict[str, Any], prop_name: str):
         return config[prop_name]

--- a/backend/src/baserow/contrib/builder/workflow_actions/exceptions.py
+++ b/backend/src/baserow/contrib/builder/workflow_actions/exceptions.py
@@ -15,3 +15,33 @@ class BuilderWorkflowActionCannotBeDispatched(Exception):
     Raised when a WorkflowAction is dispatched,
     and it does not have a service related to it.
     """
+
+
+class InvalidWorkflowActionEvent(Exception):
+    """
+    Raised when a workflow action is created or updated with an `event` that the
+    element it is attached to can never fire.
+    """
+
+    def __init__(
+        self,
+        event: str,
+        valid_events: list[str],
+        element_type: str | None = None,
+        *args,
+        **kwargs,
+    ):
+        self.event = event
+        self.valid_events = valid_events
+        self.element_type = element_type
+        target = (
+            f"the {element_type} element"
+            if element_type
+            else "a workflow action without an element"
+        )
+        valid = ", ".join(valid_events) if valid_events else "none"
+        super().__init__(
+            f"The event '{event}' is not valid for {target}. Valid events: {valid}.",
+            *args,
+            **kwargs,
+        )

--- a/backend/src/baserow/contrib/builder/workflow_actions/registries.py
+++ b/backend/src/baserow/contrib/builder/workflow_actions/registries.py
@@ -6,9 +6,17 @@ from django.core.files.storage import Storage
 
 from rest_framework.exceptions import PermissionDenied
 
+from baserow.contrib.builder.elements.models import Element
+from baserow.contrib.builder.elements.registries import element_type_registry
 from baserow.contrib.builder.formula_importer import import_formula
 from baserow.contrib.builder.mixins import BuilderInstanceWithFormulaMixin
-from baserow.contrib.builder.workflow_actions.models import BuilderWorkflowAction
+from baserow.contrib.builder.workflow_actions.exceptions import (
+    InvalidWorkflowActionEvent,
+)
+from baserow.contrib.builder.workflow_actions.models import (
+    BuilderWorkflowAction,
+    EventTypes,
+)
 from baserow.core.models import Workspace
 from baserow.core.registry import (
     CustomFieldsRegistryMixin,
@@ -57,7 +65,35 @@ class BuilderWorkflowActionType(
         if "element_id" in values:
             values["element"] = ElementHandler().get_element(values["element_id"])
 
+        if "event" in values:
+            element = values.get("element", instance.element if instance else None)
+            self.validate_event(values["event"], element)
+
         return super().prepare_values(values, user, instance)
+
+    def validate_event(self, event: str, element: Optional[Element]) -> None:
+        """
+        Ensures that the given event is one the element can fire. Every element
+        type declares its events in `ElementType.get_event_names()`. Workflow
+        actions which aren't attached to an element can only use the static
+        `EventTypes`.
+
+        :param event: The event to validate.
+        :param element: The element the workflow action is attached to, if any.
+        :raises InvalidWorkflowActionEvent: If the event can never be fired.
+        """
+
+        element_type_name = None
+        if element is None:
+            valid_events = [e.value for e in EventTypes]
+        else:
+            element = element.specific
+            element_type = element_type_registry.get_by_model(element.specific_class)
+            element_type_name = element_type.type
+            valid_events = element_type.get_event_names(element)
+
+        if event not in valid_events:
+            raise InvalidWorkflowActionEvent(event, valid_events, element_type_name)
 
     def create_instance_from_serialized(
         self,
@@ -83,10 +119,18 @@ class BuilderWorkflowActionType(
         :return: The new workflow action instance.
         """
 
-        if BuilderWorkflowAction.is_dynamic_event(serialized_values["event"]):
-            exported_uid, exported_event = serialized_values["event"].split("_", 1)
-            imported_uid = id_mapping["builder_element_event_uids"][exported_uid]
-            serialized_values["event"] = f"{imported_uid}_{exported_event}"
+        event = serialized_values["event"]
+        if BuilderWorkflowAction.is_dynamic_event(event):
+            # Dynamic events have the shape `<uid>_<event>`, where `<uid>` is the
+            # uid of a collection field / menu item that was regenerated during
+            # the import. Values which do not follow that shape, or whose uid is
+            # unknown, are kept untouched: such an action can never be fired, but
+            # it must not prevent the whole application from being imported.
+            exported_uid, separator, exported_event = event.partition("_")
+            uid_mapping = id_mapping.get("builder_element_event_uids", {})
+            if separator and exported_uid in uid_mapping:
+                imported_uid = uid_mapping[exported_uid]
+                serialized_values["event"] = f"{imported_uid}_{exported_event}"
 
         return super().create_instance_from_serialized(
             serialized_values, id_mapping, files_zip, storage, cache

--- a/backend/tests/baserow/contrib/builder/api/workflow_actions/test_workflow_actions_views.py
+++ b/backend/tests/baserow/contrib/builder/api/workflow_actions/test_workflow_actions_views.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from unittest.mock import patch
 
 from django.db import transaction
@@ -15,7 +16,10 @@ from rest_framework.status import (
 from baserow.contrib.builder.workflow_actions.handler import (
     BuilderWorkflowActionHandler,
 )
-from baserow.contrib.builder.workflow_actions.models import EventTypes
+from baserow.contrib.builder.workflow_actions.models import (
+    BuilderWorkflowAction,
+    EventTypes,
+)
 from baserow.contrib.builder.workflow_actions.workflow_action_types import (
     CreateRowWorkflowActionType,
     DeleteRowWorkflowActionType,
@@ -90,23 +94,71 @@ def test_create_workflow_action_element_does_not_exist(api_client, data_fixture)
     assert response.status_code == HTTP_404_NOT_FOUND
 
 
-@pytest.mark.django_db(transaction=True)
-def test_create_workflow_action_event_does_not_exist(api_client, data_fixture):
+@pytest.mark.django_db
+@pytest.mark.parametrize("event", ["invalid", "hover", "button_click", "submit"])
+def test_create_workflow_action_invalid_event(api_client, data_fixture, event):
     user, token = data_fixture.create_user_and_token()
     page = data_fixture.create_builder_page(user=user)
+    element = data_fixture.create_builder_button_element(page=page)
     workflow_action_type = NotificationWorkflowActionType.type
 
     url = reverse("api:builder:workflow_action:list", kwargs={"page_id": page.id})
     response = api_client.post(
         url,
-        {"type": workflow_action_type, "event": "invalid"},
+        {"type": workflow_action_type, "event": event, "element_id": element.id},
         format="json",
         HTTP_AUTHORIZATION=f"JWT {token}",
     )
 
-    # NOTE: Event names are no longer bound to a list of choices, so
-    #       the API will not raise a 400 Bad Request error
-    assert response.status_code == HTTP_404_NOT_FOUND
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    response_json = response.json()
+    assert response_json["error"] == "ERROR_INVALID_WORKFLOW_ACTION_EVENT"
+    assert response_json["detail"] == (
+        "The event is not valid for the element the workflow action is attached to."
+    )
+    assert BuilderWorkflowAction.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_create_workflow_action_with_dynamic_event(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    page = data_fixture.create_builder_page(user=user)
+    table = data_fixture.create_builder_table_element(
+        page=page,
+        fields=[{"name": "Button", "type": "button", "config": {"label": "'go'"}}],
+    )
+    button_field = table.fields.get(name="Button")
+    workflow_action_type = NotificationWorkflowActionType.type
+
+    url = reverse("api:builder:workflow_action:list", kwargs={"page_id": page.id})
+    response = api_client.post(
+        url,
+        {
+            "type": workflow_action_type,
+            "event": f"{button_field.uid}_click",
+            "element_id": table.id,
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_200_OK
+    assert response.json()["event"] == f"{button_field.uid}_click"
+
+    # A uid which doesn't belong to one of the table's button fields is rejected.
+    response = api_client.post(
+        url,
+        {
+            "type": workflow_action_type,
+            "event": f"{uuid.uuid4()}_click",
+            "element_id": table.id,
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_INVALID_WORKFLOW_ACTION_EVENT"
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/contrib/builder/domains/test_domain_handler.py
+++ b/backend/tests/baserow/contrib/builder/domains/test_domain_handler.py
@@ -10,6 +10,7 @@ from baserow.contrib.builder.domains.handler import DomainHandler
 from baserow.contrib.builder.domains.models import Domain
 from baserow.contrib.builder.exceptions import BuilderDoesNotExist
 from baserow.contrib.builder.models import Builder
+from baserow.contrib.builder.workflow_actions.models import BuilderWorkflowAction
 from baserow.core.cache import global_cache
 from baserow.core.utils import Progress
 
@@ -312,3 +313,27 @@ def test_get_published_domain_applications(data_fixture):
     assert published_applications.count() == 2
     assert published_applications.contains(published_builder1)
     assert published_applications.contains(published_builder2)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("event", ["hover", "button_click"])
+def test_domain_publishing_with_invalid_workflow_action_event(data_fixture, event):
+    """
+    A single workflow action with an event which can't be mapped (e.g. created
+    through the API with a bogus value) must not block publishing the builder.
+    """
+
+    builder = data_fixture.create_builder_application()
+    domain = data_fixture.create_builder_custom_domain(builder=builder)
+    page = data_fixture.create_builder_page(builder=builder)
+    button = data_fixture.create_builder_button_element(page=page)
+    data_fixture.create_notification_workflow_action(
+        page=page, element=button, event=event
+    )
+
+    domain = DomainHandler().publish(domain)
+
+    published_events = BuilderWorkflowAction.objects.filter(
+        page__builder=domain.published_to
+    ).values_list("event", flat=True)
+    assert list(published_events) == [event]

--- a/backend/tests/baserow/contrib/builder/elements/test_element_types.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_element_types.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from collections import defaultdict
 from io import BytesIO
 from tempfile import tempdir
@@ -1625,3 +1626,42 @@ def test_element_type_has_display_name(element_type):
     assert element_type.display_name != _("Unnamed node"), (
         f"{type(element_type).__name__}.display_name is still the default 'Unnamed node'"
     )
+
+
+@pytest.mark.django_db
+def test_element_type_get_event_names(data_fixture):
+    page = data_fixture.create_builder_page()
+    heading = data_fixture.create_builder_heading_element(page=page)
+    button = data_fixture.create_builder_button_element(page=page)
+    form = data_fixture.create_builder_form_container_element(page=page)
+    table = data_fixture.create_builder_table_element(
+        page=page,
+        fields=[
+            {"name": "Text", "type": "text", "config": {"value": "'a'"}},
+            {"name": "Button", "type": "button", "config": {"label": "'b'"}},
+        ],
+    )
+    button_field = table.fields.get(name="Button")
+    button_item_uid, link_item_uid = uuid.uuid4(), uuid.uuid4()
+    menu = data_fixture.create_builder_menu_element_items(
+        page=page,
+        menu_items=[
+            {
+                "variant": "button",
+                "type": "button",
+                "uid": button_item_uid,
+                "name": "Button",
+            },
+            {"variant": "link", "type": "link", "uid": link_item_uid, "name": "Link"},
+        ],
+    )
+
+    def get_event_names(element):
+        element_type = element_type_registry.get_by_model(element.specific_class)
+        return element_type.get_event_names(element)
+
+    assert get_event_names(heading) == []
+    assert get_event_names(button) == ["click"]
+    assert get_event_names(form) == ["submit"]
+    assert get_event_names(table) == [f"{button_field.uid}_click"]
+    assert get_event_names(menu) == [f"{button_item_uid}_click"]

--- a/backend/tests/baserow/contrib/builder/pages/test_page_handler.py
+++ b/backend/tests/baserow/contrib/builder/pages/test_page_handler.py
@@ -21,6 +21,7 @@ from baserow.contrib.builder.pages.exceptions import (
 )
 from baserow.contrib.builder.pages.handler import PageHandler
 from baserow.contrib.builder.pages.models import Page
+from baserow.contrib.builder.workflow_actions.models import BuilderWorkflowAction
 from baserow.core.graph.types import GraphPointPosition
 from baserow.core.user_sources.user_source_user import UserSourceUser
 
@@ -603,3 +604,20 @@ def test_is_published_application_page(data_fixture):
 
     assert not PageHandler()._is_published_application_page(page.id)
     assert PageHandler()._is_published_application_page(published_page.id)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("event", ["hover", "button_click"])
+def test_duplicate_page_with_invalid_workflow_action_event(data_fixture, event):
+    page = data_fixture.create_builder_page()
+    button = data_fixture.create_builder_button_element(page=page)
+    data_fixture.create_notification_workflow_action(
+        page=page, element=button, event=event
+    )
+
+    page_clone = PageHandler().duplicate_page(page)
+
+    duplicated_events = BuilderWorkflowAction.objects.filter(
+        page=page_clone
+    ).values_list("event", flat=True)
+    assert list(duplicated_events) == [event]

--- a/backend/tests/baserow/contrib/builder/workflow_actions/test_workflow_action_types.py
+++ b/backend/tests/baserow/contrib/builder/workflow_actions/test_workflow_action_types.py
@@ -1,3 +1,4 @@
+import uuid
 from collections import defaultdict
 from unittest.mock import MagicMock, patch
 
@@ -371,3 +372,67 @@ def test_workflow_action_type_deserialize_property_with_stale_page_id():
 
     result = action_type.deserialize_property("navigate_to_page_id", 100, id_mapping)
     assert result is None
+
+
+@pytest.mark.django_db
+def test_import_workflow_action_remaps_dynamic_event_uid(data_fixture):
+    page = data_fixture.create_builder_page()
+    button_1 = data_fixture.create_builder_button_element(page=page)
+    button_2 = data_fixture.create_builder_button_element(page=page)
+    exported_uid, imported_uid = str(uuid.uuid4()), str(uuid.uuid4())
+    workflow_action_type = NotificationWorkflowActionType()
+
+    exported_workflow_action = data_fixture.create_notification_workflow_action(
+        page=page, element=button_1, event=f"{exported_uid}_click"
+    )
+    serialized = workflow_action_type.export_serialized(exported_workflow_action)
+
+    id_mapping = {
+        "builder_page_elements": {button_1.id: button_2.id},
+        "builder_element_event_uids": {exported_uid: imported_uid},
+    }
+    imported_workflow_action = workflow_action_type.import_serialized(
+        page, serialized, id_mapping
+    )
+
+    assert imported_workflow_action.event == f"{imported_uid}_click"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "event",
+    [
+        # No `<uid>_<event>` shape at all.
+        "hover",
+        # Has an underscore, but the prefix is not a known uid.
+        "button_click",
+        # Looks like a dynamic event, but the uid is unknown (e.g. stale).
+        "f1594a0a-3ff0-4c8c-a175-992039b11411_click",
+    ],
+)
+def test_import_workflow_action_keeps_unknown_dynamic_event(data_fixture, event):
+    """
+    A workflow action whose event can't be mapped must not break the import of
+    the whole application (publish, duplicate, export/import). The value is kept
+    as-is; such an action simply never fires.
+    """
+
+    page = data_fixture.create_builder_page()
+    button_1 = data_fixture.create_builder_button_element(page=page)
+    button_2 = data_fixture.create_builder_button_element(page=page)
+    workflow_action_type = NotificationWorkflowActionType()
+
+    exported_workflow_action = data_fixture.create_notification_workflow_action(
+        page=page, element=button_1, event=event
+    )
+    serialized = workflow_action_type.export_serialized(exported_workflow_action)
+
+    id_mapping = {
+        "builder_page_elements": {button_1.id: button_2.id},
+        "builder_element_event_uids": {},
+    }
+    imported_workflow_action = workflow_action_type.import_serialized(
+        page, serialized, id_mapping
+    )
+
+    assert imported_workflow_action.event == event

--- a/backend/tests/baserow/contrib/builder/workflow_actions/test_workflow_actions_service.py
+++ b/backend/tests/baserow/contrib/builder/workflow_actions/test_workflow_actions_service.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.http import HttpRequest
 
 import pytest
@@ -7,6 +9,7 @@ from baserow.contrib.builder.data_sources.builder_dispatch_context import (
 )
 from baserow.contrib.builder.workflow_actions.exceptions import (
     BuilderWorkflowActionCannotBeDispatched,
+    InvalidWorkflowActionEvent,
 )
 from baserow.contrib.builder.workflow_actions.models import (
     BuilderWorkflowAction,
@@ -341,3 +344,88 @@ def test_dispatch_workflow_action_no_permissions(data_fixture):
         BuilderWorkflowActionService().dispatch_action(
             user, workflow_action, dispatch_context
         )
+
+
+@pytest.mark.django_db
+def test_create_workflow_action_with_invalid_event(data_fixture):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    element = data_fixture.create_builder_button_element(page=page)
+    workflow_action_type = NotificationWorkflowActionType()
+
+    with pytest.raises(InvalidWorkflowActionEvent) as exc_info:
+        BuilderWorkflowActionService().create_workflow_action(
+            user, workflow_action_type, page=page, element=element, event="hover"
+        )
+
+    assert str(exc_info.value) == (
+        "The event 'hover' is not valid for the button element. Valid events: click."
+    )
+    assert BuilderWorkflowAction.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_create_workflow_action_with_dynamic_event(data_fixture):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    table = data_fixture.create_builder_table_element(
+        page=page,
+        fields=[{"name": "Button", "type": "button", "config": {"label": "'go'"}}],
+    )
+    button_field = table.fields.get(name="Button")
+    workflow_action_type = NotificationWorkflowActionType()
+
+    workflow_action = BuilderWorkflowActionService().create_workflow_action(
+        user,
+        workflow_action_type,
+        page=page,
+        element=table,
+        event=f"{button_field.uid}_click",
+    )
+    assert workflow_action.event == f"{button_field.uid}_click"
+
+    with pytest.raises(InvalidWorkflowActionEvent):
+        BuilderWorkflowActionService().create_workflow_action(
+            user,
+            workflow_action_type,
+            page=page,
+            element=table,
+            event=f"{uuid.uuid4()}_click",
+        )
+
+
+@pytest.mark.django_db
+def test_create_workflow_action_without_element_only_accepts_static_events(
+    data_fixture,
+):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    workflow_action_type = NotificationWorkflowActionType()
+
+    workflow_action = BuilderWorkflowActionService().create_workflow_action(
+        user, workflow_action_type, page=page, event=EventTypes.CLICK
+    )
+    assert workflow_action.element is None
+
+    with pytest.raises(InvalidWorkflowActionEvent):
+        BuilderWorkflowActionService().create_workflow_action(
+            user, workflow_action_type, page=page, event="hover"
+        )
+
+
+@pytest.mark.django_db
+def test_update_workflow_action_with_invalid_event(data_fixture):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    element = data_fixture.create_builder_button_element(page=page)
+    workflow_action = data_fixture.create_notification_workflow_action(
+        page=page, element=element, event=EventTypes.CLICK
+    )
+
+    with pytest.raises(InvalidWorkflowActionEvent):
+        BuilderWorkflowActionService().update_workflow_action(
+            user, workflow_action, event=EventTypes.SUBMIT
+        )
+
+    workflow_action.refresh_from_db()
+    assert workflow_action.event == EventTypes.CLICK

--- a/changelog/entries/unreleased/bug/fix_builder_publish_failing_on_workflow_actions_with_an_invalid_event.json
+++ b/changelog/entries/unreleased/bug/fix_builder_publish_failing_on_workflow_actions_with_an_invalid_event.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed a bug that prevented publishing an application due to a workflow action with an invalid event.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-08-26"
+}

--- a/enterprise/backend/src/baserow_enterprise/builder/elements/element_types.py
+++ b/enterprise/backend/src/baserow_enterprise/builder/elements/element_types.py
@@ -1,5 +1,5 @@
 import mimetypes
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from django.utils.translation import gettext_lazy as _
 
@@ -10,6 +10,7 @@ from baserow.contrib.builder.elements.element_types import InputElementType
 from baserow.contrib.builder.elements.registries import ElementType
 from baserow.contrib.builder.pages.handler import PageHandler
 from baserow.contrib.builder.types import ElementDict
+from baserow.contrib.builder.workflow_actions.models import EventTypes
 from baserow.core.formula.field import BASEROW_FORMULA_VERSION_INITIAL
 from baserow.core.formula.types import (
     BASEROW_FORMULA_MODE_SIMPLE,
@@ -38,6 +39,9 @@ class AuthFormElementType(ElementType):
     class SerializedDict(ElementDict):
         user_source_id: int
         login_button_label: BaserowFormula
+
+    def get_event_names(self, instance: AuthFormElement) -> List[str]:
+        return [EventTypes.AFTER_LOGIN.value]
 
     @property
     def serializer_field_overrides(self):

--- a/enterprise/backend/tests/baserow_enterprise_tests/builder/elements/test_element_types.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/builder/elements/test_element_types.py
@@ -299,3 +299,13 @@ def test_dispatch_local_baserow_update_row_workflow_action_with_file(
             "visible_name": "image_1.png",
         },
     ]
+
+
+@pytest.mark.django_db
+def test_auth_form_element_get_event_names(data_fixture):
+    page = data_fixture.create_builder_page()
+    auth_form = data_fixture.create_builder_element(AuthFormElementType, page=page)
+
+    assert AuthFormElementType().get_event_names(auth_form) == [
+        EventTypes.AFTER_LOGIN.value
+    ]


### PR DESCRIPTION
### What is in this PR
This PR fixes a bug where an invalid event type being persisted to a Workflow Action can cause the app to no longer be publishable.

The UI won't send invalid events, but the API currently allows them to be persisted. So if a user uses any sort of AI/script, they could end up with an unpublishable app.

Fixes [this Sentry issue](https://baserow-eu.sentry.io/issues/142392248/).

### How to test this PR
In `develop`, create a Button element and take note of the Button's ID and the page ID.

Then create a workflow action via the API with an invalid event:
```bash
# set your token (or just auth with your access token)
TOKEN=$(curl -s -X POST http://localhost:8000/api/user/token-auth/ \
  -H 'Content-Type: application/json' \
  -d '{"email":"<your local user>", "password": "<your pass>"}' | jq -r .access_token)

# create the workflow action. Note that "hover" isn't a valid event, but it's accepted.
curl -s -X POST http://localhost:8000/api/builder/page/432/workflow_actions/ \
  -H "Authorization: JWT $TOKEN" -H 'Content-Type: application/json' \
  -d "{\"type\":\"notification\",\"event\":\"hover\",\"element_id\": 7504}"
```

Now if you try to publish the site, it will fail:
> <img width="400" alt="image" src="https://github.com/user-attachments/assets/b6357b5c-9f02-457c-960d-7a314d3150a8" />

And the backend crashes with:
```python
  File "/baserow/backend/src/baserow/contrib/builder/workflow_actions/registries.py", line 87, in create_instance_from_serialized
    exported_uid, exported_event = serialized_values["event"].split("_", 1)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 2, got 1)
```

In this branch, the API will return a 400 when you pass in an invalid event:
```json
{"error":"ERROR_INVALID_WORKFLOW_ACTION_EVENT","detail":"The event is not valid for the element the workflow action is attached to."}
```

And the publish will work, even with a previously set bad event (the workflow action just does nothing).

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
