### PR TITLE
fix: validate required duration form fields while editing

### DIFF
--- a/changelog/entries/unreleased/bug/5741_allow_required_duration_fields_with_valid_values_to_be_submi.json
+++ b/changelog/entries/unreleased/bug/5741_allow_required_duration_fields_with_valid_values_to_be_submi.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Allow required duration fields with valid values to be submitted in public forms",
+    "issue_origin": "github",
+    "issue_number": 5741,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-31"
+}

--- a/web-frontend/modules/database/mixins/durationField.js
+++ b/web-frontend/modules/database/mixins/durationField.js
@@ -27,10 +27,10 @@ export default {
     },
     getError() {
       // `errorMsg` holds the parse error captured while the user types, because
-      // partially-typed text may not round-trip to `value`. When there is no
-      // such error, fall back to the field-type validation so a required,
-      // untouched, empty field still reports its error (e.g. on form submit).
-      return this.errorMsg ?? this.getValidationError(this.value)
+      // partially-typed text may not round-trip to `value`. A valid parsed copy
+      // is not emitted as `value` until blur, so validate that copy while editing.
+      const value = this.editing ? this.prepareValue(this.copy) : this.value
+      return this.errorMsg ?? this.getValidationError(value)
     },
     formatValue(field, value) {
       // This function is used also in functional components,

--- a/web-frontend/test/unit/database/components/row/rowEditFieldDuration.spec.js
+++ b/web-frontend/test/unit/database/components/row/rowEditFieldDuration.spec.js
@@ -1,0 +1,67 @@
+import { TestApp } from '@baserow/test/helpers/testApp'
+import RowEditFieldDuration from '@baserow/modules/database/components/row/RowEditFieldDuration'
+
+describe('RowEditFieldDuration', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  const field = {
+    id: 1,
+    name: 'Duration',
+    type: 'duration',
+    duration_format: 'h:mm',
+  }
+
+  const mountField = (props = {}) =>
+    testApp.mount(RowEditFieldDuration, {
+      props: {
+        field,
+        value: null,
+        readOnly: false,
+        required: true,
+        touched: false,
+        workspaceId: 0,
+        ...props,
+      },
+    })
+
+  test('a required field saves a valid duration entered from empty', async () => {
+    const wrapper = await mountField({ touched: true })
+    const input = wrapper.find('input')
+
+    await input.trigger('focus')
+    await input.setValue('14:30')
+    await input.trigger('keyup')
+
+    expect(wrapper.text()).not.toContain('error.requiredField')
+
+    await input.trigger('blur')
+
+    expect(wrapper.emitted('update')).toEqual([[52_200, null]])
+  })
+
+  test('an empty required field still shows the required error when touched', async () => {
+    const wrapper = await mountField({ touched: true })
+
+    expect(wrapper.text()).toContain('error.requiredField')
+  })
+
+  test('invalid text shows the duration format error, not required', async () => {
+    const wrapper = await mountField({ touched: true })
+    const input = wrapper.find('input')
+
+    await input.trigger('focus')
+    await input.setValue('14:')
+    await input.trigger('keyup')
+
+    expect(wrapper.text()).toContain('fieldErrors.invalidDuration')
+    expect(wrapper.text()).not.toContain('error.requiredField')
+  })
+})


### PR DESCRIPTION
### What is in this PR

- Fixes #5741.
- Validates the parsed duration copy while the editor is active instead of the stale parent value that is only updated on blur.
- Preserves required validation for untouched empty fields and keeps invalid-format errors ahead of required errors.
- Adds focused regression coverage for valid, empty, and malformed required duration values.

### How to test this PR

1. Create a duration field using the h:mm format.
2. Add it to a public form and mark it required.
3. Enter 14:30 and submit the form.
4. Confirm the form submits and stores 52,200 seconds.
5. Confirm an empty value still shows the required error and malformed text shows the duration-format error.

Automated checks run:

- just f yarn test:core --run test/unit/database/components/row/rowEditFieldDuration.spec.js
- just f yarn test:core --run test/unit/database
- ESLint, Prettier, and git diff --check

### Checklist

- [x] A changelog entry has been added
- [x] Quality standards are met
- [x] Security impact has been considered; no security-sensitive behavior changes
- [x] No REST API or documentation changes are required