### PR TITLE
feat: detect more misconfigurations

### DIFF
--- a/changelog/entries/unreleased/bug/3808_improved_detection_of_misconfigured_elements_actions_and_dat.json
+++ b/changelog/entries/unreleased/bug/3808_improved_detection_of_misconfigured_elements_actions_and_dat.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Improved detection of misconfigured elements, actions, and data sources in Application Builder.",
+    "issue_origin": "github",
+    "issue_number": 3808,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-09-02"
+}

--- a/changelog/entries/unreleased/feature/3808_improved_detection_of_misconfigured_elements_actions_and_dat.json
+++ b/changelog/entries/unreleased/feature/3808_improved_detection_of_misconfigured_elements_actions_and_dat.json
@@ -1,5 +1,5 @@
 {
-    "type": "bug",
+    "type": "feature",
     "message": "Improved detection of misconfigured elements, actions, and data sources in Application Builder.",
     "issue_origin": "github",
     "issue_number": 3808,

--- a/enterprise/backend/src/baserow_enterprise/integrations/local_baserow/auth_provider_types.py
+++ b/enterprise/backend/src/baserow_enterprise/integrations/local_baserow/auth_provider_types.py
@@ -31,7 +31,7 @@ class LocalBaserowPasswordAppAuthProviderType(AppAuthProviderType):
     ]
 
     serializer_field_names = ["password_field_id"]
-    public_serializer_field_names = []
+    public_serializer_field_names = ["is_configured"]
 
     allowed_fields = ["password_field"]
 
@@ -42,7 +42,12 @@ class LocalBaserowPasswordAppAuthProviderType(AppAuthProviderType):
             help_text="The id of the field to use as password for the user account.",
         ),
     }
-    public_serializer_field_overrides = {}
+    public_serializer_field_overrides = {
+        "is_configured": serializers.BooleanField(
+            read_only=True,
+            help_text="Whether the authentication provider is configured.",
+        ),
+    }
 
     class SerializedDict(AppAuthProviderTypeDict):
         password_field_id: int

--- a/enterprise/backend/src/baserow_enterprise/integrations/local_baserow/models.py
+++ b/enterprise/backend/src/baserow_enterprise/integrations/local_baserow/models.py
@@ -50,3 +50,11 @@ class LocalBaserowPasswordAppAuthProvider(AppAuthProvider):
         related_name="+",
         help_text="The Baserow field that contains the password of the user.",
     )
+
+    @property
+    def is_configured(self) -> bool:
+        """
+        Returns whether the authentication provider is configured properly.
+        """
+
+        return self.get_type().is_configured(self)

--- a/enterprise/backend/tests/baserow_enterprise_tests/integrations/local_baserow/test_auth_provider_types.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/integrations/local_baserow/test_auth_provider_types.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 import pytest
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 
+from baserow.api.app_auth_providers.serializers import AppAuthProviderSerializer
 from baserow.contrib.database.fields.handler import FieldHandler
 from baserow.core.user_sources.exceptions import UserSourceImproperlyConfigured
 from baserow.core.user_sources.handler import UserSourceHandler
@@ -13,6 +14,7 @@ from baserow.core.user_sources.service import UserSourceService
 from baserow.core.utils import MirrorDict
 from baserow_enterprise.integrations.local_baserow.models import (
     LocalBaserowPasswordAppAuthProvider,
+    LocalBaserowUserSource,
 )
 
 from .helpers import populate_local_baserow_test_data
@@ -86,6 +88,46 @@ def test_create_local_baserow_password_app_auth_provider_w_field(
             "password_field_id": password_field.id,
         }
     ]
