### PR TITLE
fix: clear formula when switching to basic mode

### DIFF
--- a/changelog/entries/unreleased/bug/5962_clear_formula_when_switching_from_expert_to_basic.json
+++ b/changelog/entries/unreleased/bug/5962_clear_formula_when_switching_from_expert_to_basic.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed formula inputs retaining their formula when switching from expert to basic mode.",
+    "issue_origin": "github",
+    "issue_number": 5962,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-08-27"
+}

--- a/changelog/entries/unreleased/bug/fixed_formula_mode_dialog_action_spacing.json
+++ b/changelog/entries/unreleased/bug/fixed_formula_mode_dialog_action_spacing.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Fixed missing spacing between buttons in the formula mode confirmation dialog.",
+  "issue_origin": "github",
+  "issue_number": null,
+  "domain": "core",
+  "bullet_points": [],
+  "created_at": "2026-08-27"
+}

--- a/web-frontend/modules/core/components/formula/FormulaInputExplorerContext.vue
+++ b/web-frontend/modules/core/components/formula/FormulaInputExplorerContext.vue
@@ -46,19 +46,17 @@
       </h2>
       <p>{{ $t('formulaInputExplorerContext.modalMessage') }}</p>
 
-      <div class="actions margin-bottom-0">
-        <div class="align-right">
-          <Button type="secondary" size="large" @click="cancelModeChange">
-            {{ $t('action.cancel') }}
-          </Button>
-          <Button type="danger" size="large" @click="confirmModeChange">
-            {{
-              isAdvancedMode
-                ? $t('formulaInputExplorerContext.useSimpleInput')
-                : $t('formulaInputExplorerContext.useAdvancedInput')
-            }}
-          </Button>
-        </div>
+      <div class="actions actions--right actions--gap margin-bottom-0">
+        <Button type="secondary" size="large" @click="cancelModeChange">
+          {{ $t('action.cancel') }}
+        </Button>
+        <Button type="danger" size="large" @click="confirmModeChange">
+          {{
+            isAdvancedMode
+              ? $t('formulaInputExplorerContext.useSimpleInput')
+              : $t('formulaInputExplorerContext.useAdvancedInput')
+          }}
+        </Button>
       </div>
     </Modal>
   </Context>

--- a/web-frontend/modules/core/components/formula/FormulaInputField.vue
+++ b/web-frontend/modules/core/components/formula/FormulaInputField.vue
@@ -479,8 +479,9 @@ export default {
       }
     },
     createEditor(formula = null) {
-      // Use provided formula or fall back to the prop value
-      this.content = this.toContent(formula || this.value)
+      // An empty string is an intentional value after switching from expert
+      // to basic mode, so only fall back when no formula was provided.
+      this.content = this.toContent(formula ?? this.value)
       this.editor = new Editor({
         content: this.content,
         editable: !this.disabled && !this.readOnly,
@@ -506,7 +507,7 @@ export default {
     },
     recreateEditor(formula = null) {
       const currentFormula =
-        formula ||
+        formula ??
         (this.editor ? this.toFormula(this.wrapperContent) : this.value)
 
       this.editor?.destroy()
@@ -712,7 +713,10 @@ export default {
         this.$emit('input', '')
         this.isFormulaInvalid = false
         this.formulaErrorContext = { scope: null, title: '', message: '' }
-        this.isHandlingModeChange = false
+        this.$nextTick(() => {
+          this.recreateEditor('')
+          this.isHandlingModeChange = false
+        })
       } else {
         // Otherwise (simple to advanced), keep the current formula
         // Get the formula BEFORE changing the mode, using the CURRENT mode

--- a/web-frontend/test/unit/core/formula/FormulaInputField.spec.js
+++ b/web-frontend/test/unit/core/formula/FormulaInputField.spec.js
@@ -199,3 +199,45 @@ describe('FormulaInputField validates on display', () => {
     expect(wrapper.emitted('update:invalid').at(-1)).toEqual([true])
   })
 })
+
+describe('FormulaInputField mode changes', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  it('keeps an expert formula empty after switching to basic mode', async () => {
+    const wrapper = await testApp.mount(FormulaInputField, {
+      props: { value: 'now()', mode: 'advanced' },
+    })
+
+    wrapper.vm.handleModeChange('simple')
+    await wrapper.setProps({ mode: 'simple' })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.formula-input-field--formula-empty').exists()).toBe(
+      true
+    )
+    expect(wrapper.emitted('input').at(-1)).toEqual([''])
+  })
+
+  it('keeps a basic formula when switching to expert mode', async () => {
+    const wrapper = await testApp.mount(FormulaInputField, {
+      props: { value: 'now()', mode: 'simple' },
+    })
+
+    wrapper.vm.handleModeChange('advanced')
+    await wrapper.setProps({ mode: 'advanced' })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.formula-input-field--formula-empty').exists()).toBe(
+      false
+    )
+    expect(wrapper.emitted('input').at(-1)).toEqual(['now()'])
+  })
+})


### PR DESCRIPTION
### What is in this PR

Fixes #5962.

When `FormulaInputField` switches from expert to basic mode, the value is not cleared. The PR restores this behavior. 
It also restores the standard spacing between the Cancel and confirmation buttons in the formula mode reset modal.

### How to test this PR

1. Open an Application Builder or Automation formula input with an expert-mode formula.
2. Switch to Basic input and confirm the reset modal shows a gap between the Cancel and confirmation buttons.
3. Confirm the reset, verify the field is empty
4. Enter a formula in Basic input, switch to Expert input, and verify it remains intact.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder (not applicable)
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated (not applicable)
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables (not applicable)
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes (not applicable)
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens (not applicable)
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide) using the existing standard action-button gap
- [x] Security impact of change has been considered
