### PR TITLE
fix: follow-up to the button field Slack action review

### DIFF
--- a/backend/src/baserow/contrib/integrations/slack/service_types.py
+++ b/backend/src/baserow/contrib/integrations/slack/service_types.py
@@ -21,6 +21,7 @@ from baserow.core.services.exceptions import (
     AddressNotAllowedDispatchException,
     RemoteRefusedDispatchException,
     ResponseTooLargeDispatchException,
+    ServiceImproperlyConfiguredDispatchException,
     UnexpectedDispatchException,
 )
 from baserow.core.services.registries import DispatchTypes, ServiceType
@@ -105,12 +106,25 @@ class SlackWriteMessageServiceType(ServiceType):
             service's fields, including the message text.
         :param dispatch_context: The context in which the dispatch is occurring.
         :return: A dictionary containing the response data from the Slack API.
+        :raises ServiceImproperlyConfiguredDispatchException: If the integration is
+            not a Slack bot, or is one with no token.
         :raises UnexpectedDispatchException: If there's an error after the HTTP request.
         :raises RemoteRefusedDispatchException: If Slack refused the message.
         """
 
+        # Both refused before the request, so the click is not charged for them.
+        if service.integration.get_type().type != self.integration_type:
+            raise ServiceImproperlyConfiguredDispatchException(
+                "The integration of this action is not a Slack bot."
+            )
+        token = service.integration.specific.token
+        if not token:
+            raise ServiceImproperlyConfiguredDispatchException(
+                "This Slack bot has no token. Add a new bot with its token, or "
+                "paste one into this bot, before this action can post."
+            )
+
         try:
-            token = service.integration.specific.token
             response = get_http_request_function()(
                 method="POST",
                 url=f"{settings.INTEGRATIONS_SLACK_API_URL}/chat.postMessage",

--- a/backend/src/baserow/test_utils/fixtures/service.py
+++ b/backend/src/baserow/test_utils/fixtures/service.py
@@ -140,6 +140,9 @@ class ServiceFixtures:
         return self.create_service(AIAgentService, **kwargs)
 
     def create_slack_write_message_service(self, **kwargs):
+        # A bot with no token is refused before the dispatch sends anything.
+        if "integration" not in kwargs:
+            kwargs.setdefault("integration_args", {}).setdefault("token", "xoxb-test")
         return self.create_service(SlackWriteMessageService, **kwargs)
 
     def create_core_iterator_service(self, **kwargs):

--- a/backend/tests/baserow/contrib/integrations/slack/test_slack_write_message_service_type.py
+++ b/backend/tests/baserow/contrib/integrations/slack/test_slack_write_message_service_type.py
@@ -608,6 +608,58 @@ def test_slack_write_message_refused_address_is_not_charged(data_fixture):
 
 
 @pytest.mark.django_db
+def test_slack_write_message_without_a_token_is_not_sent(data_fixture):
+    """
+    An export strips the token, so an imported bot looks configured. Nothing
+    goes out, and the exception says so: a caller counting outbound traffic
+    does not count this one.
+    """
+
+    service = data_fixture.create_slack_write_message_service(
+        integration=data_fixture.create_integration(SlackBotIntegration, token=""),
+        channel="general",
+        text="'hi'",
+    )
+    sends = Mock()
+
+    with patch(
+        "baserow.contrib.integrations.slack.service_types.get_http_request_function",
+        return_value=sends,
+    ):
+        with pytest.raises(ServiceImproperlyConfiguredDispatchException) as exc:
+            service.get_type().dispatch(service, FakeDispatchContext())
+
+    assert "no token" in str(exc.value)
+    sends.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_slack_write_message_with_an_integration_of_another_type(data_fixture):
+    """
+    `prepare_values` checks an integration's application but not its type, so
+    a service can hold one with no token to post through. Refused like a
+    missing token, rather than failing on the read.
+    """
+
+    service = data_fixture.create_slack_write_message_service(
+        integration=data_fixture.create_local_baserow_integration(),
+        channel="general",
+        text="'hi'",
+    )
+    sends = Mock()
+
+    with patch(
+        "baserow.contrib.integrations.slack.service_types.get_http_request_function",
+        return_value=sends,
+    ):
+        with pytest.raises(ServiceImproperlyConfiguredDispatchException) as exc:
+            service.get_type().dispatch(service, FakeDispatchContext())
+
+    assert "not a Slack bot" in str(exc.value)
+    sends.assert_not_called()
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "body", [[], "forbidden", 12, {"ok": False, "error": {"code": "denied"}}]
 )

--- a/web-frontend/modules/database/components/field/FieldButtonSubForm.vue
+++ b/web-frontend/modules/database/components/field/FieldButtonSubForm.vue
@@ -225,6 +225,10 @@ export default {
      * `shown` both land on the first open.
      */
     async onShow() {
+      // The list is not remounted between opens, so reopening the editor is
+      // the retry for an integrations fetch that failed. Reports its own
+      // failure, so nothing here waits on it.
+      this.$refs.actionList?.fetchIntegrations()
       if (
         !this.defaultValues.id ||
         this.defaultValues.type !== 'button' ||

--- a/web-frontend/test/unit/database/components/field/fieldButtonSubForm.spec.js
+++ b/web-frontend/test/unit/database/components/field/fieldButtonSubForm.spec.js
@@ -1102,3 +1102,74 @@ describe('FieldButtonSubForm', () => {
     })
   })
 })
+
+describe('FieldButtonSubForm integrations', () => {
+  let testApp = null
+  const DATABASE_ID = 2001
+
+  // A fresh app per test, so the store the in-flight request is remembered
+  // against is fresh too.
+  beforeEach(() => {
+    testApp = new TestApp()
+  })
+
+  afterEach(() => {
+    testApp.afterEach()
+  })
+
+  const seedDatabase = async () => {
+    await testApp.store.dispatch('application/forceSetAll', {
+      applications: [
+        {
+          id: DATABASE_ID,
+          name: 'Customers',
+          type: 'database',
+          workspace: { id: 1 },
+          tables: [],
+        },
+      ],
+    })
+    return testApp.store.getters['application/get'](DATABASE_ID)
+  }
+
+  const mountForm = async (database) =>
+    testApp.mount(FieldButtonSubForm, {
+      propsData: {
+        table: { id: 1 },
+        view: null,
+        primary: false,
+        allFieldsInTable: [{ id: 1, type: 'text', name: 'Name' }],
+        name: 'button',
+        database,
+        defaultValues: { type: 'button', id: 5, label: 'Go' },
+      },
+    })
+
+  test('a failed fetch is retried when the editor is reopened', async () => {
+    // The sub-form is not remounted between opens, so nothing in the action
+    // list runs again unless the user collapses and expands a card. Without a
+    // retry here a network blip leaves the bot dropdown empty for as long as
+    // the page lives.
+    const database = await seedDatabase()
+    testApp.dontFailOnErrorResponses()
+    testApp.mock
+      .onGet('database/field/5/workflow_actions/')
+      .reply(200, [{ id: 1, type: 'slack_write_message', service: {} }])
+    testApp.mock
+      .onGet(`application/${DATABASE_ID}/integrations/`)
+      .replyOnce(500)
+      .onGet(`application/${DATABASE_ID}/integrations/`)
+      .reply(200, [{ id: 7, type: 'slack_bot', name: 'Bot', order: '1' }])
+
+    const wrapper = await mountForm(database)
+    await flushPromises()
+    expect(database.integrations).toHaveLength(0)
+
+    await wrapper.vm.onShow()
+    await flushPromises()
+
+    expect(
+      testApp.store.getters['application/get'](DATABASE_ID).integrations
+    ).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
Follow-up to #6005, for the two minor comments on the review.

**A Slack click with no token no longer sends a request.** An export strips the token, so an imported bot looks configured. Clicking one used to spend a request to find out. The token is now checked first and the click is refused, so it is not charged for outbound traffic. The same check refuses an integration that is not a Slack bot, which `prepare_values` does not rule out.

**Reopening the field editor retries the integrations fetch.** The sub-form is not remounted between opens, so a fetch that failed once left the bot dropdown empty until a card was collapsed and expanded. `onShow` now asks again. A list that loaded is not fetched twice.