+
+
+@pytest.mark.django_db
+def test_public_local_baserow_password_app_auth_provider_serializer(data_fixture):
+    user = data_fixture.create_user()
+    user_source = data_fixture.create_user_source(
+        LocalBaserowUserSource,
+        user=user,
+    )
+    _, [password_field], _ = data_fixture.build_table(
+        user=user,
+        columns=[("Password", "password")],
+        rows=[],
+    )
+    auth_provider = data_fixture.create_app_auth_provider(
+        LocalBaserowPasswordAppAuthProvider,
+        user_source=user_source,
+        password_field=password_field,
+    )
+
+    serializer = auth_provider.get_type().get_serializer(
+        auth_provider,
+        base_class=AppAuthProviderSerializer,
+        extra_params={"public": True},
+    )
+
+    assert serializer.data["is_configured"] is True
+    assert "password_field_id" not in serializer.data
+
+    auth_provider.password_field = None
+    auth_provider.save()
+
+    serializer = auth_provider.get_type().get_serializer(
+        auth_provider,
+        base_class=AppAuthProviderSerializer,
+        extra_params={"public": True},
+    )
+
+    assert serializer.data["is_configured"] is False
+    assert "password_field_id" not in serializer.data
 
 
 @pytest.mark.django_db

--- a/enterprise/web-frontend/modules/baserow_enterprise/builder/elementTypes.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/builder/elementTypes.js
@@ -71,8 +71,18 @@ export class AuthFormElementType extends ElementType {
     const loginOptions = userSourceType.getLoginOptions(userSource)
 
     const hasLoginOptions = Object.keys(loginOptions).length !== 0
+    const hasConfiguredProvider = userSource.auth_providers.some(
+      (authProvider) => {
+        const authProviderType = this.app.$registry.get(
+          'appAuthProvider',
+          authProvider.type
+        )
 
-    if (!hasLoginOptions) {
+        return authProviderType.isConfigured(authProvider, applicationContext)
+      }
+    )
+
+    if (!hasLoginOptions || !hasConfiguredProvider) {
       return this.app.$i18n.t('elementType.errorUserSourceHasNoLoginOption')
     }
 

--- a/enterprise/web-frontend/modules/baserow_enterprise/integrations/appAuthProviderTypes.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/integrations/appAuthProviderTypes.js
@@ -40,18 +40,11 @@ export class LocalBaserowPasswordAppAuthProviderType extends AppAuthProviderType
   }
 
   getLoginOptions(authProvider) {
-    if (authProvider.password_field_id) {
-      return {}
-    }
-    return null
+    return this.isConfigured(authProvider) ? {} : null
   }
 
-  isConfigured(authProvider, { mode } = {}) {
-    if (authProvider.password_field_id === undefined) {
-      return mode === 'preview' || mode === 'public'
-    }
-
-    return Boolean(authProvider.password_field_id)
+  isConfigured(authProvider) {
+    return authProvider.is_configured ?? Boolean(authProvider.password_field_id)
   }
 
   /**

--- a/enterprise/web-frontend/modules/baserow_enterprise/integrations/appAuthProviderTypes.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/integrations/appAuthProviderTypes.js
@@ -46,6 +46,14 @@ export class LocalBaserowPasswordAppAuthProviderType extends AppAuthProviderType
     return null
   }
 
+  isConfigured(authProvider, { mode } = {}) {
+    if (authProvider.password_field_id === undefined) {
+      return mode === 'preview' || mode === 'public'
+    }
+
+    return Boolean(authProvider.password_field_id)
+  }
+
   /**
    * We can create only one password provider.
    */

--- a/enterprise/web-frontend/test/unit/enterprise/builder/elementTypes.spec.js
+++ b/enterprise/web-frontend/test/unit/enterprise/builder/elementTypes.spec.js
@@ -1,4 +1,125 @@
 describe('Enterprise builder element types', () => {
+  describe('Auth form error message', () => {
+    const getAuthFormErrorMessage = (
+      authProviders,
+      applicationContext = {}
+    ) => {
+      const testApp = useNuxtApp()
+      const elementType = testApp.$registry.get('element', 'auth_form')
+      const builder = {
+        id: 1,
+        pages: [{ id: 1, workflowActions: [] }],
+        user_sources: [
+          {
+            id: 1,
+            type: 'local_baserow',
+            email_field_id: 1,
+            name_field_id: 2,
+            auth_providers: authProviders,
+          },
+        ],
+      }
+
+      return elementType.getErrorMessage(
+        { id: 1, page_id: 1, user_source_id: 1 },
+        { builder, ...applicationContext }
+      )
+    }
+
+    test.each([[null], [undefined]])(
+      'reports an error when its only password provider has a %s password field',
+      (passwordFieldId) => {
+        expect(
+          getAuthFormErrorMessage([
+            {
+              type: 'local_baserow_password',
+              password_field_id: passwordFieldId,
+            },
+          ])
+        ).toBe('elementType.errorUserSourceHasNoLoginOption')
+      }
+    )
+
+    test('accepts a configured local password provider', () => {
+      expect(
+        getAuthFormErrorMessage([
+          {
+            type: 'local_baserow_password',
+            password_field_id: 3,
+          },
+        ])
+      ).toBeNull()
+    })
+
+    test('accepts a password provider with an unknown field in public mode', () => {
+      expect(
+        getAuthFormErrorMessage(
+          [
+            {
+              type: 'local_baserow_password',
+              password_field_id: undefined,
+            },
+          ],
+          { mode: 'public' }
+        )
+      ).toBeNull()
+    })
+
+    test.each([
+      ['SAML', { type: 'saml', metadata: '<EntityDescriptor />' }],
+      [
+        'OpenID Connect',
+        { type: 'openid_connect', base_url: 'https://idp.example' },
+      ],
+    ])('accepts a configured %s provider', (_providerName, authProvider) => {
+      expect(getAuthFormErrorMessage([authProvider])).toBeNull()
+    })
+
+    test('accepts a configured SAML provider alongside an invalid password provider', () => {
+      expect(
+        getAuthFormErrorMessage([
+          {
+            type: 'local_baserow_password',
+            password_field_id: null,
+          },
+          {
+            type: 'saml',
+            metadata: '<EntityDescriptor />',
+          },
+        ])
+      ).toBeNull()
+    })
+
+    test('reports an error when the user source has no providers', () => {
+      expect(getAuthFormErrorMessage([])).toBe(
+        'elementType.errorUserSourceHasNoLoginOption'
+      )
+    })
+
+    test('requires a password field for a local password provider in editing mode', () => {
+      const appAuthProviderType = useNuxtApp().$registry.get(
+        'appAuthProvider',
+        'local_baserow_password'
+      )
+
+      expect(
+        appAuthProviderType.isConfigured({ password_field_id: null })
+      ).toBe(false)
+      expect(
+        appAuthProviderType.isConfigured({ password_field_id: undefined })
+      ).toBe(false)
+      expect(appAuthProviderType.isConfigured({ password_field_id: 3 })).toBe(
+        true
+      )
+      expect(
+        appAuthProviderType.isConfigured(
+          { password_field_id: undefined },
+          { mode: 'public' }
+        )
+      ).toBe(true)
+    })
+  })
+
   test('file input deactivation checks tolerate a missing workspace', () => {
     const testApp = useNuxtApp()
     const elementType = testApp.$registry.get('element', 'input_file')

--- a/enterprise/web-frontend/test/unit/enterprise/builder/elementTypes.spec.js
+++ b/enterprise/web-frontend/test/unit/enterprise/builder/elementTypes.spec.js
@@ -51,18 +51,34 @@ describe('Enterprise builder element types', () => {
       ).toBeNull()
     })
 
-    test('accepts a password provider with an unknown field in public mode', () => {
+    test('accepts a configured password provider with a redacted field publicly', () => {
       expect(
         getAuthFormErrorMessage(
           [
             {
               type: 'local_baserow_password',
               password_field_id: undefined,
+              is_configured: true,
             },
           ],
           { mode: 'public' }
         )
       ).toBeNull()
+    })
+
+    test('reports an error for an unconfigured password provider publicly', () => {
+      expect(
+        getAuthFormErrorMessage(
+          [
+            {
+              type: 'local_baserow_password',
+              password_field_id: undefined,
+              is_configured: false,
+            },
+          ],
+          { mode: 'public' }
+        )
+      ).toBe('elementType.errorUserSourceHasNoLoginOption')
     })
 
     test.each([
@@ -96,7 +112,7 @@ describe('Enterprise builder element types', () => {
       )
     })
 
-    test('requires a password field for a local password provider in editing mode', () => {
+    test('uses the public configuration state when its password field is redacted', () => {
       const appAuthProviderType = useNuxtApp().$registry.get(
         'appAuthProvider',
         'local_baserow_password'
@@ -112,11 +128,29 @@ describe('Enterprise builder element types', () => {
         true
       )
       expect(
-        appAuthProviderType.isConfigured(
-          { password_field_id: undefined },
-          { mode: 'public' }
-        )
+        appAuthProviderType.isConfigured({
+          password_field_id: undefined,
+          is_configured: true,
+        })
       ).toBe(true)
+      expect(
+        appAuthProviderType.isConfigured({
+          password_field_id: undefined,
+          is_configured: false,
+        })
+      ).toBe(false)
+      expect(
+        appAuthProviderType.getLoginOptions({
+          password_field_id: undefined,
+          is_configured: true,
+        })
+      ).toEqual({})
+      expect(
+        appAuthProviderType.getLoginOptions({
+          password_field_id: undefined,
+          is_configured: false,
+        })
+      ).toBeNull()
     })
   })
 

--- a/web-frontend/modules/builder/collectionFieldTypes.js
+++ b/web-frontend/modules/builder/collectionFieldTypes.js
@@ -286,6 +286,22 @@ export class ButtonCollectionFieldType extends CollectionFieldType {
     return [ClickEvent]
   }
 
+  getErrorMessage({ field, element, builder }) {
+    const elementPage = this.app.$store.getters['page/getById'](
+      builder,
+      element.page_id
+    )
+    const workflowActions = this.app.$store.getters[
+      'builderWorkflowAction/getElementWorkflowActions'
+    ](elementPage, element.id)
+
+    if (!workflowActions.some(({ event }) => event === `${field.uid}_click`)) {
+      return this.app.$i18n.t('elementType.errorNoWorkflowAction')
+    }
+
+    return super.getErrorMessage({ field, element, builder })
+  }
+
   getProps(field, { resolveFormula, applicationContext }) {
     return { label: ensureString(resolveFormula(field.label)) }
   }

--- a/web-frontend/modules/builder/collectionFieldTypes.js
+++ b/web-frontend/modules/builder/collectionFieldTypes.js
@@ -286,16 +286,18 @@ export class ButtonCollectionFieldType extends CollectionFieldType {
     return [ClickEvent]
   }
 
-  getErrorMessage({ field, element, builder }) {
-    const elementPage = this.app.$store.getters['page/getById'](
-      builder,
-      element.page_id
-    )
-    const workflowActions = this.app.$store.getters[
-      'builderWorkflowAction/getElementWorkflowActions'
-    ](elementPage, element.id)
+  getErrorMessage({ field, element, builder, workflowActionEvents }) {
+    const eventName = `${field.uid}_click`
+    const hasWorkflowAction =
+      workflowActionEvents?.has(eventName) ??
+      this.app.$store.getters[
+        'builderWorkflowAction/getElementWorkflowActions'
+      ](
+        this.app.$store.getters['page/getById'](builder, element.page_id),
+        element.id
+      ).some(({ event }) => event === eventName)
 
-    if (!workflowActions.some(({ event }) => event === `${field.uid}_click`)) {
+    if (!hasWorkflowAction) {
       return this.app.$i18n.t('elementType.errorNoWorkflowAction')
     }
 

--- a/web-frontend/modules/builder/components/workflowAction/NotificationWorkflowActionForm.vue
+++ b/web-frontend/modules/builder/components/workflowAction/NotificationWorkflowActionForm.vue
@@ -4,7 +4,6 @@
       small-label
       :label="$t('notificationWorkflowActionForm.titleLabel')"
       class="margin-bottom-2"
-      required
     >
       <InjectedFormulaInput
         v-model="values.title"
@@ -15,7 +14,6 @@
       small-label
       :label="$t('notificationWorkflowActionForm.descriptionLabel')"
       class="margin-bottom-2"
-      required
     >
       <InjectedFormulaInput
         v-model="values.description"

--- a/web-frontend/modules/builder/elementTypes.js
+++ b/web-frontend/modules/builder/elementTypes.js
@@ -1329,6 +1329,7 @@ export class TableElementType extends CollectionElementTypeMixin(ElementType) {
       )
       return collectionFieldType.isInError({
         field: collectionField,
+        element,
         builder,
       })
     })
@@ -1995,6 +1996,9 @@ export class ChoiceElementType extends FormElementType {
     if (element.option_type === CHOICE_OPTION_TYPES.MANUAL) {
       if (element.options.length === 0) {
         return this.app.$i18n.t('elementType.errorOptionsMissing')
+      }
+      if (element.options.some(({ name }) => !ensureString(name).trim())) {
+        return this.app.$i18n.t('elementType.errorOptionNameMissing')
       }
     } else if (element.option_type === CHOICE_OPTION_TYPES.FORMULAS) {
       if (element.formula_value === '') {

--- a/web-frontend/modules/builder/elementTypes.js
+++ b/web-frontend/modules/builder/elementTypes.js
@@ -1321,6 +1321,16 @@ export class TableElementType extends CollectionElementTypeMixin(ElementType) {
    */
   getErrorMessage(element, applicationContext) {
     const { builder } = applicationContext
+    const elementPage = this.app.$store.getters['page/getById'](
+      builder,
+      element.page_id
+    )
+    const workflowActions = this.app.$store.getters[
+      'builderWorkflowAction/getElementWorkflowActions'
+    ](elementPage, element.id)
+    const workflowActionEvents = new Set(
+      workflowActions.map(({ event }) => event)
+    )
 
     const hasCollectionFieldInError = element.fields.some((collectionField) => {
       const collectionFieldType = this.app.$registry.get(
@@ -1331,6 +1341,7 @@ export class TableElementType extends CollectionElementTypeMixin(ElementType) {
         field: collectionField,
         element,
         builder,
+        workflowActionEvents,
       })
     })
 

--- a/web-frontend/modules/builder/locales/en.json
+++ b/web-frontend/modules/builder/locales/en.json
@@ -176,6 +176,7 @@
     "errorImageUrlMissing": "Missing Image URL property",
     "errorNoWorkflowAction": "No workflow action configured",
     "errorOptionsMissing": "No option configured",
+    "errorOptionNameMissing": "An option is missing a name",
     "errorIframeUrlMissing": "Missing IFrame URL property",
     "errorIframeContentMissing": "Missing IFrame content",
     "errorNoMenuItem": "No menu item configured",
@@ -854,6 +855,7 @@
   "workflowActionTypes": {
     "notificationLabel": "Show Notification",
     "notificationDescription": "Show a notification message to the user.",
+    "errorNotificationContentMissing": "A notification requires a title or description",
     "openPageLabel": "Open Page",
     "openPageDescription": "Navigate the user to another page or URL.",
     "logoutLabel": "Logout",

--- a/web-frontend/modules/builder/workflowActionTypes.js
+++ b/web-frontend/modules/builder/workflowActionTypes.js
@@ -50,6 +50,19 @@ export class NotificationWorkflowActionType extends WorkflowActionType {
     return this.app.$i18n.t('workflowActionTypes.notificationDescription')
   }
 
+  getErrorMessage(workflowAction, applicationContext) {
+    if (
+      !workflowAction.title?.formula &&
+      !workflowAction.description?.formula
+    ) {
+      return this.app.$i18n.t(
+        'workflowActionTypes.errorNotificationContentMissing'
+      )
+    }
+
+    return super.getErrorMessage(workflowAction, applicationContext)
+  }
+
   execute({ workflowAction: { title, description }, resolveFormula }) {
     return this.app.$store.dispatch('builderToast/info', {
       title: ensureString(resolveFormula(title)),

--- a/web-frontend/modules/core/appAuthProviderTypes.js
+++ b/web-frontend/modules/core/appAuthProviderTypes.js
@@ -9,6 +9,10 @@ export class AppAuthProviderType extends BaseAuthProviderType {
     return null
   }
 
+  isConfigured() {
+    return true
+  }
+
   get component() {
     return null
   }

--- a/web-frontend/test/unit/builder/collectionFieldTypes.spec.js
+++ b/web-frontend/test/unit/builder/collectionFieldTypes.spec.js
@@ -89,4 +89,48 @@ describe('Builder collection field types', () => {
       expect(fieldType.isInError({ field, builder })).toBe(false)
     })
   })
+
+  describe('ButtonCollectionFieldType getErrorMessage', () => {
+    test('requires an action for its own click event', () => {
+      const fieldType = testApp.getRegistry().get('collectionField', 'button')
+      const tableElementType = testApp.getRegistry().get('element', 'table')
+      const buttonField = { type: 'button', uid: 'first-button' }
+      const otherButtonField = { type: 'button', uid: 'second-button' }
+      const page = {
+        id: 1,
+        workflowActions: [
+          {
+            element_id: 50,
+            event: 'second-button_click',
+            order: 1,
+            type: 'notification',
+          },
+        ],
+      }
+      const element = {
+        id: 50,
+        type: 'table',
+        page_id: page.id,
+        fields: [buttonField, otherButtonField],
+      }
+      const builder = { id: 1, pages: [page] }
+
+      expect(
+        fieldType.getErrorMessage({ field: buttonField, element, builder })
+      ).toBe('elementType.errorNoWorkflowAction')
+      expect(tableElementType.getErrorMessage(element, { builder })).toBe(
+        'elementType.errorCollectionFieldInError'
+      )
+
+      page.workflowActions.push({
+        element_id: element.id,
+        event: 'first-button_click',
+        order: 2,
+        type: 'notification',
+      })
+      expect(
+        fieldType.getErrorMessage({ field: buttonField, element, builder })
+      ).toBeNull()
+    })
+  })
 })

--- a/web-frontend/test/unit/builder/collectionFieldTypes.spec.js
+++ b/web-frontend/test/unit/builder/collectionFieldTypes.spec.js
@@ -98,22 +98,32 @@ describe('Builder collection field types', () => {
       const otherButtonField = { type: 'button', uid: 'second-button' }
       const page = {
         id: 1,
+        shared: false,
+        dataSources: [
+          {
+            id: 1,
+            type: 'local_baserow_list_rows',
+          },
+        ],
         workflowActions: [
           {
             element_id: 50,
             event: 'second-button_click',
             order: 1,
             type: 'notification',
+            title: { formula: "'Notification'" },
           },
         ],
       }
+      const sharedPage = { id: 2, shared: true, dataSources: [] }
       const element = {
         id: 50,
         type: 'table',
         page_id: page.id,
+        data_source_id: 1,
         fields: [buttonField, otherButtonField],
       }
-      const builder = { id: 1, pages: [page] }
+      const builder = { id: 1, pages: [page, sharedPage] }
 
       expect(
         fieldType.getErrorMessage({ field: buttonField, element, builder })
@@ -127,10 +137,12 @@ describe('Builder collection field types', () => {
         event: 'first-button_click',
         order: 2,
         type: 'notification',
+        title: { formula: "'Notification'" },
       })
       expect(
         fieldType.getErrorMessage({ field: buttonField, element, builder })
       ).toBeNull()
+      expect(tableElementType.getErrorMessage(element, { builder })).toBeNull()
     })
   })
 })

--- a/web-frontend/test/unit/builder/components/workflowAction/notificationWorkflowActionForm.spec.js
+++ b/web-frontend/test/unit/builder/components/workflowAction/notificationWorkflowActionForm.spec.js
@@ -1,0 +1,37 @@
+import { defineComponent } from 'vue'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+
+import NotificationWorkflowActionForm from '@baserow/modules/builder/components/workflowAction/NotificationWorkflowActionForm'
+
+const FormGroupStub = defineComponent({
+  name: 'FormGroup',
+  props: {
+    required: Boolean,
+  },
+  template: '<div><slot /></div>',
+})
+
+describe('NotificationWorkflowActionForm', () => {
+  test('does not mark either content field as individually required', async () => {
+    const wrapper = await mountSuspended(NotificationWorkflowActionForm, {
+      global: {
+        stubs: {
+          FormGroup: FormGroupStub,
+          InjectedFormulaInput: true,
+        },
+        mocks: {
+          $t: (key) => key,
+        },
+      },
+    })
+
+    expect(wrapper.findAllComponents(FormGroupStub)).toHaveLength(2)
+    expect(
+      wrapper
+        .findAllComponents(FormGroupStub)
+        .map((formGroup) => formGroup.props('required'))
+    ).toEqual([false, false])
+
+    wrapper.unmount()
+  })
+})

--- a/web-frontend/test/unit/builder/elementTypes.spec.js
+++ b/web-frontend/test/unit/builder/elementTypes.spec.js
@@ -1148,6 +1148,31 @@ describe('elementTypes tests', () => {
     })
   })
 
+  describe('ChoiceElementType getErrorMessage tests', () => {
+    test('is in error when a manual option has an empty name', () => {
+      const elementType = testApp.$registry.get('element', 'choice')
+      const element = {
+        option_type: CHOICE_OPTION_TYPES.MANUAL,
+        options: [
+          { id: 1, name: '', value: null },
+          { id: 2, name: 'Blank value', value: '' },
+        ],
+      }
+
+      expect(elementType.getErrorMessage(element, {})).toBe(
+        'elementType.errorOptionNameMissing'
+      )
+
+      element.options[0].name = '   '
+      expect(elementType.getErrorMessage(element, {})).toBe(
+        'elementType.errorOptionNameMissing'
+      )
+
+      element.options[0].name = 'Named option'
+      expect(elementType.getErrorMessage(element, {})).toBeNull()
+    })
+  })
+
   describe('ButtonElementType isInError tests', () => {
     test('Returns true if Button Element has no errors, but has misconfigured workflow actions.', () => {
       const page = {

--- a/web-frontend/test/unit/builder/workflowActionTypes.spec.js
+++ b/web-frontend/test/unit/builder/workflowActionTypes.spec.js
@@ -112,6 +112,28 @@ describe('Builder workflow action types', () => {
     )
   })
 
+  test('requires a title or description for notification actions', () => {
+    const workflowActionType = testApp
+      .getRegistry()
+      .get('workflowAction', 'notification')
+    const workflowAction = {
+      type: 'notification',
+      title: {},
+      description: {},
+    }
+
+    expect(workflowActionType.getErrorMessage(workflowAction, {})).toBe(
+      'workflowActionTypes.errorNotificationContentMissing'
+    )
+
+    workflowAction.title = { formula: "'Title'" }
+    expect(workflowActionType.getErrorMessage(workflowAction, {})).toBeNull()
+
+    workflowAction.title = {}
+    workflowAction.description = { formula: "'Description'" }
+    expect(workflowActionType.getErrorMessage(workflowAction, {})).toBeNull()
+  })
+
   test('open page action is in error when saved page parameters are outdated', () => {
     const workflowActionType = testApp
       .getRegistry()


### PR DESCRIPTION
### What is in this PR

Fixes #3808.

Improves Builder misconfiguration reporting for four previously-valid invalid states:
- notification workflow actions with neither a title nor a description;
- manual choice options with a blank name while preserving blank option values;
- table button fields without a workflow action for that specific button;
- login forms whose configured providers are all invalid.

### How to test this PR

- In Builder, verify an empty notification action, a manual choice with an unnamed option, and a table button without its own click action are flagged. Add the missing configuration and verify each clears.
- Configure an auth form and in the user source Authentication settings leave the password field unset. Observe the error state in the editor. Verify also that the auth form is not showing in the preview. 

### Checklist

- [x] A changelog entry has been added to changelog/entries/unreleased using changelog/src/changelog.py
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered