### PR TITLE
fix: reject AI fields referencing themselves as file field

### DIFF
--- a/backend/src/baserow/contrib/database/fields/dependencies/dependency_rebuilder.py
+++ b/backend/src/baserow/contrib/database/fields/dependencies/dependency_rebuilder.py
@@ -11,6 +11,7 @@ from baserow.contrib.database.fields.dependencies.circular_reference_checker imp
 )
 from baserow.contrib.database.fields.dependencies.exceptions import (
     CircularFieldDependencyError,
+    SelfReferenceFieldDependencyError,
 )
 from baserow.contrib.database.fields.dependencies.models import FieldDependency
 from baserow.contrib.database.fields.field_cache import FieldCache
@@ -162,6 +163,10 @@ def rebuild_fields_dependencies(
                 new_dependencies_to_create.append(new_dep)
 
         for dep in new_dependencies_to_create:
+            # `will_cause_circular_dep` only inspects dependencies that already
+            # exist, so a field depending on itself must be rejected explicitly.
+            if dep.dependency_id is not None and dep.dependency_id == field_instance.id:
+                raise SelfReferenceFieldDependencyError()
             # Unfortunately, the `will_cause_circular_dep` still causes N number of
             # queries, but that's only if new dependencies must be created.
             if dep.dependency is not None and will_cause_circular_dep(

--- a/backend/src/baserow/contrib/database/fields/dependencies/handler.py
+++ b/backend/src/baserow/contrib/database/fields/dependencies/handler.py
@@ -204,7 +204,10 @@ class FieldDependencyHandler:
                 FROM traverse
                 INNER JOIN relationship_table_cte
                     ON relationship_table_cte.dependency_id = traverse.id
-                WHERE 1 = 1
+                -- Stop recursing once the maximum depth is reached. Without this the
+                -- recursion is unbounded, and a cyclic dependency would make Postgres
+                -- spill temporary files until the disk is full.
+                WHERE traverse.depth < %(max_depth)s
                 -- LIMITING_FK_EDGES_CLAUSE_2
                 -- DISALLOWED_ANCESTORS_NODES_CLAUSE_2
                 -- ALLOWED_ANCESTORS_NODES_CLAUSE_2

--- a/backend/tests/baserow/contrib/database/field/dependencies/test_dependency_rebuilder.py
+++ b/backend/tests/baserow/contrib/database/field/dependencies/test_dependency_rebuilder.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from baserow.contrib.database.fields.dependencies.circular_reference_checker import (
@@ -5,10 +7,12 @@ from baserow.contrib.database.fields.dependencies.circular_reference_checker imp
 )
 from baserow.contrib.database.fields.dependencies.exceptions import (
     CircularFieldDependencyError,
+    SelfReferenceFieldDependencyError,
 )
 from baserow.contrib.database.fields.dependencies.handler import FieldDependencyHandler
 from baserow.contrib.database.fields.dependencies.models import FieldDependency
 from baserow.contrib.database.fields.field_cache import FieldCache
+from baserow.contrib.database.fields.field_types import TextFieldType
 from baserow.contrib.database.fields.handler import FieldHandler
 from baserow.contrib.database.rows.handler import RowHandler
 from baserow.core.trash.handler import TrashHandler
@@ -395,3 +399,25 @@ def test_even_with_circular_dependencies_queries_finish_in_time(data_fixture):
 
     with pytest.raises(CircularFieldDependencyError):
         assert get_all_field_dependencies(f2) == {f1.id}  # f2 -> f1
+
+
+@pytest.mark.django_db
+def test_rebuild_dependencies_rejects_a_field_depending_on_itself(data_fixture):
+    """
+    `will_cause_circular_dep` only looks at dependencies that already exist, so a
+    brand new self dependency must be rejected explicitly by the rebuilder.
+    """
+
+    field = data_fixture.create_text_field()
+
+    with (
+        patch.object(
+            TextFieldType,
+            "get_field_dependencies",
+            return_value=[FieldDependency(dependant=field, dependency=field)],
+        ),
+        pytest.raises(SelfReferenceFieldDependencyError),
+    ):
+        FieldDependencyHandler.rebuild_dependencies([field], FieldCache())
+
+    assert not FieldDependency.objects.filter(dependant=field).exists()

--- a/backend/tests/baserow/contrib/database/field/dependencies/test_field_dependency_handler.py
+++ b/backend/tests/baserow/contrib/database/field/dependencies/test_field_dependency_handler.py
@@ -1,6 +1,6 @@
 from django.contrib.contenttypes.models import ContentType
 from django.db import connection
-from django.test.utils import CaptureQueriesContext
+from django.test.utils import CaptureQueriesContext, override_settings
 
 import pytest
 from pytest_unordered import unordered
@@ -865,3 +865,32 @@ def test_get_via_dependants_of_link_field_num_queries_does_not_scale(data_fixtur
     for field, field_type, via_path in more_dependants:
         assert via_path == []
         assert field_type == field_type_registry.get_by_model(field)
+
+
+@pytest.mark.django_db
+@override_settings(MAX_FIELD_REFERENCE_DEPTH=3)
+def test_get_all_dependant_fields_stops_recursing_on_cyclic_dependency(data_fixture):
+    """
+    The recursive dependants query used to only apply the max depth to its final
+    result, so a cycle in the dependency rows made it recurse without bound and
+    spill temporary files until the disk was full. The recursion itself must stop
+    at the configured max depth.
+    """
+
+    field_a = data_fixture.create_text_field()
+    field_b = data_fixture.create_text_field(table=field_a.table)
+    # Insert the cycle directly, bypassing the checks that normally prevent it.
+    FieldDependency.objects.create(dependant=field_a, dependency=field_a)
+    FieldDependency.objects.create(dependant=field_a, dependency=field_b)
+    FieldDependency.objects.create(dependant=field_b, dependency=field_a)
+
+    # The query must return, after which the cycle is reported as such rather
+    # than hanging Postgres.
+    with pytest.raises(CircularFieldDependencyError):
+        FieldDependencyHandler.group_all_dependent_fields_by_level(
+            field_a.table_id,
+            [field_a.id],
+            FieldCache(),
+            associated_relations_changed=False,
+            database_id_prefilter=field_a.table.database_id,
+        )

--- a/changelog/entries/unreleased/bug/resolved_a_bug_which_caused_an_ai_field_selfreferencing_to_r.json
+++ b/changelog/entries/unreleased/bug/resolved_a_bug_which_caused_an_ai_field_selfreferencing_to_r.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolved a bug which caused an AI field self-referencing to recurse indefinitely.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-09-04"
+}

--- a/premium/backend/src/baserow_premium/fields/field_types.py
+++ b/premium/backend/src/baserow_premium/fields/field_types.py
@@ -11,7 +11,10 @@ from baserow.api.generative_ai.errors import (
     ERROR_GENERATIVE_AI_DOES_NOT_EXIST,
     ERROR_MODEL_DOES_NOT_BELONG_TO_TYPE,
 )
-from baserow.contrib.database.api.fields.errors import ERROR_FIELD_DOES_NOT_EXIST
+from baserow.contrib.database.api.fields.errors import (
+    ERROR_FIELD_DOES_NOT_EXIST,
+    ERROR_INCOMPATIBLE_FIELD,
+)
 from baserow.contrib.database.fields.dependencies.handler import (
     FieldDependencyHandler,
 )
@@ -21,12 +24,16 @@ from baserow.contrib.database.fields.dependencies.update_collector import (
     DependencyContext,
     FieldUpdateCollector,
 )
+from baserow.contrib.database.fields.exceptions import (
+    FieldDoesNotExist,
+    IncompatibleField,
+)
 from baserow.contrib.database.fields.field_cache import FieldCache
 from baserow.contrib.database.fields.field_types import (
     CollationSortMixin,
     SelectOptionBaseFieldType,
 )
-from baserow.contrib.database.fields.models import Field, LinkRowField
+from baserow.contrib.database.fields.models import Field, FileField, LinkRowField
 from baserow.contrib.database.fields.registries import field_type_registry
 from baserow.contrib.database.formula import BaserowFormulaType
 from baserow.core.formula.parser.exceptions import BaserowFormulaException
@@ -135,6 +142,8 @@ class AIFieldType(CollationSortMixin, SelectOptionBaseFieldType):
         ModelDoesNotBelongToType: ERROR_MODEL_DOES_NOT_BELONG_TO_TYPE,
         GenerativeAITypeDoesNotSupportFileField: ERROR_GENERATIVE_AI_DOES_NOT_SUPPORT_FILE_FIELD,
         IntegrityError: ERROR_FIELD_DOES_NOT_EXIST,
+        FieldDoesNotExist: ERROR_FIELD_DOES_NOT_EXIST,
+        IncompatibleField: ERROR_INCOMPATIBLE_FIELD,
     }
     can_get_unique_values = True
     can_have_select_options = True
@@ -350,7 +359,13 @@ class AIFieldType(CollationSortMixin, SelectOptionBaseFieldType):
         return baserow_field_type.get_human_readable_value(value, field_object)
 
     def _validate_field_kwargs(
-        self, ai_output_type, ai_type, model_type, ai_file_field_id, workspace=None
+        self,
+        ai_output_type,
+        ai_type,
+        model_type,
+        ai_file_field_id,
+        workspace=None,
+        table=None,
     ):
         ai_field_output_registry.get(ai_output_type)
         if ai_type is not None:
@@ -366,6 +381,30 @@ class AIFieldType(CollationSortMixin, SelectOptionBaseFieldType):
                 raise ModelDoesNotBelongToType(model_name=model_type)
         if ai_file_field_id is not None and not ai_type.supports_files:
             raise GenerativeAITypeDoesNotSupportFileField()
+        if ai_file_field_id is not None and table is not None:
+            self._validate_ai_file_field(ai_file_field_id, table)
+
+    def _validate_ai_file_field(self, ai_file_field_id, table):
+        """
+        Ensures the referenced file field exists in the same table and is a file
+        field. This also rejects an AI field pointing at itself, which would
+        otherwise create a self-dependency and an unbounded recursive query.
+
+        :param ai_file_field_id: The id of the field the AI field wants to use.
+        :param table: The table the AI field belongs to.
+        :raises FieldDoesNotExist: If no such field exists in the table.
+        :raises IncompatibleField: If the field is not a file field.
+        """
+
+        if not Field.objects.filter(id=ai_file_field_id, table=table).exists():
+            raise FieldDoesNotExist(
+                f"The field with id {ai_file_field_id} does not exist in table "
+                f"{table.id}."
+            )
+        if not FileField.objects.filter(id=ai_file_field_id, table=table).exists():
+            raise IncompatibleField(
+                f"The field with id {ai_file_field_id} is not a file field."
+            )
 
     def get_field_dependencies(
         self, field_instance: AIField, field_cache: "FieldCache"
@@ -380,6 +419,9 @@ class AIFieldType(CollationSortMixin, SelectOptionBaseFieldType):
             field_ids = set()
         if field_instance.ai_file_field_id is not None:
             field_ids.add(field_instance.ai_file_field_id)
+        # A field can never depend on itself. This would create a cycle in the
+        # dependency graph, which makes the recursive dependants query run away.
+        field_ids.discard(field_instance.id)
         # Scoped to the field's table, matching `get_ai_prompt_error`; a prompt
         # can only reference fields in the same table.
         existing_field_ids = set(
@@ -534,7 +576,12 @@ class AIFieldType(CollationSortMixin, SelectOptionBaseFieldType):
         ai_file_field_id = field_kwargs.get("ai_file_field_id", None)
         workspace = table.database.workspace
         self._validate_field_kwargs(
-            ai_output_type, ai_type, model_type, ai_file_field_id, workspace=workspace
+            ai_output_type,
+            ai_type,
+            model_type,
+            ai_file_field_id,
+            workspace=workspace,
+            table=table,
         )
         if allowed_field_values.get("ai_auto_update"):
             allowed_field_values["ai_auto_update_user_id"] = user.id if user else None
@@ -565,7 +612,12 @@ class AIFieldType(CollationSortMixin, SelectOptionBaseFieldType):
             ai_file_field_id = getattr(update_field, "ai_file_field_id", None)
         workspace = from_field.table.database.workspace
         self._validate_field_kwargs(
-            ai_output_type, ai_type, model_type, ai_file_field_id, workspace=workspace
+            ai_output_type,
+            ai_type,
+            model_type,
+            ai_file_field_id,
+            workspace=workspace,
+            table=from_field.table,
         )
 
         # Set the auto update user if the auto update is being enabled.

--- a/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_type.py
+++ b/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_type.py
@@ -636,7 +636,7 @@ def test_create_ai_field_type_via_api_file_field_doesnt_exist(
             "ai_generative_ai_type": "test_generative_ai_with_files",
             "ai_generative_ai_model": "test_1",
             "ai_prompt": "'Test'",
-            "ai_file_field_id": 999,
+            "ai_file_field_id": 999999999,
         },
         format="json",
         HTTP_AUTHORIZATION=f"JWT {token}",
@@ -644,6 +644,98 @@ def test_create_ai_field_type_via_api_file_field_doesnt_exist(
     response_json = response.json()
     assert response.status_code == HTTP_404_NOT_FOUND, response_json
     assert response_json["error"] == "ERROR_FIELD_DOES_NOT_EXIST"
+
+
+@pytest.mark.django_db
+@pytest.mark.field_ai
+def test_create_ai_field_type_via_api_file_field_not_a_file_field(
+    premium_data_fixture, api_client
+):
+    user, token = premium_data_fixture.create_user_and_token()
+    table = premium_data_fixture.create_database_table(user=user)
+    premium_data_fixture.register_fake_generate_ai_type()
+    text_field = premium_data_fixture.create_text_field(
+        table=table, order=1, name="name"
+    )
+
+    response = api_client.post(
+        reverse("api:database:fields:list", kwargs={"table_id": table.id}),
+        {
+            "name": "Test 1",
+            "type": "ai",
+            "ai_generative_ai_type": "test_generative_ai_with_files",
+            "ai_generative_ai_model": "test_1",
+            "ai_prompt": "'Test'",
+            "ai_file_field_id": text_field.id,
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    response_json = response.json()
+    assert response.status_code == HTTP_400_BAD_REQUEST, response_json
+    assert response_json["error"] == "ERROR_INCOMPATIBLE_FIELD"
+
+
+@pytest.mark.django_db
+@pytest.mark.field_ai
+def test_create_ai_field_type_via_api_file_field_in_other_table(
+    premium_data_fixture, api_client
+):
+    user, token = premium_data_fixture.create_user_and_token()
+    table = premium_data_fixture.create_database_table(user=user)
+    other_table = premium_data_fixture.create_database_table(user=user)
+    premium_data_fixture.register_fake_generate_ai_type()
+    file_field = premium_data_fixture.create_file_field(table=other_table, name="file")
+
+    response = api_client.post(
+        reverse("api:database:fields:list", kwargs={"table_id": table.id}),
+        {
+            "name": "Test 1",
+            "type": "ai",
+            "ai_generative_ai_type": "test_generative_ai_with_files",
+            "ai_generative_ai_model": "test_1",
+            "ai_prompt": "'Test'",
+            "ai_file_field_id": file_field.id,
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    response_json = response.json()
+    assert response.status_code == HTTP_404_NOT_FOUND, response_json
+    assert response_json["error"] == "ERROR_FIELD_DOES_NOT_EXIST"
+
+
+@pytest.mark.django_db
+@pytest.mark.field_ai
+def test_update_ai_field_type_via_api_file_field_cannot_reference_itself(
+    premium_data_fixture, api_client
+):
+    """
+    An AI field pointing at itself as its file field would create a self
+    dependency, which previously made the recursive dependants query run forever.
+    """
+
+    user, token = premium_data_fixture.create_user_and_token()
+    table = premium_data_fixture.create_database_table(user=user)
+    premium_data_fixture.register_fake_generate_ai_type()
+    field = premium_data_fixture.create_ai_field(table=table, order=1, name="name")
+
+    response = api_client.patch(
+        reverse("api:database:fields:item", kwargs={"field_id": field.id}),
+        {
+            "ai_generative_ai_type": "test_generative_ai_with_files",
+            "ai_generative_ai_model": "test_1",
+            "ai_file_field_id": field.id,
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    response_json = response.json()
+    assert response.status_code == HTTP_400_BAD_REQUEST, response_json
+    assert response_json["error"] == "ERROR_INCOMPATIBLE_FIELD"
+    field.refresh_from_db()
+    assert field.ai_file_field_id is None
+    assert not FieldDependency.objects.filter(dependant=field).exists()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### What is in this PR

Updating or creating an AI field with `ai_file_field_id` set to a field that is not a file field in the same table was never validated, so a field could be pointed at itself. That creates a self-dependency which the existing circular reference check misses, because it only inspects dependency rows that already exist, and the recursive dependants query only applied `MAX_FIELD_REFERENCE_DEPTH` to its final result rather than to the recursion itself. The result was an unbounded recursive CTE that spilled temporary files until Postgres ran out of disk, which a single authenticated PATCH on a field could trigger. The same thing surfaced in CI as a persistent "No space left on device" in one backend test group, because a test used the hard-coded field id 999 and the field sequence happened to allocate that id to the AI field itself. This PR validates that the AI file field exists in the same table and is a file field, rejects any new self-dependency generically in the dependency rebuilder, caps the depth inside the recursive query so a cycle now terminates and is reported as a circular dependency error, and fixes the test to use an id that can never be allocated.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
