### PR TITLE
fix(backend): return isError=true in tool error responses

### DIFF
--- a/backend/src/baserow/core/mcp/__init__.py
+++ b/backend/src/baserow/core/mcp/__init__.py
@@ -90,21 +90,30 @@ class BaserowMCPServer:
             return None
 
     async def call_tool(self, name: str, arguments):
-        from mcp.types import TextContent
+        from mcp.types import CallToolResult, TextContent
 
         from baserow.core.mcp.registries import mcp_tool_registry
 
         endpoint = await self.get_endpoint()
         if not endpoint:
-            return [TextContent(type="text", text="Endpoint not found.")]
+            return CallToolResult(
+                content=[TextContent(type="text", text="Endpoint not found.")],
+                isError=True,
+            )
         tool = mcp_tool_registry.match_by_name(name)
         if not tool:
-            return [TextContent(type="text", text=f"Tool '{name}' not found.")]
+            return CallToolResult(
+                content=[TextContent(type="text", text=f"Tool '{name}' not found.")],
+                isError=True,
+            )
         try:
             return await tool.call(endpoint, arguments)
         except Exception as e:
             logger.exception("Unhandled exception in MCP tool '{}'", name)
-            return [TextContent(type="text", text=f"Error: {e}")]
+            return CallToolResult(
+                content=[TextContent(type="text", text=f"Error: {e}")],
+                isError=True,
+            )
 
     async def list_tools(self) -> list["Tool"]:
         from baserow.core.mcp.registries import mcp_tool_registry

--- a/backend/tests/baserow/core/mcp/test_mcp_server.py
+++ b/backend/tests/baserow/core/mcp/test_mcp_server.py
@@ -431,6 +431,51 @@ def test_call_tool_without_endpoint_key(data_fixture):
                 # tools.
                 result = await client.call_tool("list_tables", {})
                 assert result.content[0].text == "Endpoint not found."
+                assert result.isError is True
+
+        with transaction.atomic():
+            async_to_sync(inner)()
+    finally:
+        current_key.reset(key_token)
+
+
+@pytest.mark.django_db
+def test_call_tool_unknown_tool_name(data_fixture):
+    endpoint = data_fixture.create_mcp_endpoint()
+    mcp = BaserowMCPServer()
+
+    key_token = current_key.set(endpoint.key)
+
+    try:
+
+        async def inner():
+            async with client_session(mcp._mcp_server) as client:
+                result = await client.call_tool("nonexistent_tool", {})
+                assert result.content[0].text == "Tool 'nonexistent_tool' not found."
+                assert result.isError is True
+
+        with transaction.atomic():
+            async_to_sync(inner)()
+    finally:
+        current_key.reset(key_token)
+
+
+@pytest.mark.django_db
+def test_call_tool_exception_returns_is_error_true(data_fixture):
+    endpoint = data_fixture.create_mcp_endpoint()
+    mcp = BaserowMCPServer()
+
+    key_token = current_key.set(endpoint.key)
+
+    try:
+
+        async def inner():
+            async with client_session(mcp._mcp_server) as client:
+                result = await client.call_tool(
+                    "update_rows", {"table_id": 999999, "rows": []}
+                )
+                assert result.isError is True
+                assert "Error:" in result.content[0].text
 
         with transaction.atomic():
             async_to_sync(inner)()

--- a/changelog/entries/unreleased/bug/5961_fixed_mcp_server_tool_errors_returning_iserror_false_instead.json
+++ b/changelog/entries/unreleased/bug/5961_fixed_mcp_server_tool_errors_returning_iserror_false_instead.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed MCP server tool errors returning isError: false instead of true",
+    "issue_origin": "github",
+    "issue_number": 5961,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-26"
+}


### PR DESCRIPTION
## Summary
- MCP tool error responses now correctly return `isError: true` per MCP specification
- Previously, all three error paths in `call_tool()` returned plain `TextContent` lists, which the MCP library wrapped with `isError=false`
- Fix returns `CallToolResult(isError=True)` directly so the library passes it through unchanged

## Testing

Follow steps to reproduce and observe that `isError: true` is returned

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
