### PR TITLE
fix: when_empty does not work with empty string values

### DIFF
--- a/backend/src/baserow/contrib/database/formula/ast/function_defs.py
+++ b/backend/src/baserow/contrib/database/formula/ast/function_defs.py
@@ -43,6 +43,7 @@ from django.db.models.functions import (
     Log,
     Lower,
     Mod,
+    NullIf,
     Power,
     Replace,
     Reverse,
@@ -1991,17 +1992,8 @@ class BaserowWhenEmpty(TwoArgumentBaserowFunction):
 
     def to_django_expression(self, arg1: Expression, arg2: Expression) -> Expression:
         if isinstance(arg2.output_field, (fields.CharField, fields.TextField)):
-            return Case(
-                When(
-                    condition=EqualsExpr(
-                        Coalesce(arg1, Value("")),
-                        Value(""),
-                        output_field=fields.BooleanField(),
-                    ),
-                    then=arg2,
-                ),
-                default=arg1,
-                output_field=arg2.output_field,
+            return Coalesce(
+                NullIf(arg1, Value("")), arg2, output_field=arg2.output_field
             )
         return Coalesce(arg1, arg2, output_field=arg2.output_field)
 

--- a/backend/src/baserow/contrib/database/formula/ast/function_defs.py
+++ b/backend/src/baserow/contrib/database/formula/ast/function_defs.py
@@ -1990,6 +1990,19 @@ class BaserowWhenEmpty(TwoArgumentBaserowFunction):
         )
 
     def to_django_expression(self, arg1: Expression, arg2: Expression) -> Expression:
+        if isinstance(arg2.output_field, (fields.CharField, fields.TextField)):
+            return Case(
+                When(
+                    condition=EqualsExpr(
+                        Coalesce(arg1, Value("")),
+                        Value(""),
+                        output_field=fields.BooleanField(),
+                    ),
+                    then=arg2,
+                ),
+                default=arg1,
+                output_field=arg2.output_field,
+            )
         return Coalesce(arg1, arg2, output_field=arg2.output_field)
 
 

--- a/backend/tests/baserow/contrib/database/formula/test_baserow_formula_results.py
+++ b/backend/tests/baserow/contrib/database/formula/test_baserow_formula_results.py
@@ -255,6 +255,8 @@ VALID_FORMULA_TESTS = [
     ("right('abcde', 2)", "de"),
     ("right('abc', 2/0)", None),
     ("when_empty(1, 2)", "1"),
+    ("when_empty('', 'fallback')", "fallback"),
+    ("when_empty('hello', 'fallback')", "hello"),
     ("round(1.12345, 0)", "1"),
     ("round(1.12345, 4)", "1.1235"),
     ("round(1.12345, 100)", "1.1234500000"),

--- a/changelog/entries/unreleased/bug/3121_fixed_when_empty_formula_function_not_treating_empty_string_.json
+++ b/changelog/entries/unreleased/bug/3121_fixed_when_empty_formula_function_not_treating_empty_string_.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed `when_empty` formula function not treating empty string values as empty, only handling NULL.",
+    "issue_origin": "github",
+    "issue_number": 3121,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-27"
+}


### PR DESCRIPTION
## Summary
- `when_empty` formula used `Coalesce` which only handles `NULL`, ignoring empty strings `""`
- Text fields in Baserow can store both `NULL` and `""` as "no value" depending on how a row was created
- Fix adds an `isblank`-style check (`Coalesce(arg, '') = ''`) for text-type output fields, matching the existing `isblank` semantics
- Non-text types retain the original `Coalesce` behavior (empty strings can't occur in numeric/date/boolean columns)

Closes #3121

## Test plan
- Follow steps from issue and observe it now returns correct value.


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
