### PR TITLE
fix(css): prevent text overlap in rich text field preview with nested lists

### DIFF
--- a/changelog/entries/unreleased/bug/3475_fixed_text_overlap_in_rich_text_field_preview_with_nested_li.json
+++ b/changelog/entries/unreleased/bug/3475_fixed_text_overlap_in_rich_text_field_preview_with_nested_li.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed text overlap in rich text field preview with nested lists",
+    "issue_origin": "github",
+    "issue_number": 3475,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-27"
+}

--- a/web-frontend/modules/core/assets/scss/components/fields/rich_text.scss
+++ b/web-frontend/modules/core/assets/scss/components/fields/rich_text.scss
@@ -85,11 +85,6 @@
     height: auto;
   }
 
-  li > ul,
-  li > ol {
-    line-height: normal;
-  }
-
   blockquote {
     @extend %rich-text-editor-content-blockquote;
 

--- a/web-frontend/modules/core/assets/scss/components/fields/rich_text.scss
+++ b/web-frontend/modules/core/assets/scss/components/fields/rich_text.scss
@@ -75,7 +75,19 @@
   }
 
   li {
+    height: auto;
+    min-height: 32px;
     margin-left: 20px;
+  }
+
+  ul,
+  ol {
+    height: auto;
+  }
+
+  li > ul,
+  li > ol {
+    line-height: normal;
   }
 
   blockquote {


### PR DESCRIPTION
## Summary
This PR fixes CSS issue where nested sub-lists in non-expanded rich text fields caused text to overlay when row height is set to medium or large

Resolves #3475

### How to test this PR
Follow steps to reproduce from issue and observe there is no overlap

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
