### PR TITLE
feat: Allow markdown in more Builder elements and fields (option a - prefix)

### DIFF
--- a/backend/src/baserow/contrib/builder/elements/element_types.py
+++ b/backend/src/baserow/contrib/builder/elements/element_types.py
@@ -99,6 +99,7 @@ from baserow.core.formula import (
 )
 from baserow.core.formula.field import BASEROW_FORMULA_VERSION_INITIAL
 from baserow.core.formula.registries import formula_runtime_function_registry
+from baserow.core.formula.text_format import strip_format
 from baserow.core.formula.types import (
     BASEROW_FORMULA_MODE_SIMPLE,
     BaserowFormula,
@@ -682,7 +683,7 @@ class RecordSelectorElementType(
                 # of the element so that we can resolve them.
                 formula_context = kwargs | self.import_context_addition(instance)
                 tree = get_parse_tree_for_formula(
-                    instance.option_name_suffix["formula"]
+                    strip_format(instance.option_name_suffix["formula"])
                 )
                 properties = merge_dicts_no_duplicates(
                     properties,
@@ -2062,8 +2063,11 @@ class ChoiceElementType(FormElementTypeMixin, ElementType):
         options_tuple = set(
             element.choiceelementoption_set.values_list("value", "name")
         )
+        # A `null` value falls back to the name, which the frontend displays
+        # and submits without its text format marker.
         options = [
-            value if value is not None else name for (value, name) in options_tuple
+            value if value is not None else strip_format(name)
+            for (value, name) in options_tuple
         ]
 
         if element.option_type == ChoiceElement.OPTION_TYPE.FORMULAS:

--- a/backend/src/baserow/contrib/builder/formula_importer.py
+++ b/backend/src/baserow/contrib/builder/formula_importer.py
@@ -10,6 +10,7 @@ from baserow.core.formula import (
     BaserowFormulaObject,
     get_parse_tree_for_formula,
 )
+from baserow.core.formula.text_format import add_prefix, split_format
 from baserow.core.formula.types import BASEROW_FORMULA_MODE_RAW
 from baserow.core.services.formula_importer import BaserowFormulaImporter
 
@@ -56,12 +57,18 @@ def import_formula(
 
     formula = BaserowFormulaObject.to_formula(formula)
 
-    if formula["mode"] == BASEROW_FORMULA_MODE_RAW or not formula["formula"]:
+    # The text format marker is not part of the formula syntax. It is stripped
+    # before the paths are rewritten and added back to the result.
+    text_format, bare_formula = split_format(formula["formula"])
+
+    if formula["mode"] == BASEROW_FORMULA_MODE_RAW or not bare_formula:
         return formula
 
     try:
-        tree = get_parse_tree_for_formula(formula["formula"])
-        new_formula = BuilderFormulaImporter(id_mapping, **kwargs).visit(tree)
+        tree = get_parse_tree_for_formula(bare_formula)
+        new_formula = add_prefix(
+            BuilderFormulaImporter(id_mapping, **kwargs).visit(tree), text_format
+        )
     except (
         BaserowFormulaException,
         RecursionError,

--- a/backend/src/baserow/contrib/builder/mixins.py
+++ b/backend/src/baserow/contrib/builder/mixins.py
@@ -1,6 +1,7 @@
 from baserow.contrib.builder.formula_property_extractor import FormulaFieldVisitor
 from baserow.core.formula.parser.exceptions import BaserowFormulaSyntaxError
 from baserow.core.formula.parser.parser import get_parse_tree_for_formula
+from baserow.core.formula.text_format import strip_format
 from baserow.core.formula.types import BaserowFormulaObject
 from baserow.core.registry import InstanceWithFormulaMixin
 from baserow.core.utils import merge_dicts_no_duplicates
@@ -11,8 +12,11 @@ class BuilderInstanceWithFormulaMixin(InstanceWithFormulaMixin):
         result = {}
 
         for formula in self.formula_generator(instance):
-            # Figure out what our formula string is.
-            formula_str = BaserowFormulaObject.to_formula(formula)["formula"]
+            # Figure out what our formula string is, without its text format
+            # marker: a Markdown label still references its fields.
+            formula_str = strip_format(
+                BaserowFormulaObject.to_formula(formula)["formula"]
+            )
 
             if not formula_str:
                 continue

--- a/backend/src/baserow/core/formula/__init__.py
+++ b/backend/src/baserow/core/formula/__init__.py
@@ -9,6 +9,7 @@ from baserow.core.formula.parser.generated.BaserowFormula import BaserowFormula
 from baserow.core.formula.parser.generated.BaserowFormulaVisitor import (
     BaserowFormulaVisitor,
 )
+from baserow.core.formula.text_format import strip_format
 from baserow.core.formula.types import (
     BASEROW_FORMULA_MODE_RAW,
     BaserowFormulaObject,
@@ -45,12 +46,16 @@ def resolve_formula(
     :return: the formula result.
     """
 
+    # The text format marker is not part of the formula: it is never resolved
+    # and never part of the result.
+    bare_formula = strip_format(formula["formula"])
+
     # If we receive a blank formula string, don't attempt to parse it.
-    if not formula["formula"]:
-        return formula["formula"]
+    if not bare_formula:
+        return bare_formula
 
     if formula["mode"] == BASEROW_FORMULA_MODE_RAW:
-        return formula["formula"]
+        return bare_formula
 
-    tree = get_parse_tree_for_formula(formula["formula"])
+    tree = get_parse_tree_for_formula(bare_formula)
     return BaserowFormulaExecutionVisitor(functions, formula_context).visit(tree)

--- a/backend/src/baserow/core/formula/serializers.py
+++ b/backend/src/baserow/core/formula/serializers.py
@@ -16,6 +16,7 @@ from baserow.core.formula.parser.formula_validation_visitor import (
 )
 from baserow.core.formula.parser.parser import get_parse_tree_for_formula
 from baserow.core.formula.registries import formula_runtime_function_registry
+from baserow.core.formula.text_format import strip_format
 from baserow.core.formula.types import (
     BASEROW_FORMULA_MODE_ADVANCED,
     BASEROW_FORMULA_MODE_RAW,
@@ -117,7 +118,12 @@ class FormulaSerializerField(serializers.JSONField):
                 mode=BASEROW_FORMULA_MODE_SIMPLE,
             )
 
-        if not data["formula"] or data["mode"] == BASEROW_FORMULA_MODE_RAW:
+        # The stored formula may carry a text format marker, which is not part
+        # of the formula syntax: validate the bare formula and keep the stored
+        # value as it was given.
+        bare_formula = strip_format(data["formula"])
+
+        if not bare_formula or data["mode"] == BASEROW_FORMULA_MODE_RAW:
             return data
 
         # Inspect the `context` for an `ApplicationType`, we'll need to
@@ -132,7 +138,7 @@ class FormulaSerializerField(serializers.JSONField):
             )
 
         try:
-            tree = get_parse_tree_for_formula(data["formula"])
+            tree = get_parse_tree_for_formula(bare_formula)
             try:
                 BaserowFormulaValidationVisitor(
                     formula_runtime_function_registry,

--- a/backend/src/baserow/core/formula/text_format.py
+++ b/backend/src/baserow/core/formula/text_format.py
@@ -1,0 +1,52 @@
+from typing import Literal, Optional, Tuple
+
+TEXT_FORMAT_PLAIN: Literal["plain"] = "plain"
+TEXT_FORMAT_MARKDOWN: Literal["markdown"] = "markdown"
+TextFormat = Literal["plain", "markdown"]
+
+# A stored text value (a formula string, or a plain string such as a collection
+# field name) that begins with this sentinel is rendered as Markdown by the
+# frontend. The sentinel is part of the *stored* value only: it must be stripped
+# before the value is parsed, resolved, validated or displayed. Every consumer
+# goes through `split_format` / `strip_format` below, nothing else should
+# compare against the literal.
+MARKDOWN_PREFIX = "__markdown__"
+
+
+def split_format(value: Optional[str]) -> Tuple[TextFormat, Optional[str]]:
+    """
+    Splits a stored text value into its text format and the bare value.
+
+    :param value: The stored value, with or without the Markdown sentinel.
+    :return: A `(format, bare_value)` tuple. Non-string values are returned
+        unchanged with the `plain` format.
+    """
+
+    if isinstance(value, str) and value.startswith(MARKDOWN_PREFIX):
+        return TEXT_FORMAT_MARKDOWN, value[len(MARKDOWN_PREFIX) :]
+    return TEXT_FORMAT_PLAIN, value
+
+
+def strip_format(value: Optional[str]) -> Optional[str]:
+    """
+    Returns the bare value without the Markdown sentinel, if it has one.
+
+    :param value: The stored value.
+    :return: The value without its text format marker.
+    """
+
+    return split_format(value)[1]
+
+
+def add_prefix(bare_value: str, text_format: TextFormat = TEXT_FORMAT_MARKDOWN) -> str:
+    """
+    Marks a bare value with the given text format.
+
+    :param bare_value: The value without any text format marker.
+    :param text_format: The text format the value should be rendered with.
+    :return: The stored representation of the value.
+    """
+
+    if text_format == TEXT_FORMAT_MARKDOWN:
+        return f"{MARKDOWN_PREFIX}{bare_value}"
+    return bare_value

--- a/backend/tests/baserow/api/formula/test_formula_serializers.py
+++ b/backend/tests/baserow/api/formula/test_formula_serializers.py
@@ -3,7 +3,10 @@ from rest_framework.exceptions import ValidationError
 
 from baserow.core.formula.field import BASEROW_FORMULA_VERSION_INITIAL
 from baserow.core.formula.serializers import FormulaSerializerField
-from baserow.core.formula.types import BASEROW_FORMULA_MODE_SIMPLE
+from baserow.core.formula.types import (
+    BASEROW_FORMULA_MODE_RAW,
+    BASEROW_FORMULA_MODE_SIMPLE,
+)
 
 
 @pytest.mark.parametrize("context", [None, {}, {"application_type": None}])
@@ -22,3 +25,75 @@ def test_formula_serializer_field_without_context(context):
         "The formula serializer field requires "
         "an application type context to validate the formula arguments."
     )
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "__markdown__concat('a', 'b')",
+        "__markdown__'**a**'",
+        # The marker alone is an empty Markdown formula, which is valid.
+        "__markdown__",
+    ],
+)
+def test_formula_serializer_field_accepts_text_format_marker(formula):
+    from baserow.contrib.builder.application_types import BuilderApplicationType
+
+    field = FormulaSerializerField()
+    field._context = {"application_type": BuilderApplicationType}
+
+    result = field.to_internal_value(
+        {
+            "formula": formula,
+            "version": BASEROW_FORMULA_VERSION_INITIAL,
+            "mode": BASEROW_FORMULA_MODE_SIMPLE,
+        }
+    )
+
+    # The stored value keeps the marker, only the validation ignores it.
+    assert result["formula"] == formula
+
+
+def test_formula_serializer_field_accepts_text_format_marker_in_raw_mode():
+    field = FormulaSerializerField()
+    field._context = {}
+
+    result = field.to_internal_value(
+        {
+            "formula": "__markdown__**a**",
+            "version": BASEROW_FORMULA_VERSION_INITIAL,
+            "mode": BASEROW_FORMULA_MODE_RAW,
+        }
+    )
+
+    assert result["formula"] == "__markdown__**a**"
+
+
+@pytest.mark.parametrize(
+    "formula,code",
+    [
+        # An unknown data provider is still rejected behind the marker. An
+        # unknown function name raises `InvalidRuntimeFormula`, which the field
+        # does not translate into a validation error with or without the marker.
+        ("__markdown__get('foobar.1')", "invalid_formula_argument"),
+        ("__markdown__concat('a'", "invalid"),
+    ],
+)
+def test_formula_serializer_field_still_validates_behind_text_format_marker(
+    formula, code
+):
+    from baserow.contrib.builder.application_types import BuilderApplicationType
+
+    field = FormulaSerializerField()
+    field._context = {"application_type": BuilderApplicationType}
+
+    with pytest.raises(ValidationError) as exc:
+        field.to_internal_value(
+            {
+                "formula": formula,
+                "version": BASEROW_FORMULA_VERSION_INITIAL,
+                "mode": BASEROW_FORMULA_MODE_SIMPLE,
+            }
+        )
+
+    assert exc.value.detail[0].code == code

--- a/backend/tests/baserow/contrib/builder/api/domains/test_domain_public_views.py
+++ b/backend/tests/baserow/contrib/builder/api/domains/test_domain_public_views.py
@@ -2370,3 +2370,61 @@ def test_public_dispatch_data_source_with_refinements_referencing_trashed_field(
         "detail": "A data source sort is misconfigured: "
         "One or more sorted properties no longer exist.",
     }
+
+
+@pytest.mark.django_db
+def test_public_dispatch_data_source_view_returns_fields_behind_text_format_marker(
+    data_fixture,
+    api_client,
+    user_source_user_fixture,
+):
+    """
+    A field referenced only from a Markdown label, stored as `__markdown__get(...)`,
+    must be part of the public allowlist and returned by the dispatch.
+    """
+
+    user = user_source_user_fixture["user"]
+    table, fields, rows = data_fixture.build_table(
+        user=user,
+        columns=[
+            ("Food", "text"),
+            ("Spiciness", "number"),
+        ],
+        rows=[
+            ["Paneer Tikka", 5],
+            ["Gobi Manchurian", 8],
+        ],
+    )
+    page = user_source_user_fixture["page"]
+    data_source = data_fixture.create_builder_local_baserow_list_rows_data_source(
+        user=user,
+        page=page,
+        integration=user_source_user_fixture["integration"],
+        table=table,
+    )
+    data_fixture.create_builder_input_text_element(
+        page=page,
+        label=f"__markdown__get('data_source.{data_source.id}.*.field_{fields[0].id}')",
+    )
+
+    builder = user_source_user_fixture["builder"]
+    builder.workspace = None
+    builder.save()
+    data_fixture.create_builder_custom_domain(published_to=builder)
+
+    url = reverse(
+        "api:builder:domains:public_dispatch",
+        kwargs={"data_source_id": data_source.id},
+    )
+    user_token = user_source_user_fixture["user_source_user_token"]
+    response = api_client.post(url, HTTP_AUTHORIZATION=f"JWT {user_token}")
+
+    assert response.status_code == 200
+    # Only the field used by the Markdown label is returned.
+    assert response.json() == {
+        "has_next_page": False,
+        "results": [
+            {fields[0].name: "Paneer Tikka"},
+            {fields[0].name: "Gobi Manchurian"},
+        ],
+    }

--- a/backend/tests/baserow/contrib/builder/api/elements/test_table_element.py
+++ b/backend/tests/baserow/contrib/builder/api/elements/test_table_element.py
@@ -186,3 +186,51 @@ def test_cant_update_a_table_element_fields_with_wrong_field_property(
 
     assert response.status_code == HTTP_400_BAD_REQUEST
     assert response.json()["detail"]["fields"][0][0]["code"] == "INVALID_FIELD_PROPERTY"
+
+
+@pytest.mark.django_db
+def test_can_update_a_table_element_field_with_markdown_name(api_client, data_fixture):
+    """
+    A Markdown column header is stored as its name with the `__markdown__`
+    marker in front, which the API stores and returns as-is.
+    """
+
+    user, token = data_fixture.create_user_and_token()
+    table_element = data_fixture.create_builder_table_element(user=user)
+
+    url = reverse("api:builder:element:item", kwargs={"element_id": table_element.id})
+
+    response = api_client.patch(
+        url,
+        {
+            "fields": [
+                {
+                    "name": "__markdown__**Bold**",
+                    "type": "text",
+                    "value": "__markdown__get('data_source.123')",
+                    "uid": str(uuid.uuid4()),
+                },
+                {
+                    "name": "Plain",
+                    "type": "text",
+                    "value": "get('data_source.123')",
+                    "uid": str(uuid.uuid4()),
+                },
+            ],
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_200_OK
+    markdown_field, plain_field = response.json()["fields"]
+    assert markdown_field["name"] == "__markdown__**Bold**"
+    assert markdown_field["value"]["formula"] == "__markdown__get('data_source.123')"
+    assert plain_field["name"] == "Plain"
+
+    markdown_field, plain_field = table_element.fields.all()
+    assert markdown_field.name == "__markdown__**Bold**"
+    assert markdown_field.config["value"]["formula"] == (
+        "__markdown__get('data_source.123')"
+    )
+    assert plain_field.name == "Plain"

--- a/backend/tests/baserow/contrib/builder/api/elements/test_text_format_views.py
+++ b/backend/tests/baserow/contrib/builder/api/elements/test_text_format_views.py
@@ -1,0 +1,121 @@
+"""
+API tests for the Markdown text format of the form element labels and the
+choice element option names. The format is stored inside the value itself, as
+a `__markdown__` marker in front of the formula or name, so it goes through the
+regular formula validation.
+"""
+
+from django.urls import reverse
+
+import pytest
+from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
+
+from baserow.core.formula.text_format import MARKDOWN_PREFIX
+
+LABEL_ELEMENT_TYPES = [
+    "input_text",
+    "choice",
+    "checkbox",
+    "rating_input",
+    "datetime_picker",
+    "record_selector",
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("element_type", LABEL_ELEMENT_TYPES)
+def test_create_element_with_markdown_label(api_client, data_fixture, element_type):
+    user, token = data_fixture.create_user_and_token()
+    page = data_fixture.create_builder_page(user=user)
+    label = f"{MARKDOWN_PREFIX}concat('**', get('page_parameter.id'), '**')"
+
+    url = reverse("api:builder:element:list", kwargs={"page_id": page.id})
+    response = api_client.post(
+        url,
+        {"type": element_type, "label": {"formula": label, "mode": "simple"}},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_200_OK
+    assert response.json()["label"]["formula"] == label
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("element_type", LABEL_ELEMENT_TYPES)
+def test_update_element_markdown_label_is_still_validated(
+    api_client, data_fixture, element_type
+):
+    user, token = data_fixture.create_user_and_token()
+    page = data_fixture.create_builder_page(user=user)
+
+    url = reverse("api:builder:element:list", kwargs={"page_id": page.id})
+    response = api_client.post(
+        url,
+        {"type": element_type},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    element_id = response.json()["id"]
+
+    url = reverse("api:builder:element:item", kwargs={"element_id": element_id})
+    response = api_client.patch(
+        url,
+        {"label": {"formula": f"{MARKDOWN_PREFIX}'**Bold**'", "mode": "simple"}},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_200_OK
+    assert response.json()["label"]["formula"] == f"{MARKDOWN_PREFIX}'**Bold**'"
+
+    # The marker does not bypass the validation of the formula behind it.
+    response = api_client.patch(
+        url,
+        {
+            "label": {
+                "formula": f"{MARKDOWN_PREFIX}get('foobar.123')",
+                "mode": "simple",
+            }
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+    assert response.json()["detail"]["label"][0]["code"] == "invalid_formula_argument"
+
+
+@pytest.mark.django_db
+def test_choice_element_markdown_option_names(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    page = data_fixture.create_builder_page(user=user)
+
+    url = reverse("api:builder:element:list", kwargs={"page_id": page.id})
+    response = api_client.post(
+        url,
+        {
+            "type": "choice",
+            "options": [
+                {"name": f"{MARKDOWN_PREFIX}**Bold**", "value": None},
+                {"name": "Plain", "value": "plain"},
+            ],
+            "formula_name": {
+                "formula": f"{MARKDOWN_PREFIX}get('data_source.1.*.field_2')",
+                "mode": "simple",
+            },
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_200_OK
+    response_json = response.json()
+    assert [(o["name"], o["value"]) for o in response_json["options"]] == [
+        (f"{MARKDOWN_PREFIX}**Bold**", None),
+        ("Plain", "plain"),
+    ]
+    assert response_json["formula_name"]["formula"] == (
+        f"{MARKDOWN_PREFIX}get('data_source.1.*.field_2')"
+    )

--- a/backend/tests/baserow/contrib/builder/api/workflow_actions/test_workflow_actions_views.py
+++ b/backend/tests/baserow/contrib/builder/api/workflow_actions/test_workflow_actions_views.py
@@ -1684,3 +1684,60 @@ def test_create_row_action_can_access_the_field_of_previous_action(
     # The ID of the new row that was created by the first Workflow Action
     row_id = action_1.service.table.get_model().objects.all()[2].id
     assert getattr(results[0], fields_2[0].db_column) == str(row_id)
+
+
+@pytest.mark.django_db
+def test_notification_workflow_action_markdown_title_and_description(
+    api_client, data_fixture
+):
+    """
+    A Markdown title or description is stored with the `__markdown__` marker in
+    front of the formula, which the API validates, stores and returns as-is.
+    """
+
+    user, token = data_fixture.create_user_and_token()
+    page = data_fixture.create_builder_page(user=user)
+    element = data_fixture.create_builder_button_element(page=page)
+
+    url = reverse("api:builder:workflow_action:list", kwargs={"page_id": page.id})
+    response = api_client.post(
+        url,
+        {"type": "notification", "event": "click", "element_id": element.id},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    assert response.status_code == HTTP_200_OK
+
+    url = reverse(
+        "api:builder:workflow_action:item",
+        kwargs={"workflow_action_id": response.json()["id"]},
+    )
+    response = api_client.patch(
+        url,
+        {
+            "title": {"formula": "__markdown__'**Saved**'", "mode": "simple"},
+            "description": {
+                "formula": "__markdown__See [details](/details)",
+                "mode": "raw",
+            },
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_200_OK
+    assert response.json()["title"]["formula"] == "__markdown__'**Saved**'"
+    assert response.json()["description"]["formula"] == (
+        "__markdown__See [details](/details)"
+    )
+
+    response = api_client.patch(
+        url,
+        {"title": {"formula": "__markdown__get('foobar.1')", "mode": "simple"}},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+    assert response.json()["detail"]["title"][0]["code"] == "invalid_formula_argument"

--- a/backend/tests/baserow/contrib/builder/elements/test_element_types.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_element_types.py
@@ -1665,3 +1665,28 @@ def test_element_type_get_event_names(data_fixture):
     assert get_event_names(form) == ["submit"]
     assert get_event_names(table) == [f"{button_field.uid}_click"]
     assert get_event_names(menu) == [f"{button_item_uid}_click"]
+
+
+@pytest.mark.django_db
+def test_choice_element_is_valid_with_markdown_option_names(data_fixture):
+    """
+    An option without a value falls back to its name. A Markdown option name is
+    stored with the `__markdown__` marker, which the frontend neither displays nor
+    submits, so the fallback value is the bare name.
+    """
+
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    choice = ElementService().create_element(
+        user=user,
+        element_type=element_type_registry.get("choice"),
+        page=page,
+    )
+    choice.choiceelementoption_set.create(value=None, name="__markdown__**Bold**")
+    choice.choiceelementoption_set.create(value="plain", name="__markdown__Plain")
+
+    assert ChoiceElementType().is_valid(choice, "**Bold**", {}) == "**Bold**"
+    assert ChoiceElementType().is_valid(choice, "plain", {}) == "plain"
+
+    with pytest.raises(ValueError):
+        ChoiceElementType().is_valid(choice, "__markdown__**Bold**", {})

--- a/backend/tests/baserow/contrib/builder/elements/test_text_format_fields.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_text_format_fields.py
@@ -1,0 +1,188 @@
+"""
+Export/import tests for the Markdown text format of the form element labels,
+the choice element option names, the collection field names and the text
+collection field values. The format is stored inside the value itself, as a
+`__markdown__` marker in front of it, so there is no separate property to carry.
+"""
+
+from collections import defaultdict
+
+import pytest
+
+from baserow.contrib.builder.elements.handler import ElementHandler
+from baserow.contrib.builder.elements.registries import element_type_registry
+from baserow.contrib.builder.pages.service import PageService
+from baserow.core.formula import BaserowFormulaObject
+from baserow.core.formula.field import BASEROW_FORMULA_VERSION_INITIAL
+from baserow.core.formula.text_format import MARKDOWN_PREFIX
+from baserow.core.formula.types import BASEROW_FORMULA_MODE_SIMPLE
+from baserow.core.utils import MirrorDict
+
+# The element types with a Markdown-capable `label`.
+LABEL_ELEMENT_TYPES = [
+    "input_text",
+    "choice",
+    "checkbox",
+    "rating_input",
+    "datetime_picker",
+    "record_selector",
+]
+
+
+@pytest.fixture
+def data_source_pair(data_fixture):
+    """
+    A page with a list rows data source, and a duplicated page whose data
+    source has a different id, to check that `get()` paths are rewritten.
+    """
+
+    user, _ = data_fixture.create_user_and_token()
+    page = data_fixture.create_builder_page(user=user)
+    table, fields, _ = data_fixture.build_table(
+        user=user, columns=[("Name", "text")], rows=[["Foo"]]
+    )
+    data_source = data_fixture.create_builder_local_baserow_list_rows_data_source(
+        table=table, page=page
+    )
+    duplicated_page = PageService().duplicate_page(user, page)
+    data_source2 = duplicated_page.datasource_set.first()
+
+    return {
+        "user": user,
+        "page": page,
+        "field": fields[0],
+        "data_source": data_source,
+        "data_source2": data_source2,
+        "id_mapping": {"builder_data_sources": {data_source.id: data_source2.id}},
+    }
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("element_type_name", LABEL_ELEMENT_TYPES)
+def test_export_import_element_markdown_label(
+    data_fixture, data_source_pair, element_type_name
+):
+    """
+    The marker survives an export/import and the `get()` path behind it is
+    rewritten like any other formula.
+    """
+
+    element_type = element_type_registry.get(element_type_name)
+    data_source = data_source_pair["data_source"]
+    data_source2 = data_source_pair["data_source2"]
+    db_column = data_source_pair["field"].db_column
+    element = data_fixture.create_builder_element(
+        type(element_type),
+        data_source_pair["user"],
+        page=data_source_pair["page"],
+        label=f"{MARKDOWN_PREFIX}get('data_source.{data_source.id}.0.{db_column}')",
+    )
+
+    exported = element_type.export_serialized(element)
+    assert exported["label"]["formula"] == (
+        f"{MARKDOWN_PREFIX}get('data_source.{data_source.id}.0.{db_column}')"
+    )
+
+    imported_element = ElementHandler().import_element(
+        data_source_pair["page"], exported, data_source_pair["id_mapping"]
+    )
+
+    assert imported_element.id != element.id
+    assert imported_element.label == BaserowFormulaObject(
+        formula=f"{MARKDOWN_PREFIX}get('data_source.{data_source2.id}.0.{db_column}')",
+        version=BASEROW_FORMULA_VERSION_INITIAL,
+        mode=BASEROW_FORMULA_MODE_SIMPLE,
+    )
+
+
+@pytest.mark.django_db
+def test_export_import_choice_element_markdown_option_names(data_fixture):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    element = data_fixture.create_builder_choice_element(user=user, page=page)
+    element.choiceelementoption_set.create(value=None, name=f"{MARKDOWN_PREFIX}**a**")
+    element.choiceelementoption_set.create(value="b", name="plain b")
+    element_type = element.get_type()
+
+    exported = element_type.export_serialized(element)
+    assert [option["name"] for option in exported["options"]] == [
+        f"{MARKDOWN_PREFIX}**a**",
+        "plain b",
+    ]
+
+    id_mapping = defaultdict(lambda: MirrorDict())
+    imported_element = ElementHandler().import_element(page, exported, id_mapping)
+
+    assert list(
+        imported_element.choiceelementoption_set.values_list("value", "name")
+    ) == [(None, f"{MARKDOWN_PREFIX}**a**"), ("b", "plain b")]
+
+
+@pytest.mark.django_db
+def test_export_import_collection_field_markdown_name(data_fixture):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    table_element = data_fixture.create_builder_table_element(
+        user=user,
+        page=page,
+        fields=[
+            {
+                "name": f"{MARKDOWN_PREFIX}**Bold** header",
+                "type": "text",
+                "config": {"value": "'x'"},
+            },
+            {"name": "Plain header", "type": "text", "config": {"value": "'y'"}},
+        ],
+    )
+
+    exported = table_element.get_type().export_serialized(table_element)
+    assert exported["fields"][0]["name"] == f"{MARKDOWN_PREFIX}**Bold** header"
+    assert exported["fields"][1]["name"] == "Plain header"
+
+    id_mapping = defaultdict(lambda: MirrorDict())
+    imported_table_element = ElementHandler().import_element(page, exported, id_mapping)
+
+    markdown_field, plain_field = imported_table_element.fields.all()
+    assert markdown_field.name == f"{MARKDOWN_PREFIX}**Bold** header"
+    assert plain_field.name == "Plain header"
+
+
+@pytest.mark.django_db
+def test_export_import_text_collection_field_markdown_value(
+    data_fixture, data_source_pair
+):
+    """
+    The text collection field value lives in the JSON `config`, and is imported
+    through the same formula importer as the element formulas.
+    """
+
+    data_source = data_source_pair["data_source"]
+    data_source2 = data_source_pair["data_source2"]
+    db_column = data_source_pair["field"].db_column
+    table_element = data_fixture.create_builder_table_element(
+        page=data_source_pair["page"],
+        data_source=data_source,
+        fields=[
+            {
+                "name": "Foo Field",
+                "type": "text",
+                "config": {
+                    "value": f"{MARKDOWN_PREFIX}get('data_source.{data_source.id}.0.{db_column}')"
+                },
+            },
+        ],
+    )
+
+    exported = table_element.get_type().export_serialized(table_element)
+    imported_table_element = ElementHandler().import_element(
+        data_source_pair["page"], exported, data_source_pair["id_mapping"]
+    )
+
+    imported_field = imported_table_element.fields.get(name="Foo Field")
+    assert imported_field.config == {
+        "value": BaserowFormulaObject(
+            formula=f"{MARKDOWN_PREFIX}get('data_source.{data_source2.id}.0.{db_column}')",
+            version=BASEROW_FORMULA_VERSION_INITIAL,
+            mode=BASEROW_FORMULA_MODE_SIMPLE,
+        )
+    }

--- a/backend/tests/baserow/contrib/builder/test_formula_importer.py
+++ b/backend/tests/baserow/contrib/builder/test_formula_importer.py
@@ -137,3 +137,49 @@ def test_formula_import_ignores_parseable_but_invalid_formula(
     result = import_formula(BaserowFormulaObject.create(invalid_formula), id_mapping)
 
     assert result["formula"] == invalid_formula
+
+
+@pytest.mark.django_db
+def test_formula_import_formula_keeps_text_format_marker(
+    mutable_builder_data_provider_registry,
+):
+    """
+    A Markdown formula is stored with the `__markdown__` marker in front of it.
+    The marker is not part of the formula: the `get()` paths behind it are
+    rewritten as usual and the marker is kept on the result.
+    """
+
+    mutable_builder_data_provider_registry.register(TestDataProviderTypeWithImport())
+    id_mapping = {"first": {1: 10}, "second": {10: 42}}
+
+    result = import_formula(
+        BaserowFormulaObject.create("__markdown__get('test_provider.1.10')"),
+        id_mapping,
+    )
+
+    assert result["formula"] == "__markdown__get('test_provider.10.42')"
+
+
+@pytest.mark.django_db
+# `stored_formula` rather than `formula`, which `pytest_generate_tests` above
+# parametrizes for the whole module.
+@pytest.mark.parametrize(
+    "stored_formula,mode",
+    [
+        ("__markdown__", "simple"),
+        ("__markdown__get('test_provider.1.10')", "raw"),
+        ("__markdown__'plain text'", "simple"),
+    ],
+)
+def test_formula_import_formula_marker_only_raw_or_literal(
+    stored_formula, mode, mutable_builder_data_provider_registry
+):
+    mutable_builder_data_provider_registry.register(TestDataProviderTypeWithImport())
+    id_mapping = {"first": {1: 10}, "second": {10: 42}}
+
+    result = import_formula(
+        BaserowFormulaObject.create(stored_formula, mode=mode),
+        id_mapping,
+    )
+
+    assert result["formula"] == stored_formula

--- a/backend/tests/baserow/contrib/builder/test_formula_property_extractor.py
+++ b/backend/tests/baserow/contrib/builder/test_formula_property_extractor.py
@@ -1130,3 +1130,39 @@ def test_get_builder_used_property_names_returns_merged_property_names_integrati
             ],  # From workflow_action2
         },
     }
+
+
+@pytest.mark.django_db
+def test_get_element_property_names_includes_fields_behind_text_format_marker(
+    data_fixture,
+):
+    """
+    A Markdown label is stored as `__markdown__get(...)`. The public page
+    allowlist must still see the fields it references, otherwise the published
+    element would render blank.
+    """
+
+    user = data_fixture.create_user()
+    table, fields, rows = data_fixture.build_table(
+        user=user,
+        columns=[("Food", "text"), ("Spiciness", "number")],
+        rows=[["Paneer Tikka", 5]],
+    )
+    builder = data_fixture.create_builder_application(user=user)
+    integration = data_fixture.create_local_baserow_integration(
+        user=user, application=builder
+    )
+    page = data_fixture.create_builder_page(builder=builder)
+    data_source = data_fixture.create_builder_local_baserow_list_rows_data_source(
+        page=page, integration=integration, table=table
+    )
+    element = data_fixture.create_builder_input_text_element(
+        page=page,
+        label=f"__markdown__get('data_source.{data_source.id}.*.field_{fields[0].id}')",
+    )
+
+    results = get_element_property_names([element], {element.id: element})
+
+    assert results == {
+        "external": {data_source.service_id: [f"field_{fields[0].id}"]},
+    }

--- a/backend/tests/baserow/contrib/builder/workflow_actions/test_workflow_action_types.py
+++ b/backend/tests/baserow/contrib/builder/workflow_actions/test_workflow_action_types.py
@@ -436,3 +436,34 @@ def test_import_workflow_action_keeps_unknown_dynamic_event(data_fixture, event)
     )
 
     assert imported_workflow_action.event == event
+
+
+@pytest.mark.django_db
+def test_export_import_notification_workflow_action_markdown_formulas(data_fixture):
+    page = data_fixture.create_builder_page()
+    workflow_action_type = NotificationWorkflowActionType()
+    button_1 = data_fixture.create_builder_button_element(page=page)
+    button_2 = data_fixture.create_builder_button_element(page=page)
+
+    exported_workflow_action = data_fixture.create_notification_workflow_action(
+        page=page,
+        element=button_1,
+        event=EventTypes.CLICK,
+        title="__markdown__'**Saved**'",
+        description="__markdown__'See [details](/details)'",
+    )
+    serialized = workflow_action_type.export_serialized(exported_workflow_action)
+    assert serialized["title"]["formula"] == "__markdown__'**Saved**'"
+
+    id_mapping = {
+        "builder_data_sources": {},
+        "builder_page_elements": {button_1.id: button_2.id},
+    }
+    imported_workflow_action = workflow_action_type.import_serialized(
+        page, serialized, id_mapping
+    )
+
+    assert imported_workflow_action.title["formula"] == "__markdown__'**Saved**'"
+    assert imported_workflow_action.description["formula"] == (
+        "__markdown__'See [details](/details)'"
+    )

--- a/backend/tests/baserow/core/formula/test_text_format.py
+++ b/backend/tests/baserow/core/formula/test_text_format.py
@@ -1,0 +1,76 @@
+"""
+The text format of a Builder text is stored inside the value itself, as a
+`__markdown__` marker in front of the formula. These tests cover the helpers and
+the core consumers that must ignore the marker.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from baserow.core.formula import BaserowFormulaObject, resolve_formula
+from baserow.core.formula.registries import formula_runtime_function_registry
+from baserow.core.formula.text_format import (
+    MARKDOWN_PREFIX,
+    TEXT_FORMAT_MARKDOWN,
+    TEXT_FORMAT_PLAIN,
+    add_prefix,
+    split_format,
+    strip_format,
+)
+from baserow.core.formula.types import (
+    BASEROW_FORMULA_MODE_RAW,
+    BASEROW_FORMULA_MODE_SIMPLE,
+)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("__markdown__get('a.b')", (TEXT_FORMAT_MARKDOWN, "get('a.b')")),
+        ("__markdown__", (TEXT_FORMAT_MARKDOWN, "")),
+        ("get('a.b')", (TEXT_FORMAT_PLAIN, "get('a.b')")),
+        # Only a leading marker counts, and a marker inside a literal is text.
+        ("'__markdown__**a**'", (TEXT_FORMAT_PLAIN, "'__markdown__**a**'")),
+        (" __markdown__a", (TEXT_FORMAT_PLAIN, " __markdown__a")),
+        ("", (TEXT_FORMAT_PLAIN, "")),
+        (None, (TEXT_FORMAT_PLAIN, None)),
+        (5, (TEXT_FORMAT_PLAIN, 5)),
+    ],
+)
+def test_split_format(value, expected):
+    assert split_format(value) == expected
+    assert strip_format(value) == expected[1]
+
+
+def test_add_prefix():
+    assert add_prefix("get('a.b')") == f"{MARKDOWN_PREFIX}get('a.b')"
+    assert add_prefix("get('a.b')", TEXT_FORMAT_MARKDOWN) == "__markdown__get('a.b')"
+    assert add_prefix("get('a.b')", TEXT_FORMAT_PLAIN) == "get('a.b')"
+    assert add_prefix("", TEXT_FORMAT_MARKDOWN) == "__markdown__"
+    assert split_format(add_prefix("x")) == (TEXT_FORMAT_MARKDOWN, "x")
+
+
+@pytest.mark.parametrize(
+    "formula,mode,expected",
+    [
+        ("'**a**'", BASEROW_FORMULA_MODE_SIMPLE, "**a**"),
+        ("__markdown__'**a**'", BASEROW_FORMULA_MODE_SIMPLE, "**a**"),
+        ("__markdown__concat('**a**', 'b')", BASEROW_FORMULA_MODE_SIMPLE, "**a**b"),
+        # A marker inside the resolved output is just text.
+        ("'__markdown__**a**'", BASEROW_FORMULA_MODE_SIMPLE, "__markdown__**a**"),
+        ("**a**", BASEROW_FORMULA_MODE_RAW, "**a**"),
+        ("__markdown__**a**", BASEROW_FORMULA_MODE_RAW, "**a**"),
+        ("", BASEROW_FORMULA_MODE_SIMPLE, ""),
+        ("__markdown__", BASEROW_FORMULA_MODE_SIMPLE, ""),
+        ("__markdown__", BASEROW_FORMULA_MODE_RAW, ""),
+    ],
+)
+def test_resolve_formula_ignores_the_text_format_marker(formula, mode, expected):
+    result = resolve_formula(
+        BaserowFormulaObject.create(formula, mode=mode),
+        formula_runtime_function_registry,
+        MagicMock(),
+    )
+
+    assert result == expected

--- a/changelog/entries/unreleased/feature/4330_allow_markdown_formatting_in_the_text_field_of_the_table_ele.json
+++ b/changelog/entries/unreleased/feature/4330_allow_markdown_formatting_in_the_text_field_of_the_table_ele.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Allow Markdown formatting in more Application Builder texts: the Text field and column headers of the Table element, form field labels, Choice element options, the notification toast and the File input help text.",
+    "issue_origin": "github",
+    "issue_number": 4330,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-08-25"
+}

--- a/e2e-tests/tests/builder/events/showNotification.spec.ts
+++ b/e2e-tests/tests/builder/events/showNotification.spec.ts
@@ -48,6 +48,6 @@ test.describe("Builder page show notification action test suite", () => {
 
     await eventsTab.getByText("Show Notification").click();
 
-    await expect(eventsTab.getByText("Title")).toBeVisible();
+    await expect(eventsTab.getByText("Title", { exact: true })).toBeVisible();
   });
 });

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/shared/formula_utils.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/shared/formula_utils.py
@@ -7,6 +7,7 @@ from typing import Any
 from baserow.core.formula.parser.exceptions import BaserowFormulaException
 from baserow.core.formula.parser.generated.BaserowFormula import BaserowFormula
 from baserow.core.formula.parser.parser import get_parse_tree_for_formula
+from baserow.core.formula.text_format import add_prefix, split_format, strip_format
 from baserow.core.formula.types import (
     BASEROW_FORMULA_MODE_SIMPLE,
     BaserowFormulaMode,
@@ -103,7 +104,7 @@ def is_valid_formula(value: str) -> bool:
     """
 
     try:
-        get_parse_tree_for_formula(value)
+        get_parse_tree_for_formula(strip_format(value))
     except (BaserowFormulaException, RecursionError):
         return False
     return True
@@ -122,7 +123,7 @@ def is_string_literal(value: str) -> bool:
     """
 
     try:
-        tree = get_parse_tree_for_formula(value)
+        tree = get_parse_tree_for_formula(strip_format(value))
     except (BaserowFormulaException, RecursionError):
         return False
     return isinstance(tree.expr(), BaserowFormula.StringLiteralContext)
@@ -173,10 +174,16 @@ def ensure_valid_formula(formula: str) -> str:
     :return: The formula itself, or a string literal fallback.
     """
 
-    if not formula or not isinstance(formula, str) or is_valid_formula(formula):
+    if not formula or not isinstance(formula, str):
         return formula
 
-    fallback = wrap_static_string(formula)
+    # The Markdown text format marker is not part of the formula syntax: it is
+    # kept as-is and only the bare formula is checked and, if needed, quoted.
+    text_format, bare_formula = split_format(formula)
+    if not bare_formula or is_valid_formula(bare_formula):
+        return formula
+
+    fallback = add_prefix(wrap_static_string(bare_formula), text_format)
     logger.warning(
         "The assistant produced an invalid formula, storing it as a static "
         "string literal instead: %s",

--- a/enterprise/backend/tests/baserow_enterprise_tests/assistant/test_formula_utils.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/assistant/test_formula_utils.py
@@ -1,0 +1,53 @@
+"""
+The assistant validates the formulas it persists. A Builder Markdown text is
+stored with the `__markdown__` marker in front of the formula, which is not
+part of the formula syntax.
+"""
+
+import pytest
+
+from baserow_enterprise.assistant.tools.shared.formula_utils import (
+    ensure_valid_formula,
+    is_string_literal,
+    is_valid_formula,
+    wrap_static_string,
+)
+
+
+@pytest.mark.parametrize(
+    "formula,expected",
+    [
+        ("__markdown__'Submit'", True),
+        ("__markdown__concat('a', 'b')", True),
+        ("__markdown__'Managers' Week'", False),
+        ("concat('a', 'b')", True),
+        ("'Managers' Week'", False),
+    ],
+)
+def test_is_valid_formula_ignores_text_format_marker(formula, expected):
+    assert is_valid_formula(formula) is expected
+
+
+def test_is_string_literal_ignores_text_format_marker():
+    assert is_string_literal("__markdown__'Submit'") is True
+    assert is_string_literal("__markdown__concat('a')") is False
+    assert wrap_static_string("__markdown__'Submit'") == "__markdown__'Submit'"
+
+
+@pytest.mark.parametrize(
+    "formula,expected",
+    [
+        # Valid formulas are kept as-is, marker included.
+        ("__markdown__'**Submit**'", "__markdown__'**Submit**'"),
+        (
+            "__markdown__get('data_source.1.field_2')",
+            "__markdown__get('data_source.1.field_2')",
+        ),
+        ("__markdown__", "__markdown__"),
+        # An invalid formula is quoted behind the marker, not with it.
+        ("__markdown__Managers' Week", "__markdown__'Managers\\' Week'"),
+        ("Managers' Week", "'Managers\\' Week'"),
+    ],
+)
+def test_ensure_valid_formula_keeps_text_format_marker(formula, expected):
+    assert ensure_valid_formula(formula) == expected

--- a/enterprise/backend/tests/baserow_enterprise_tests/builder/elements/test_element_types.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/builder/elements/test_element_types.py
@@ -1,4 +1,5 @@
 import json
+from collections import defaultdict
 from unittest.mock import MagicMock, patch
 
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -11,9 +12,11 @@ from baserow.api.exceptions import RequestBodyValidationException
 from baserow.contrib.builder.data_sources.builder_dispatch_context import (
     BuilderDispatchContext,
 )
+from baserow.contrib.builder.elements.handler import ElementHandler
 from baserow.contrib.builder.elements.registries import element_type_registry
 from baserow.contrib.builder.elements.service import ElementService
 from baserow.contrib.builder.workflow_actions.models import EventTypes
+from baserow.core.utils import MirrorDict
 from baserow.test_utils.helpers import AnyInt, AnyStr
 from baserow_enterprise.builder.elements.element_types import (
     AuthFormElementType,
@@ -309,3 +312,34 @@ def test_auth_form_element_get_event_names(data_fixture):
     assert AuthFormElementType().get_event_names(auth_form) == [
         EventTypes.AFTER_LOGIN.value
     ]
+
+
+@pytest.mark.django_db
+def test_export_import_file_input_element_markdown_formulas(
+    data_fixture, enable_enterprise
+):
+    """
+    A Markdown label or help text is stored with the `__markdown__` marker in
+    front of the formula, which survives an export/import.
+    """
+
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    element = data_fixture.create_builder_element(
+        FileInputElementType,
+        user,
+        page=page,
+        label="__markdown__'Your **CV**'",
+        help_text="__markdown__'# Drop it'",
+    )
+    element_type = element.get_type()
+
+    exported = element_type.export_serialized(element)
+    assert exported["label"]["formula"] == "__markdown__'Your **CV**'"
+    assert exported["help_text"]["formula"] == "__markdown__'# Drop it'"
+
+    imported_element = ElementHandler().import_element(
+        page, exported, defaultdict(lambda: MirrorDict())
+    )
+    assert imported_element.label["formula"] == "__markdown__'Your **CV**'"
+    assert imported_element.help_text["formula"] == "__markdown__'# Drop it'"

--- a/enterprise/web-frontend/modules/baserow_enterprise/builder/components/elements/FileInputElement.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/builder/components/elements/FileInputElement.vue
@@ -7,13 +7,28 @@
     :required="element.required"
     :style="getStyleOverride('input')"
   >
+    <template #label>
+      <FormattedText
+        :content="resolvedLabel"
+        :format="labelFormat"
+        preset="inlineLinks"
+      />
+    </template>
     <ABFileInput
       v-model="computedInputValue"
       :multiple="element.multiple"
       :help-text="resolvedHelpText"
       :accept="allowedExtensions"
       :preview="element.preview"
-    />
+    >
+      <template #help-text>
+        <FormattedText
+          :content="resolvedHelpText"
+          :format="helpTextFormat"
+          preset="block"
+        />
+      </template>
+    </ABFileInput>
   </ABFormGroup>
 </template>
 
@@ -21,11 +36,14 @@
 import formElement from '@baserow/modules/builder/mixins/formElement'
 import { ensureString } from '@baserow/modules/core/utils/validator'
 import UserFileService from '@baserow/modules/core/services/userFile'
+import FormattedText from '@baserow/modules/builder/components/FormattedText'
+import { getFormulaFormat } from '@baserow/modules/core/formula/textFormat'
 
 import { FileInputElementType } from '@baserow_enterprise/builder/elementTypes'
 
 export default {
   name: 'FileInputElement',
+  components: { FormattedText },
   mixins: [formElement],
   props: {
     /**
@@ -50,6 +68,12 @@ export default {
     }
   },
   computed: {
+    labelFormat() {
+      return getFormulaFormat(this.element.label)
+    },
+    helpTextFormat() {
+      return getFormulaFormat(this.element.help_text)
+    },
     computedInputValue: {
       get() {
         return this.inputValue

--- a/enterprise/web-frontend/modules/baserow_enterprise/builder/components/elements/FileInputElementForm.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/builder/components/elements/FileInputElementForm.vue
@@ -18,6 +18,10 @@
         :placeholder="$t('generalForm.labelPlaceholder')"
       />
     </FormGroup>
+    <ValueFormatSelector
+      v-model="values.label"
+      :label="$t('textFormatSelector.labelFormat')"
+    />
     <FormGroup
       :label="$t('fileInputElementForm.helpTextTitle')"
       class="margin-bottom-2"
@@ -29,6 +33,10 @@
         :placeholder="$t('fileInputElementForm.helpTextPlaceholder')"
       />
     </FormGroup>
+    <ValueFormatSelector
+      v-model="values.help_text"
+      :label="$t('fileInputElementForm.helpTextFormat')"
+    />
     <hr />
     <FormGroup
       :label="
@@ -155,6 +163,7 @@
 import InjectedFormulaInput from '@baserow/modules/core/components/formula/InjectedFormulaInput.vue'
 import CustomStyleButton from '@baserow/modules/builder/components/elements/components/forms/style/CustomStyleButton'
 import formElementForm from '@baserow/modules/builder/mixins/formElementForm'
+import ValueFormatSelector from '@baserow/modules/builder/components/elements/components/forms/ValueFormatSelector'
 import { useVuelidate } from '@vuelidate/core'
 import {
   required,
@@ -166,7 +175,7 @@ import {
 
 export default {
   name: 'FileInputElementForm',
-  components: { InjectedFormulaInput, CustomStyleButton },
+  components: { InjectedFormulaInput, CustomStyleButton, ValueFormatSelector },
   mixins: [formElementForm],
   setup() {
     return { v$: useVuelidate() }

--- a/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
+++ b/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
@@ -724,7 +724,8 @@
     "preview": "Preview images?",
     "maxFileSize": "Maximum file size",
     "maxFileSizePlaceholder": "Enter a number...",
-    "addFileType": "Add file type"
+    "addFileType": "Add file type",
+    "helpTextFormat": "Help text format"
   },
   "fileInputElement": {
     "defaultHelpText": "Drag and drop files here or click to select",

--- a/enterprise/web-frontend/test/unit/enterprise/builder/components/fileInputElement.spec.js
+++ b/enterprise/web-frontend/test/unit/enterprise/builder/components/fileInputElement.spec.js
@@ -1,0 +1,81 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import FileInputElement from '@baserow_enterprise/builder/components/elements/FileInputElement.vue'
+import { MARKDOWN_PREFIX } from '@baserow/modules/core/formula/textFormat'
+
+describe('FileInputElement', () => {
+  let store = null
+
+  beforeEach(() => {
+    store = useNuxtApp().$store
+  })
+
+  const mountFileInput = async (elementOverrides = {}) => {
+    const page = { id: 1, elements: [] }
+    const builder = { id: 1, theme: { primary_color: '#ccc' }, pages: [page] }
+    const mode = 'public'
+    const element = {
+      id: 44,
+      type: 'input_file',
+      label: { mode: 'raw', formula: 'Your **CV** ([tips](/tips))' },
+      help_text: { mode: 'raw', formula: '# Drop it\n\nPDF **only**' },
+      default_url: { formula: '' },
+      default_name: { formula: '' },
+      required: false,
+      multiple: false,
+      preview: false,
+      allowed_filetypes: [],
+      max_filesize: 5,
+      page_id: page.id,
+      styles: {},
+      ...elementOverrides,
+    }
+
+    store.dispatch('element/forceCreate', { page, element })
+
+    return mountSuspended(FileInputElement, {
+      props: { element },
+      global: {
+        provide: {
+          builder,
+          currentPage: page,
+          elementPage: page,
+          mode,
+          applicationContext: { builder, page, mode },
+          element,
+          workspace: {},
+        },
+      },
+    })
+  }
+
+  test('renders the label and help text as-is by default', async () => {
+    const wrapper = await mountFileInput()
+
+    expect(wrapper.find('.ab-form-group__label').text()).toBe(
+      'Your **CV** ([tips](/tips))'
+    )
+    expect(wrapper.find('.ab-file-input .ab-heading').exists()).toBe(false)
+    expect(wrapper.find('.ab-file-input').text()).toContain('# Drop it')
+  })
+
+  test('renders a Markdown label with links and block Markdown help text', async () => {
+    const wrapper = await mountFileInput({
+      label: {
+        mode: 'raw',
+        formula: `${MARKDOWN_PREFIX}Your **CV** ([tips](/tips))`,
+      },
+      help_text: {
+        mode: 'raw',
+        formula: `${MARKDOWN_PREFIX}# Drop it\n\nPDF **only**`,
+      },
+    })
+
+    const label = wrapper.find('.ab-form-group__label')
+    expect(label.find('strong').text()).toBe('CV')
+    expect(label.find('a.ab-link').attributes('href')).toBe('/tips')
+
+    const helpText = wrapper.find('.ab-file-input')
+    expect(helpText.find('.ab-heading').text()).toBe('Drop it')
+    expect(helpText.find('strong').text()).toBe('only')
+  })
+})

--- a/web-frontend/modules/builder/collectionFieldTypes.js
+++ b/web-frontend/modules/builder/collectionFieldTypes.js
@@ -24,6 +24,7 @@ import { pathParametersInError } from '@baserow/modules/builder/utils/params'
 import { ClickEvent } from '@baserow/modules/builder/eventTypes'
 import { ThemeConfigBlockType } from '@baserow/modules/builder/themeConfigBlockTypes'
 import { LINK_VARIANTS } from '@baserow/modules/builder/enums'
+import { getFormulaFormat } from '@baserow/modules/core/formula/textFormat'
 
 export class CollectionFieldType extends Registerable {
   get name() {
@@ -140,7 +141,10 @@ export class TextCollectionFieldType extends CollectionFieldType {
   }
 
   getProps(field, { resolveFormula, applicationContext }) {
-    return { value: ensureString(resolveFormula(field.value)) }
+    return {
+      value: ensureString(resolveFormula(field.value)),
+      format: getFormulaFormat(field.value),
+    }
   }
 
   getOrder() {

--- a/web-frontend/modules/builder/components/ApplicationBuilderFormulaInput.vue
+++ b/web-frontend/modules/builder/components/ApplicationBuilderFormulaInput.vue
@@ -17,6 +17,7 @@
 import FormulaInputField from '@baserow/modules/core/components/formula/FormulaInputField'
 import { DataSourceDataProviderType } from '@baserow/modules/builder/dataProviderTypes'
 import { buildFormulaFunctionNodes } from '@baserow/modules/core/formula'
+import { addPrefix, splitFormat } from '@baserow/modules/core/formula/textFormat'
 import { getDataNodesFromDataProvider } from '@baserow/modules/core/utils/dataProviders'
 import { useApplicationContext } from '@baserow/modules/builder/mixins/useApplicationContext'
 
@@ -106,12 +107,19 @@ const nodesHierarchy = computed(() => {
 })
 
 /**
+ * The stored formula may begin with a text format marker (see
+ * `core/formula/textFormat`). It is not part of the formula: the editor never
+ * shows it, and it is added back to whatever the editor emits.
+ */
+const formulaParts = computed(() => splitFormat(currentValue.value.formula))
+
+/**
  * Extract the expression string from the value object, the FormulaInputField
  * component only needs the expression string itself.
  * @returns {String} The expression string.
  */
 const formulaStr = computed(() => {
-  return currentValue.value.formula
+  return formulaParts.value.value
 })
 
 const dataSourceLoading = computed(() => {
@@ -147,14 +155,15 @@ const dataExplorerLoading = computed(() => {
  * @param {String} newFormulaStr The new expression string.
  */
 const updatedFormulaStr = (newFormulaStr) => {
+  const formula = addPrefix(newFormulaStr, formulaParts.value.format)
   emit('input', {
     ...currentValue.value,
-    formula: newFormulaStr,
+    formula,
     mode: localMode.value,
   })
   emit('update:modelValue', {
     ...currentValue.value,
-    formula: newFormulaStr,
+    formula,
     mode: localMode.value,
   })
 }

--- a/web-frontend/modules/builder/components/BuilderToasts.vue
+++ b/web-frontend/modules/builder/components/BuilderToasts.vue
@@ -8,8 +8,24 @@
       close-button
       @close="closeToast(toast)"
     >
-      <template #title>{{ toast.title }}</template>
-      <div>{{ toast.message }}</div>
+      <template #title>
+        <FormattedText
+          :content="toast.title"
+          :format="toast.titleFormat"
+          preset="inline"
+          :builder="builder"
+          :mode="mode"
+        />
+      </template>
+      <div>
+        <FormattedText
+          :content="toast.message"
+          :format="toast.messageFormat"
+          preset="restrictedBlock"
+          :builder="builder"
+          :mode="mode"
+        />
+      </div>
       <details v-if="toast.details" class="ab-toast__details">
         <summary class="ab-toast__details-summary">
           {{ $t('builderToast.details') }}
@@ -26,11 +42,19 @@
 import { mapGetters } from 'vuex'
 
 import BuilderToast from '@baserow/modules/builder/components/BuilderToast'
+import FormattedText from '@baserow/modules/builder/components/FormattedText'
 
 export default {
   name: 'BuilderToasts',
   components: {
     BuilderToast,
+    FormattedText,
+  },
+  // Needed to resolve links in Markdown toasts. The public page provides both,
+  // the editor preview only provides the builder.
+  inject: {
+    builder: { default: null },
+    mode: { default: 'editing' },
   },
   computed: {
     ...mapGetters({

--- a/web-frontend/modules/builder/components/FormattedText.vue
+++ b/web-frontend/modules/builder/components/FormattedText.vue
@@ -1,0 +1,94 @@
+<template>
+  <MarkdownIt
+    v-if="isMarkdown"
+    :content="text"
+    :inline="markdownPreset.inline"
+    :rules="markdownPreset.rules"
+    :disabled-rules="markdownPreset.disabledRules"
+    @click="onMarkdownClick"
+  />
+  <template v-else>{{ text }}</template>
+</template>
+
+<script>
+import { TEXT_FORMAT_TYPES } from '@baserow/modules/builder/enums'
+import {
+  MARKDOWN_PRESETS,
+  createApplicationBuilderMarkdownPreset,
+  handleMarkdownClick,
+} from '@baserow/modules/builder/utils/markdown'
+
+/**
+ * Renders a user-provided text either as-is or as Markdown, depending on its
+ * `format`, using one of the Application Builder rendering presets.
+ *
+ * `builder` and `mode` are needed to resolve internal links; they're injected
+ * from the surrounding element by default, and can be passed explicitly by
+ * consumers living outside an element (e.g. the toasts).
+ */
+export default {
+  name: 'FormattedText',
+  inject: {
+    injectedBuilder: { from: 'builder', default: null },
+    injectedMode: { from: 'mode', default: null },
+  },
+  props: {
+    content: {
+      type: [String, Number],
+      required: false,
+      default: '',
+    },
+    format: {
+      type: String,
+      required: false,
+      default: TEXT_FORMAT_TYPES.PLAIN,
+    },
+    preset: {
+      type: String,
+      required: false,
+      default: MARKDOWN_PRESETS.BLOCK,
+      validator: (value) => Object.values(MARKDOWN_PRESETS).includes(value),
+    },
+    builder: {
+      type: Object,
+      required: false,
+      default: null,
+    },
+    mode: {
+      type: String,
+      required: false,
+      default: null,
+    },
+  },
+  computed: {
+    text() {
+      return this.content === null || this.content === undefined
+        ? ''
+        : String(this.content)
+    },
+    isMarkdown() {
+      return this.format === TEXT_FORMAT_TYPES.MARKDOWN
+    },
+    resolvedBuilder() {
+      return this.builder || this.injectedBuilder
+    },
+    resolvedMode() {
+      return this.mode || this.injectedMode
+    },
+    markdownPreset() {
+      return createApplicationBuilderMarkdownPreset(this.preset, {
+        builder: this.resolvedBuilder,
+        mode: this.resolvedMode,
+      })
+    },
+  },
+  methods: {
+    onMarkdownClick(event) {
+      handleMarkdownClick(event, {
+        mode: this.resolvedMode,
+        router: this.$router,
+      })
+    },
+  },
+}
+</script>

--- a/web-frontend/modules/builder/components/elements/baseComponents/ABFileInput.vue
+++ b/web-frontend/modules/builder/components/elements/baseComponents/ABFileInput.vue
@@ -12,7 +12,9 @@
       @keydown.enter.prevent="triggerFileInput"
       @keydown.space.prevent="triggerFileInput"
     >
-      <div>{{ helpText }}</div>
+      <div>
+        <slot name="help-text">{{ helpText }}</slot>
+      </div>
       <input
         ref="fileInputRef"
         type="file"
@@ -171,7 +173,12 @@ export default {
     onDragLeave() {
       this.isDragOver = false
     },
-    triggerFileInput() {
+    triggerFileInput(event) {
+      // A link inside the help text navigates on its own, it shouldn't also
+      // open the file picker.
+      if (event?.target?.closest?.('a')) {
+        return
+      }
       this.$refs.fileInputRef.click()
     },
     removeFile(index) {

--- a/web-frontend/modules/builder/components/elements/baseComponents/ABFormGroup.vue
+++ b/web-frontend/modules/builder/components/elements/baseComponents/ABFormGroup.vue
@@ -14,7 +14,7 @@
       class="ab-form-group__label"
       :class="{ 'ab-form-group__label--small': smallLabel }"
     >
-      {{ label }}
+      <slot name="label">{{ label }}</slot>
       <span v-if="required" :title="$t('error.requiredField')">*</span>
     </label>
     <div class="ab-form-group__children">
@@ -36,6 +36,10 @@ export default {
       required: false,
       default: null,
     },
+    /**
+     * The label text. The optional `label` slot customises its rendering, the
+     * prop still decides whether the label is shown at all.
+     */
     label: {
       type: String,
       required: false,

--- a/web-frontend/modules/builder/components/elements/components/CheckboxElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/CheckboxElement.vue
@@ -8,7 +8,11 @@
       :required="element.required"
       :read-only="isEditMode"
     >
-      {{ resolvedLabel }}
+      <FormattedText
+        :content="resolvedLabel"
+        :format="labelFormat"
+        preset="inlineLinks"
+      />
       <span
         v-if="element.label && element.required"
         :title="$t('error.requiredField')"
@@ -20,12 +24,18 @@
 
 <script>
 import formElement from '@baserow/modules/builder/mixins/formElement'
+import FormattedText from '@baserow/modules/builder/components/FormattedText'
+import { getFormulaFormat } from '@baserow/modules/core/formula/textFormat'
 import { ensureString } from '@baserow/modules/core/utils/validator'
 
 export default {
   name: 'CheckboxElement',
+  components: { FormattedText },
   mixins: [formElement],
   computed: {
+    labelFormat() {
+      return getFormulaFormat(this.element.label)
+    },
     resolvedLabel() {
       return ensureString(this.resolveFormula(this.element.label))
     },

--- a/web-frontend/modules/builder/components/elements/components/ChoiceElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/ChoiceElement.vue
@@ -5,6 +5,13 @@
     :error-message="displayFormDataError ? $t('error.requiredField') : ''"
     :style="getStyleOverride('input')"
   >
+    <template #label>
+      <FormattedText
+        :content="labelResolved"
+        :format="labelFormat"
+        preset="inlineLinks"
+      />
+    </template>
     <ABDropdown
       v-if="element.show_as_dropdown"
       v-model="inputValue"
@@ -17,12 +24,39 @@
       :clearable="!element.multiple && !element.required"
       @hide="onFormElementTouch"
     >
+      <template v-if="hasMarkdownOptions" #value>
+        <span class="ab-dropdown__selected-text">
+          <template v-for="(option, index) in selectedOptions" :key="index">
+            <template v-if="index > 0">, </template>
+            <FormattedText
+              :content="option.name"
+              :format="option.format"
+              preset="inline"
+            />
+          </template>
+        </span>
+      </template>
       <ABDropdownItem
         v-for="option in optionsResolved"
         :key="option.id"
-        :name="option.name || (option.value ? `${option.value}` : '')"
+        :name="dropdownOptionName(option)"
         :value="option.value"
-      />
+      >
+        <!--
+        The search and the tooltip keep using the raw option name; only the
+        visible text is rendered.
+        -->
+        <span
+          class="ab-dropdownitem__item-name-text"
+          :title="dropdownOptionName(option)"
+        >
+          <FormattedText
+            :content="dropdownOptionName(option)"
+            :format="option.format"
+            preset="inline"
+          />
+        </span>
+      </ABDropdownItem>
     </ABDropdown>
     <template v-else>
       <template v-if="canHaveOptions">
@@ -35,7 +69,11 @@
             :model-value="inputValue.includes(option.value)"
             @update:model-value="onOptionChange(option, $event)"
           >
-            {{ option.name || option.value }}
+            <FormattedText
+              :content="optionName(option)"
+              :format="option.format"
+              preset="inline"
+            />
           </ABCheckbox>
         </template>
         <template v-else>
@@ -47,7 +85,11 @@
             :model-value="option.value === inputValue"
             @update:model-value="onOptionChange(option, $event)"
           >
-            {{ option.name || option.value }}
+            <FormattedText
+              :content="optionName(option)"
+              :format="option.format"
+              preset="inline"
+            />
           </ABRadio>
         </template>
       </template>
@@ -59,9 +101,13 @@
 <script>
 import formElement from '@baserow/modules/builder/mixins/formElement'
 import { ensureString } from '@baserow/modules/core/utils/validator'
+import { TEXT_FORMAT_TYPES } from '@baserow/modules/builder/enums'
+import FormattedText from '@baserow/modules/builder/components/FormattedText'
+import { getFormulaFormat } from '@baserow/modules/core/formula/textFormat'
 
 export default {
   name: 'ChoiceElement',
+  components: { FormattedText },
   mixins: [formElement],
   props: {
     /**
@@ -83,6 +129,9 @@ export default {
     },
   },
   computed: {
+    labelFormat() {
+      return getFormulaFormat(this.element.label)
+    },
     labelResolved() {
       return ensureString(this.resolveFormula(this.element.label))
     },
@@ -98,6 +147,29 @@ export default {
         this.applicationContext
       )
     },
+    hasMarkdownOptions() {
+      return this.optionsResolved.some(
+        (option) => option.format === TEXT_FORMAT_TYPES.MARKDOWN
+      )
+    },
+    /**
+     * The selected options, in the order the values are stored, used to render
+     * the collapsed dropdown when the options are Markdown.
+     */
+    selectedOptions() {
+      const values = this.element.multiple
+        ? this.inputValue || []
+        : [this.inputValue]
+      return values
+        .map((value) =>
+          this.optionsResolved.find((option) => option.value === value)
+        )
+        .filter(Boolean)
+        .map((option) => ({
+          name: this.dropdownOptionName(option),
+          format: option.format,
+        }))
+    },
   },
   watch: {
     'element.multiple'() {
@@ -105,6 +177,12 @@ export default {
     },
   },
   methods: {
+    optionName(option) {
+      return ensureString(option.name || option.value)
+    },
+    dropdownOptionName(option) {
+      return option.name || (option.value ? `${option.value}` : '')
+    },
     onOptionChange(option, value) {
       if (value) {
         if (this.element.multiple) {

--- a/web-frontend/modules/builder/components/elements/components/DateTimePickerElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/DateTimePickerElement.vue
@@ -5,6 +5,13 @@
     :required="element.required"
     :style="getStyleOverride('input')"
   >
+    <template #label>
+      <FormattedText
+        :content="resolvedLabel"
+        :format="labelFormat"
+        preset="inlineLinks"
+      />
+    </template>
     <ABDateTimePicker
       ref="datePicker"
       v-model="inputValue"
@@ -20,12 +27,14 @@
 <script>
 import formElement from '@baserow/modules/builder/mixins/formElement'
 import ABDateTimePicker from '@baserow/modules/builder/components/elements/baseComponents/ABDateTimePicker.vue'
+import FormattedText from '@baserow/modules/builder/components/FormattedText'
+import { getFormulaFormat } from '@baserow/modules/core/formula/textFormat'
 import { DATE_FORMATS, TIME_FORMATS } from '@baserow/modules/builder/enums'
 import { ensureString } from '@baserow/modules/core/utils/validator'
 
 export default {
   name: 'DateTimePickerElement',
-  components: { ABDateTimePicker },
+  components: { ABDateTimePicker, FormattedText },
   mixins: [formElement],
   props: {
     /**
@@ -42,6 +51,9 @@ export default {
     },
   },
   computed: {
+    labelFormat() {
+      return getFormulaFormat(this.element.label)
+    },
     TIME_FORMATS() {
       return TIME_FORMATS
     },

--- a/web-frontend/modules/builder/components/elements/components/InputTextElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/InputTextElement.vue
@@ -6,6 +6,13 @@
     :required="element.required"
     :style="getStyleOverride('input')"
   >
+    <template #label>
+      <FormattedText
+        :content="resolvedLabel"
+        :format="labelFormat"
+        preset="inlineLinks"
+      />
+    </template>
     <ABInput
       v-model="computedValue"
       :placeholder="resolvedPlaceholder"
@@ -19,6 +26,8 @@
 
 <script>
 import formElement from '@baserow/modules/builder/mixins/formElement'
+import FormattedText from '@baserow/modules/builder/components/FormattedText'
+import { getFormulaFormat } from '@baserow/modules/core/formula/textFormat'
 import {
   ensureNumeric,
   ensureString,
@@ -27,6 +36,7 @@ import { parseLocalizedNumber } from '@baserow/modules/core/utils/string'
 
 export default {
   name: 'InputTextElement',
+  components: { FormattedText },
   mixins: [formElement],
   props: {
     /**
@@ -48,6 +58,9 @@ export default {
     }
   },
   computed: {
+    labelFormat() {
+      return getFormulaFormat(this.element.label)
+    },
     computedValue: {
       get() {
         return this.internalValue

--- a/web-frontend/modules/builder/components/elements/components/RatingInputElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/RatingInputElement.vue
@@ -4,6 +4,13 @@
     :required="element.required"
     :error-message="displayFormDataError ? $t('error.requiredField') : ''"
   >
+    <template #label>
+      <FormattedText
+        :content="labelResolved"
+        :format="labelFormat"
+        preset="inlineLinks"
+      />
+    </template>
     <Rating
       :value="inputValue"
       :max-value="element.max_value"
@@ -17,6 +24,8 @@
 
 <script>
 import Rating from '@baserow/modules/database/components/Rating'
+import FormattedText from '@baserow/modules/builder/components/FormattedText'
+import { getFormulaFormat } from '@baserow/modules/core/formula/textFormat'
 import formElement from '@baserow/modules/builder/mixins/formElement'
 import { ensureString } from '@baserow/modules/core/utils/validator'
 import { useVuelidate } from '@vuelidate/core'
@@ -26,12 +35,16 @@ export default {
   name: 'RatingInputElement',
   components: {
     Rating,
+    FormattedText,
   },
   mixins: [formElement],
   setup() {
     return { v$: useVuelidate() }
   },
   computed: {
+    labelFormat() {
+      return getFormulaFormat(this.element.label)
+    },
     labelResolved() {
       return ensureString(this.resolveFormula(this.element.label))
     },

--- a/web-frontend/modules/builder/components/elements/components/RecordSelectorElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/RecordSelectorElement.vue
@@ -5,6 +5,13 @@
     :error-message="getErrorMessage()"
     :style="getStyleOverride('input')"
   >
+    <template #label>
+      <FormattedText
+        :content="resolvedLabel"
+        :format="labelFormat"
+        preset="inlineLinks"
+      />
+    </template>
     <ABDropdown
       ref="recordSelectorDropdown"
       v-model="inputValue"
@@ -73,12 +80,14 @@ import formElement from '@baserow/modules/builder/mixins/formElement'
 import collectionElement from '@baserow/modules/builder/mixins/collectionElement'
 import RuntimeFormulaContext from '@baserow/modules/core/runtimeFormulaContext'
 import InfiniteScroll from '@baserow/modules/core/components/helpers/InfiniteScroll.vue'
+import FormattedText from '@baserow/modules/builder/components/FormattedText'
+import { getFormulaFormat } from '@baserow/modules/core/formula/textFormat'
 import DataSourceService from '@baserow/modules/builder/services/dataSource'
 import { handleDispatchError } from '@baserow/modules/builder/utils/error'
 
 export default {
   name: 'RecordSelectorElement',
-  components: { InfiniteScroll },
+  components: { InfiniteScroll, FormattedText },
   mixins: [formElement, collectionElement],
   props: {
     /**
@@ -107,6 +116,9 @@ export default {
     }
   },
   computed: {
+    labelFormat() {
+      return getFormulaFormat(this.element.label)
+    },
     adhocSearchEnabled() {
       return (
         this.elementType.adhocSearchableProperties(

--- a/web-frontend/modules/builder/components/elements/components/TableElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/TableElement.vue
@@ -14,6 +14,13 @@
       :style="getStyleOverride('table')"
       :orientation="orientation"
     >
+      <template #field-name="{ field }">
+        <FormattedText
+          :content="splitFieldName(field).value"
+          :format="splitFieldName(field).format"
+          preset="inline"
+        />
+      </template>
       <template #cell-content="{ rowIndex, field, value, row }">
         <!--
         -- We force-self-alignment to `auto` here to prevent some self-positioning
@@ -70,11 +77,13 @@ import { uuid } from '@baserow/modules/core/utils/string'
 import BaserowTable from '@baserow/modules/builder/components/elements/components/BaserowTable'
 import { ensureString } from '@baserow/modules/core/utils/validator'
 import CollectionElementHeader from '@baserow/modules/builder/components/elements/components/CollectionElementHeader'
+import FormattedText from '@baserow/modules/builder/components/FormattedText'
+import { splitFormat } from '@baserow/modules/core/formula/textFormat'
 import { useCollectionElement } from '@baserow/modules/builder/composables/useCollectionElement'
 
 export default {
   name: 'TableElement',
-  components: { CollectionElementHeader, BaserowTable },
+  components: { CollectionElementHeader, BaserowTable, FormattedText },
   props: {
     /**
      * @type {Object}
@@ -197,6 +206,13 @@ export default {
   },
 
   methods: {
+    /**
+     * The field name carries its own text format marker, see
+     * `core/formula/textFormat`.
+     */
+    splitFieldName(field) {
+      return splitFormat(field.name)
+    },
     resolveRowFormula(formula, index) {
       const formulaContext = new Proxy(
         new RuntimeFormulaContext(

--- a/web-frontend/modules/builder/components/elements/components/TextElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/TextElement.vue
@@ -13,8 +13,8 @@
           resolvedValue ||
           (mode === 'editing' ? $t('textElement.emptyValue') : '&nbsp;')
         "
-        :rules="rules"
-        @click="onClick"
+        :rules="markdownRules"
+        @click="onMarkdownClick"
       ></MarkdownIt>
       <ABParagraph v-else>{{ $t('textElement.missingValue') }}</ABParagraph>
     </template>
@@ -37,7 +37,7 @@ import element from '@baserow/modules/builder/mixins/element'
 import { generateHash } from '@baserow/modules/core/utils/hashing'
 import { ensureString } from '@baserow/modules/core/utils/validator'
 import { TEXT_FORMAT_TYPES } from '@baserow/modules/builder/enums'
-import { createApplicationBuilderMarkdownRules } from '@baserow/modules/builder/utils/markdown'
+import markdownContent from '@baserow/modules/builder/mixins/markdownContent'
 
 /**
  * @typedef Text
@@ -47,7 +47,7 @@ import { createApplicationBuilderMarkdownRules } from '@baserow/modules/builder/
 
 export default {
   name: 'TextElement',
-  mixins: [element],
+  mixins: [element, markdownContent],
   props: {
     /**
      * @type {Object}
@@ -80,31 +80,6 @@ export default {
     },
     TEXT_FORMAT_TYPES() {
       return TEXT_FORMAT_TYPES
-    },
-    // Custom rules to pass down to `MarkdownIt` element.
-    // The goal is to make the styling of the rendered markdown content
-    // consistent with the rest of the application builder CSS classes
-    rules() {
-      return createApplicationBuilderMarkdownRules({
-        builder: this.builder,
-        mode: this.mode,
-      })
-    },
-  },
-  methods: {
-    onClick(event) {
-      if (this.mode === 'editing') {
-        event.preventDefault()
-        return
-      }
-      if (event.target.classList.contains('ab-link')) {
-        const url = event.target.getAttribute('href')
-
-        if (url.startsWith('/')) {
-          event.preventDefault()
-          this.$router.push(url)
-        }
-      }
     },
   },
 }

--- a/web-frontend/modules/builder/components/elements/components/collectionField/TextField.vue
+++ b/web-frontend/modules/builder/components/elements/components/collectionField/TextField.vue
@@ -1,17 +1,34 @@
 <template>
-  <span class="ab-text">{{ value }}</span>
+  <MarkdownIt
+    v-if="format === TEXT_FORMAT_TYPES.MARKDOWN"
+    :content="value"
+    :rules="markdownRules"
+    @click="onMarkdownClick"
+  />
+  <span v-else class="ab-text">{{ value }}</span>
 </template>
 
 <script>
 import collectionField from '@baserow/modules/builder/mixins/collectionField'
+import markdownContent from '@baserow/modules/builder/mixins/markdownContent'
+import { TEXT_FORMAT_TYPES } from '@baserow/modules/builder/enums'
 
 export default {
   name: 'TextField',
-  mixins: [collectionField],
+  mixins: [collectionField, markdownContent],
   props: {
     value: {
       type: String,
       required: true,
+    },
+    format: {
+      type: String,
+      default: TEXT_FORMAT_TYPES.PLAIN,
+    },
+  },
+  computed: {
+    TEXT_FORMAT_TYPES() {
+      return TEXT_FORMAT_TYPES
     },
   },
 }

--- a/web-frontend/modules/builder/components/elements/components/collectionField/form/TextFieldForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/collectionField/form/TextFieldForm.vue
@@ -1,5 +1,6 @@
 <template>
   <form @submit.prevent @keydown.enter.prevent>
+    <ValueFormatSelector v-model="values.value" horizontal />
     <FormGroup
       small-label
       :label="$t('textFieldForm.fieldValueLabel')"
@@ -18,7 +19,11 @@
           :config-block-types="['table', 'typography']"
           :theme="baseTheme"
           :on-styles-changed="onFieldStylesChanged"
-          :extra-args="{ onlyCell: true, onlyBody: true, noAlignment: true }"
+          :extra-args="{
+            onlyCell: true,
+            onlyBody: valueFormat === TEXT_FORMAT_TYPES.PLAIN,
+            noAlignment: true,
+          }"
           variant="normal"
         />
       </template>
@@ -30,10 +35,13 @@
 import collectionFieldForm from '@baserow/modules/builder/mixins/collectionFieldForm'
 import InjectedFormulaInput from '@baserow/modules/core/components/formula/InjectedFormulaInput'
 import CustomStyleButton from '@baserow/modules/builder/components/elements/components/forms/style/CustomStyleButton'
+import { TEXT_FORMAT_TYPES } from '@baserow/modules/builder/enums'
+import { getFormulaFormat } from '@baserow/modules/core/formula/textFormat'
+import ValueFormatSelector from '@baserow/modules/builder/components/elements/components/forms/ValueFormatSelector'
 
 export default {
   name: 'TextField',
-  components: { InjectedFormulaInput, CustomStyleButton },
+  components: { InjectedFormulaInput, CustomStyleButton, ValueFormatSelector },
   mixins: [collectionFieldForm],
   data() {
     return {
@@ -43,6 +51,14 @@ export default {
         styles: {},
       },
     }
+  },
+  computed: {
+    TEXT_FORMAT_TYPES() {
+      return TEXT_FORMAT_TYPES
+    },
+    valueFormat() {
+      return getFormulaFormat(this.values.value)
+    },
   },
 }
 </script>

--- a/web-frontend/modules/builder/components/elements/components/forms/TextFormatSelector.vue
+++ b/web-frontend/modules/builder/components/elements/components/forms/TextFormatSelector.vue
@@ -1,0 +1,60 @@
+<template>
+  <FormGroup
+    :label="label || $t('textFormatSelector.label')"
+    small-label
+    required
+    :horizontal="horizontal"
+    class="margin-bottom-2"
+  >
+    <RadioGroup
+      :model-value="modelValue"
+      type="button"
+      :options="options"
+      @update:model-value="$emit('update:modelValue', $event)"
+    />
+  </FormGroup>
+</template>
+
+<script>
+import { TEXT_FORMAT_TYPES } from '@baserow/modules/builder/enums'
+
+/**
+ * The Plain text / Markdown toggle shared by every form exposing a text
+ * `format` setting.
+ */
+export default {
+  name: 'TextFormatSelector',
+  props: {
+    modelValue: {
+      type: String,
+      required: false,
+      default: TEXT_FORMAT_TYPES.PLAIN,
+    },
+    label: {
+      type: String,
+      required: false,
+      default: null,
+    },
+    horizontal: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+  },
+  emits: ['update:modelValue'],
+  computed: {
+    options() {
+      return [
+        {
+          value: TEXT_FORMAT_TYPES.PLAIN,
+          label: this.$t('textFormatSelector.plain'),
+        },
+        {
+          value: TEXT_FORMAT_TYPES.MARKDOWN,
+          label: this.$t('textFormatSelector.markdown'),
+        },
+      ]
+    },
+  },
+}
+</script>

--- a/web-frontend/modules/builder/components/elements/components/forms/ValueFormatSelector.vue
+++ b/web-frontend/modules/builder/components/elements/components/forms/ValueFormatSelector.vue
@@ -1,0 +1,67 @@
+<template>
+  <TextFormatSelector
+    :model-value="format"
+    :label="label"
+    :horizontal="horizontal"
+    @update:model-value="updateFormat"
+  />
+</template>
+
+<script>
+import TextFormatSelector from '@baserow/modules/builder/components/elements/components/forms/TextFormatSelector'
+import {
+  getFormat,
+  getFormulaFormat,
+  setFormat,
+  setFormulaFormat,
+} from '@baserow/modules/core/formula/textFormat'
+
+/**
+ * The Plain text / Markdown toggle of a text whose format is stored inside the
+ * value itself, as a marker in front of it. The value is either a formula
+ * object, in which case the marker goes in front of the formula, or a plain
+ * string such as a collection field name.
+ */
+export default {
+  name: 'ValueFormatSelector',
+  components: { TextFormatSelector },
+  props: {
+    modelValue: {
+      type: [Object, String],
+      required: false,
+      default: '',
+    },
+    label: {
+      type: String,
+      required: false,
+      default: null,
+    },
+    horizontal: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+  },
+  emits: ['update:modelValue'],
+  computed: {
+    isFormula() {
+      return typeof this.modelValue === 'object' && this.modelValue !== null
+    },
+    format() {
+      return this.isFormula
+        ? getFormulaFormat(this.modelValue)
+        : getFormat(this.modelValue)
+    },
+  },
+  methods: {
+    updateFormat(format) {
+      this.$emit(
+        'update:modelValue',
+        this.isFormula
+          ? setFormulaFormat(this.modelValue, format)
+          : setFormat(this.modelValue || '', format)
+      )
+    },
+  },
+}
+</script>

--- a/web-frontend/modules/builder/components/elements/components/forms/general/CheckboxElementForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/forms/general/CheckboxElementForm.vue
@@ -18,6 +18,10 @@
         :placeholder="$t('generalForm.labelPlaceholder')"
       />
     </FormGroup>
+    <ValueFormatSelector
+      v-model="values.label"
+      :label="$t('textFormatSelector.labelFormat')"
+    />
 
     <FormGroup
       small-label
@@ -44,14 +48,20 @@
 import formElementForm from '@baserow/modules/builder/mixins/formElementForm'
 import InjectedFormulaInput from '@baserow/modules/core/components/formula/InjectedFormulaInput.vue'
 import CustomStyleButton from '@baserow/modules/builder/components/elements/components/forms/style/CustomStyleButton'
+import ValueFormatSelector from '@baserow/modules/builder/components/elements/components/forms/ValueFormatSelector'
 
 export default {
   name: 'CheckboxElementForm',
-  components: { InjectedFormulaInput, CustomStyleButton },
+  components: { InjectedFormulaInput, CustomStyleButton, ValueFormatSelector },
   mixins: [formElementForm],
   data() {
     return {
-      allowedValues: ['label', 'default_value', 'required', 'styles'],
+      allowedValues: [
+        'label',
+        'default_value',
+        'required',
+        'styles',
+      ],
       values: {
         label: {},
         default_value: {},

--- a/web-frontend/modules/builder/components/elements/components/forms/general/ChoiceElementForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/forms/general/ChoiceElementForm.vue
@@ -17,6 +17,10 @@
         :placeholder="$t('generalForm.labelPlaceholder')"
       />
     </FormGroup>
+    <ValueFormatSelector
+      v-model="values.label"
+      :label="$t('textFormatSelector.labelFormat')"
+    />
     <FormGroup
       small-label
       :label="$t('generalForm.valueTitle')"
@@ -82,6 +86,10 @@
         type="button"
       />
     </FormGroup>
+    <TextFormatSelector
+      v-model="optionFormat"
+      :label="$t('choiceElementForm.optionFormat')"
+    />
     <template v-if="values.option_type === CHOICE_OPTION_TYPES.MANUAL">
       <template v-if="values.options.length">
         <div class="row" style="--gap: 6px">
@@ -100,13 +108,14 @@
         >
           <div class="col col-5">
             <FormInput
-              v-model="option.name"
+              :model-value="optionName(option)"
               :placeholder="$t('choiceOptionSelector.namePlaceholder')"
+              @update:model-value="setOptionName(option, $event)"
             />
           </div>
           <div class="col col-5">
             <FormInput
-              :value="option.value === null ? option.name : option.value"
+              :value="option.value === null ? optionName(option) : option.value"
               :placeholder="$t('choiceOptionSelector.valuePlaceholder')"
               :class="{
                 'choice-element__option-value--fake': option.value === null,
@@ -164,16 +173,31 @@
 
 <script>
 import InjectedFormulaInput from '@baserow/modules/core/components/formula/InjectedFormulaInput.vue'
-import { CHOICE_OPTION_TYPES } from '@baserow/modules/builder/enums'
+import {
+  CHOICE_OPTION_TYPES,
+  TEXT_FORMAT_TYPES,
+} from '@baserow/modules/builder/enums'
 import CustomStyleButton from '@baserow/modules/builder/components/elements/components/forms/style/CustomStyleButton'
 import formElementForm from '@baserow/modules/builder/mixins/formElementForm'
 import { uuid } from '@baserow/modules/core/utils/string'
+import {
+  addPrefix,
+  getFormat,
+  getFormulaFormat,
+  setFormat,
+  setFormulaFormat,
+  stripFormat,
+} from '@baserow/modules/core/formula/textFormat'
+import TextFormatSelector from '@baserow/modules/builder/components/elements/components/forms/TextFormatSelector'
+import ValueFormatSelector from '@baserow/modules/builder/components/elements/components/forms/ValueFormatSelector'
 
 export default {
   name: 'ChoiceElementForm',
   components: {
     InjectedFormulaInput,
     CustomStyleButton,
+    TextFormatSelector,
+    ValueFormatSelector,
   },
   mixins: [formElementForm],
   props: {
@@ -211,10 +235,21 @@ export default {
         formula_value: {},
         styles: {},
       },
+      /**
+       * The option names carry their own text format marker (see
+       * `core/formula/textFormat`), so there is no `option_format` property to
+       * store: this element-level toggle is initialised from the stored option
+       * names and written back into every option name, or into the name formula
+       * when the options come from formulas.
+       */
+      optionFormat: TEXT_FORMAT_TYPES.PLAIN,
     }
   },
   computed: {
     CHOICE_OPTION_TYPES: () => CHOICE_OPTION_TYPES,
+    manualOptions() {
+      return Array.isArray(this.values.options) ? this.values.options : []
+    },
     element() {
       return this.$store.getters['element/getElementById'](
         this.elementPage,
@@ -262,10 +297,65 @@ export default {
     'element.options'(options) {
       this.values.options = { ...options }
     },
+    optionFormat(format) {
+      this.applyOptionFormat(format)
+    },
+    'values.option_type'() {
+      this.applyOptionFormat(this.optionFormat)
+    },
+  },
+  created() {
+    this.optionFormat = this.getStoredOptionFormat()
   },
   methods: {
+    /**
+     * The format the active option type is stored with: the manual options are
+     * Markdown when every option name is marked, the formula options when the
+     * name formula is.
+     */
+    getStoredOptionFormat() {
+      if (this.values.option_type === CHOICE_OPTION_TYPES.FORMULAS) {
+        return getFormulaFormat(this.values.formula_name)
+      }
+      const options = this.manualOptions
+      const allMarkdown =
+        options.length > 0 &&
+        options.every(
+          (option) => getFormat(option.name) === TEXT_FORMAT_TYPES.MARKDOWN
+        )
+      return allMarkdown ? TEXT_FORMAT_TYPES.MARKDOWN : TEXT_FORMAT_TYPES.PLAIN
+    },
+    /**
+     * Writes the toggle into the stored values of the active option type.
+     */
+    applyOptionFormat(format) {
+      if (this.values.option_type === CHOICE_OPTION_TYPES.FORMULAS) {
+        if (getFormulaFormat(this.values.formula_name) !== format) {
+          this.values.formula_name = setFormulaFormat(
+            this.values.formula_name,
+            format
+          )
+        }
+      } else {
+        this.manualOptions.forEach((option) => {
+          if (getFormat(option.name) !== format) {
+            option.name = setFormat(option.name, format)
+          }
+        })
+      }
+    },
+    optionName(option) {
+      return stripFormat(option.name)
+    },
+    setOptionName(option, name) {
+      option.name = addPrefix(name, this.optionFormat)
+    },
     createOption() {
-      this.values.options.push({ name: '', value: null, id: uuid() })
+      this.values.options.push({
+        name: addPrefix('', this.optionFormat),
+        value: null,
+        id: uuid(),
+      })
     },
     deleteOption({ id }) {
       this.values.options = this.values.options.filter(

--- a/web-frontend/modules/builder/components/elements/components/forms/general/DateTimePickerElementForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/forms/general/DateTimePickerElementForm.vue
@@ -17,6 +17,10 @@
         :placeholder="$t('generalForm.labelPlaceholder')"
       />
     </FormGroup>
+    <ValueFormatSelector
+      v-model="values.label"
+      :label="$t('textFormatSelector.labelFormat')"
+    />
     <FormGroup
       small-label
       :label="$t('generalForm.valueTitle')"
@@ -87,10 +91,11 @@ import formElementForm from '@baserow/modules/builder/mixins/formElementForm'
 import InjectedFormulaInput from '@baserow/modules/core/components/formula/InjectedFormulaInput.vue'
 import CustomStyleButton from '@baserow/modules/builder/components/elements/components/forms/style/CustomStyleButton'
 import { DATE_FORMATS, TIME_FORMATS } from '@baserow/modules/builder/enums'
+import ValueFormatSelector from '@baserow/modules/builder/components/elements/components/forms/ValueFormatSelector'
 
 export default {
   name: 'DateTimePickerElementForm',
-  components: { InjectedFormulaInput, CustomStyleButton },
+  components: { InjectedFormulaInput, CustomStyleButton, ValueFormatSelector },
   mixins: [formElementForm],
   data() {
     return {

--- a/web-frontend/modules/builder/components/elements/components/forms/general/InputTextElementForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/forms/general/InputTextElementForm.vue
@@ -17,6 +17,10 @@
         :placeholder="$t('generalForm.labelPlaceholder')"
       />
     </FormGroup>
+    <ValueFormatSelector
+      v-model="values.label"
+      :label="$t('textFormatSelector.labelFormat')"
+    />
     <FormGroup
       :label="$t('generalForm.valueTitle')"
       class="margin-bottom-2"
@@ -123,6 +127,7 @@ import form from '@baserow/modules/core/mixins/form'
 import InjectedFormulaInput from '@baserow/modules/core/components/formula/InjectedFormulaInput.vue'
 import formElementForm from '@baserow/modules/builder/mixins/formElementForm'
 import CustomStyleButton from '@baserow/modules/builder/components/elements/components/forms/style/CustomStyleButton'
+import ValueFormatSelector from '@baserow/modules/builder/components/elements/components/forms/ValueFormatSelector'
 import {
   required,
   integer,
@@ -133,7 +138,7 @@ import {
 
 export default {
   name: 'InputTextElementForm',
-  components: { InjectedFormulaInput, CustomStyleButton },
+  components: { InjectedFormulaInput, CustomStyleButton, ValueFormatSelector },
   mixins: [formElementForm],
   setup() {
     return { v$: useVuelidate() }

--- a/web-frontend/modules/builder/components/elements/components/forms/general/RatingInputElementForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/forms/general/RatingInputElementForm.vue
@@ -11,6 +11,10 @@
         :placeholder="$t('generalForm.labelPlaceholder')"
       />
     </FormGroup>
+    <ValueFormatSelector
+      v-model="values.label"
+      :label="$t('textFormatSelector.labelFormat')"
+    />
 
     <FormGroup
       :label="$t('generalForm.requiredTitle')"
@@ -47,6 +51,7 @@ import elementForm from '@baserow/modules/builder/mixins/elementForm'
 import InjectedFormulaInput from '@baserow/modules/core/components/formula/InjectedFormulaInput'
 import Checkbox from '@baserow/modules/core/components/Checkbox'
 import RatingFormFields from '@baserow/modules/builder/components/elements/components/forms/RatingFormFields.vue'
+import ValueFormatSelector from '@baserow/modules/builder/components/elements/components/forms/ValueFormatSelector'
 
 export default {
   name: 'RatingInputElementForm',
@@ -54,6 +59,7 @@ export default {
     InjectedFormulaInput,
     Checkbox,
     RatingFormFields,
+    ValueFormatSelector,
   },
   mixins: [elementForm],
   data() {

--- a/web-frontend/modules/builder/components/elements/components/forms/general/RecordSelectorElementForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/forms/general/RecordSelectorElementForm.vue
@@ -73,6 +73,10 @@
         :placeholder="$t('generalForm.labelPlaceholder')"
       />
     </FormGroup>
+    <ValueFormatSelector
+      v-model="values.label"
+      :label="$t('textFormatSelector.labelFormat')"
+    />
     <FormGroup
       v-if="values.data_source_id"
       small-label
@@ -145,6 +149,7 @@ import {
 } from '@vuelidate/validators'
 import DataSourceDropdown from '@baserow/modules/builder/components/dataSource/DataSourceDropdown.vue'
 import PropertyOptionForm from '@baserow/modules/builder/components/elements/components/forms/general/settings/PropertyOptionForm'
+import ValueFormatSelector from '@baserow/modules/builder/components/elements/components/forms/ValueFormatSelector'
 
 export default {
   name: 'RecordSelectorElementForm',
@@ -153,6 +158,7 @@ export default {
     DataSourceDropdown,
     CustomStyleButton,
     InjectedFormulaInput,
+    ValueFormatSelector,
   },
   mixins: [formElementForm, collectionElementForm],
   emits: ['values-changed'],

--- a/web-frontend/modules/builder/components/elements/components/forms/general/TableElementForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/forms/general/TableElementForm.vue
@@ -114,7 +114,7 @@
             toggle-on-click
           >
             <template #title>
-              <span v-if="field.name">{{ field.name }}</span>
+              <span v-if="fieldName(field)">{{ fieldName(field) }}</span>
               <span v-else class="color-neutral">
                 ({{ $t('tableElementForm.noName') }})
               </span>
@@ -137,11 +137,17 @@
                 :error-message="v$.values.fields.$each.$message[index]?.[0]"
               >
                 <FormInput
-                  v-model="v$.values.fields.$model[index].name"
+                  :model-value="fieldName(field)"
                   class="table-element-form__field-label"
+                  @update:model-value="setFieldName(index, $event)"
                 >
                 </FormInput>
               </FormGroup>
+              <ValueFormatSelector
+                v-model="v$.values.fields.$model[index].name"
+                :label="$t('tableElementForm.nameFormat')"
+                horizontal
+              />
 
               <FormGroup
                 small-label
@@ -267,6 +273,11 @@ import {
 } from '@vuelidate/validators'
 import collectionElementForm from '@baserow/modules/builder/mixins/collectionElementForm'
 import { ORIENTATIONS } from '@baserow/modules/builder/enums'
+import {
+  addPrefix,
+  getFormat,
+  stripFormat,
+} from '@baserow/modules/core/formula/textFormat'
 import DeviceSelector from '@baserow/modules/builder/components/page/header/DeviceSelector.vue'
 import { mapActions, mapGetters } from 'vuex'
 import CustomStyleButton from '@baserow/modules/builder/components/elements/components/forms/style/CustomStyleButton'
@@ -274,6 +285,7 @@ import ServiceSchemaPropertySelector from '@baserow/modules/core/components/serv
 import DataSourceDropdown from '@baserow/modules/builder/components/dataSource/DataSourceDropdown'
 import PropertyOptionForm from '@baserow/modules/builder/components/elements/components/forms/general/settings/PropertyOptionForm'
 import SidebarExpandable from '@baserow/modules/builder/components/SidebarExpandable.vue'
+import ValueFormatSelector from '@baserow/modules/builder/components/elements/components/forms/ValueFormatSelector'
 
 export default {
   name: 'TableElementForm',
@@ -285,6 +297,7 @@ export default {
     DeviceSelector,
     CustomStyleButton,
     SidebarExpandable,
+    ValueFormatSelector,
   },
   mixins: [collectionElementForm],
   emits: ['values-changed'],
@@ -344,11 +357,22 @@ export default {
     ...mapActions({
       actionSetDeviceTypeSelected: 'page/setDeviceTypeSelected',
     }),
+    /**
+     * The field name carries its own text format marker (see
+     * `core/formula/textFormat`), which the name input never shows.
+     */
+    fieldName(field) {
+      return stripFormat(field.name)
+    },
+    setFieldName(index, name) {
+      const field = this.v$.values.fields.$model[index]
+      field.name = addPrefix(name, getFormat(field.name))
+    },
     addField() {
       this.v$.values.fields.$model.push({
         name: getNextAvailableNameInSequence(
           this.$t('tableElementForm.fieldDefaultName'),
-          this.v$.values.fields.$model.map(({ name }) => name)
+          this.v$.values.fields.$model.map(({ name }) => stripFormat(name))
         ),
         value: {},
         type: 'text',

--- a/web-frontend/modules/builder/components/elements/components/forms/general/TextElementForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/forms/general/TextElementForm.vue
@@ -1,18 +1,6 @@
 <template>
   <form @submit.prevent @keydown.enter.prevent>
-    <FormGroup
-      :label="$t('textElementForm.textFormatTypeLabel')"
-      small-label
-      required
-      class="margin-bottom-2"
-    >
-      <RadioGroup
-        v-model="values.format"
-        type="button"
-        :options="textFormatTypeOptions"
-      >
-      </RadioGroup>
-    </FormGroup>
+    <TextFormatSelector v-model="values.format" />
 
     <CustomStyleButton
       v-model="values.styles"
@@ -40,12 +28,14 @@ import InjectedFormulaInput from '@baserow/modules/core/components/formula/Injec
 import elementForm from '@baserow/modules/builder/mixins/elementForm'
 import { TEXT_FORMAT_TYPES } from '@baserow/modules/builder/enums'
 import CustomStyleButton from '@baserow/modules/builder/components/elements/components/forms/style/CustomStyleButton'
+import TextFormatSelector from '@baserow/modules/builder/components/elements/components/forms/TextFormatSelector'
 
 export default {
   name: 'TextElementForm',
   components: {
     InjectedFormulaInput,
     CustomStyleButton,
+    TextFormatSelector,
   },
   mixins: [elementForm],
   data() {
@@ -56,16 +46,6 @@ export default {
         format: TEXT_FORMAT_TYPES.PLAIN,
         styles: {},
       },
-      textFormatTypeOptions: [
-        {
-          value: TEXT_FORMAT_TYPES.PLAIN,
-          label: this.$t('textElementForm.textFormatTypePlain'),
-        },
-        {
-          value: TEXT_FORMAT_TYPES.MARKDOWN,
-          label: this.$t('textElementForm.textFormatTypeMarkdown'),
-        },
-      ],
     }
   },
   computed: {

--- a/web-frontend/modules/builder/components/workflowAction/NotificationWorkflowActionForm.vue
+++ b/web-frontend/modules/builder/components/workflowAction/NotificationWorkflowActionForm.vue
@@ -11,6 +11,10 @@
         :placeholder="$t('notificationWorkflowActionForm.titlePlaceholder')"
       />
     </FormGroup>
+    <ValueFormatSelector
+      v-model="values.title"
+      :label="$t('notificationWorkflowActionForm.titleFormat')"
+    />
     <FormGroup
       small-label
       :label="$t('notificationWorkflowActionForm.descriptionLabel')"
@@ -24,19 +28,25 @@
         "
       />
     </FormGroup>
+    <ValueFormatSelector
+      v-model="values.description"
+      :label="$t('notificationWorkflowActionForm.descriptionFormat')"
+    />
   </form>
 </template>
 
 <script>
 import form from '@baserow/modules/core/mixins/form'
 import InjectedFormulaInput from '@baserow/modules/core/components/formula/InjectedFormulaInput'
+import ValueFormatSelector from '@baserow/modules/builder/components/elements/components/forms/ValueFormatSelector'
 
 export default {
   name: 'NotificationWorkflowActionForm',
-  components: { InjectedFormulaInput },
+  components: { InjectedFormulaInput, ValueFormatSelector },
   mixins: [form],
   data() {
     return {
+      allowedValues: ['title', 'description'],
       values: {
         title: {},
         description: {},

--- a/web-frontend/modules/builder/elementTypes.js
+++ b/web-frontend/modules/builder/elementTypes.js
@@ -38,6 +38,10 @@ import ButtonElementForm from '@baserow/modules/builder/components/elements/comp
 import { ClickEvent, SubmitEvent } from '@baserow/modules/builder/eventTypes'
 import RuntimeFormulaContext from '@baserow/modules/core/runtimeFormulaContext'
 import { resolveFormula } from '@baserow/modules/core/formula'
+import {
+  getFormulaFormat,
+  splitFormat,
+} from '@baserow/modules/core/formula/textFormat'
 import FormContainerElement from '@baserow/modules/builder/components/elements/components/FormContainerElement.vue'
 import FormContainerElementForm from '@baserow/modules/builder/components/elements/components/forms/general/FormContainerElementForm.vue'
 import SimpleContainerElement from '@baserow/modules/builder/components/elements/components/SimpleContainerElement.vue'
@@ -1893,16 +1897,26 @@ export class ChoiceElementType extends FormElementType {
    * gathers all valid Values. When a Value null, the Name is used instead.
    * Otherwise, the Value itself is used.
    *
+   * The option names carry their own text format (see
+   * `core/formula/textFormat`): a manual option name is stored with the
+   * marker, a formula name formula is marked as a whole. The marker is
+   * neither displayed nor submitted as the value, so every option is returned
+   * with its bare `name` and a `format`.
+   *
    * @param element - The choice form element
    * @returns {Array} - An array of valid Values
    */
   getOptionsResolved(element, applicationContext) {
     switch (element.option_type) {
       case CHOICE_OPTION_TYPES.MANUAL:
-        return element.options.map(({ name, value }) => ({
-          name,
-          value: value === null ? name : value,
-        }))
+        return element.options.map(({ name, value }) => {
+          const { format, value: bareName } = splitFormat(name)
+          return {
+            name: bareName,
+            value: value === null ? bareName : value,
+            format,
+          }
+        })
       case CHOICE_OPTION_TYPES.FORMULAS: {
         const formulaValues = ensureArray(
           this.resolveFormula(element.formula_value, applicationContext)
@@ -1910,12 +1924,14 @@ export class ChoiceElementType extends FormElementType {
         const formulaNames = ensureArray(
           this.resolveFormula(element.formula_name, applicationContext)
         )
+        const format = getFormulaFormat(element.formula_name)
         return formulaValues.map((value, index) => ({
           id: index,
           value: ensureStringOrInteger(value),
           name: ensureString(
             index < formulaValues.length ? formulaNames[index] : value
           ),
+          format,
         }))
       }
       default:

--- a/web-frontend/modules/builder/enums.js
+++ b/web-frontend/modules/builder/enums.js
@@ -5,6 +5,7 @@ import {
   ensureArray,
   ensureNumeric,
 } from '@baserow/modules/core/utils/validator'
+import { TEXT_FORMATS } from '@baserow/modules/core/formula/textFormat'
 import {
   DataSourceDataProviderType,
   DataSourceContextDataProviderType,
@@ -53,10 +54,9 @@ export const ALLOWED_LINK_PROTOCOLS = [
   'tel:',
 ]
 
-export const TEXT_FORMAT_TYPES = {
-  PLAIN: 'plain',
-  MARKDOWN: 'markdown',
-}
+// The text format is stored inside the value itself, see
+// `core/formula/textFormat`. Only the Text element keeps a `format` column.
+export const TEXT_FORMAT_TYPES = TEXT_FORMATS
 
 export const IMAGE_SOURCE_TYPES = {
   UPLOAD: 'upload',

--- a/web-frontend/modules/builder/locales/en.json
+++ b/web-frontend/modules/builder/locales/en.json
@@ -249,10 +249,13 @@
   "textElementForm": {
     "textTitle": "Text",
     "textPlaceholder": "Enter text...",
-    "textError": "The value is invalid.",
-    "textFormatTypeLabel": "Format",
-    "textFormatTypePlain": "Plain text",
-    "textFormatTypeMarkdown": "Markdown"
+    "textError": "The value is invalid."
+  },
+  "textFormatSelector": {
+    "label": "Format",
+    "plain": "Plain text",
+    "markdown": "Markdown",
+    "labelFormat": "Label format"
   },
   "orientations": {
     "label": "Orientation",
@@ -762,7 +765,8 @@
     "display": "Display",
     "dropdown": "Dropdown",
     "checkbox": "Checkbox",
-    "radio": "Radio"
+    "radio": "Radio",
+    "optionFormat": "Option format"
   },
   "dropdown": {
     "empty": "No options available"
@@ -783,7 +787,8 @@
     "buttonColor": "Button color",
     "refreshFieldsFromDataSource": "refresh fields from data source",
     "buttonLoadMoreLabel": "Show more label",
-    "propertySelectorMissingArrays": "No multiple valued fields found to use as rows."
+    "propertySelectorMissingArrays": "No multiple valued fields found to use as rows.",
+    "nameFormat": "Name format"
   },
   "tableElement": {
     "showMore": "Show more"
@@ -870,7 +875,9 @@
     "titleLabel": "Title",
     "titlePlaceholder": "Enter text...",
     "descriptionLabel": "Description",
-    "descriptionPlaceholder": "Enter text..."
+    "descriptionPlaceholder": "Enter text...",
+    "titleFormat": "Title format",
+    "descriptionFormat": "Description format"
   },
   "event": {
     "addAction": "add action",

--- a/web-frontend/modules/builder/mixins/markdownContent.js
+++ b/web-frontend/modules/builder/mixins/markdownContent.js
@@ -1,0 +1,31 @@
+import {
+  createApplicationBuilderMarkdownRules,
+  handleMarkdownClick,
+} from '@baserow/modules/builder/utils/markdown'
+
+/**
+ * Shared behaviour for elements and collection fields that render Markdown
+ * through the global `MarkdownIt` component: the Application Builder renderer
+ * rules and the click handler that keeps internal links inside the SPA router.
+ *
+ * Requires `builder` and `mode` on the component, which are both provided by
+ * the `element` / `collectionField` mixins via inject.
+ */
+export default {
+  computed: {
+    // Custom rules to pass down to the `MarkdownIt` component. The goal is to
+    // make the styling of the rendered markdown content consistent with the
+    // rest of the application builder CSS classes.
+    markdownRules() {
+      return createApplicationBuilderMarkdownRules({
+        builder: this.builder,
+        mode: this.mode,
+      })
+    },
+  },
+  methods: {
+    onMarkdownClick(event) {
+      handleMarkdownClick(event, { mode: this.mode, router: this.$router })
+    },
+  },
+}

--- a/web-frontend/modules/builder/store/builderToast.js
+++ b/web-frontend/modules/builder/store/builderToast.js
@@ -30,8 +30,8 @@ export const actions = {
   infoNeutral({ dispatch }, { title, message }) {
     dispatch('add', { type: 'info-neutral', title, message })
   },
-  info({ dispatch }, { title, message }) {
-    dispatch('add', { type: 'info-primary', title, message })
+  info({ dispatch }, { title, message, ...rest }) {
+    dispatch('add', { type: 'info-primary', title, message, ...rest })
   },
   error({ dispatch }, { title, message, details }) {
     dispatch('add', { type: 'error', title, message, details })

--- a/web-frontend/modules/builder/utils/markdown.js
+++ b/web-frontend/modules/builder/utils/markdown.js
@@ -91,3 +91,136 @@ export const createApplicationBuilderMarkdownRules = ({ builder, mode }) => ({
     return renderer.renderToken(tokens, idx, options)
   },
 })
+
+/**
+ * The rendering presets available for Application Builder Markdown surfaces.
+ *
+ * - `block`: the full Markdown syntax, for free-flowing text (Text element, Text
+ *   collection field, file input help text).
+ * - `restrictedBlock`: block mode without the layout-breaking blocks (tables,
+ *   code blocks, images, headings), for the notification toast description.
+ * - `inline`: emphasis, strikethrough and inline code only, for selectable or
+ *   truncated single-line content (option names, table headers, toast title).
+ *   Links are disabled, as these contexts are either already wrapped in
+ *   an `<a>`, or select something on click.
+ * - `inlineLinks`: inline mode with links, for descriptive single-line content
+ *   such as form field labels ("I agree to the [terms](...)").
+ */
+export const MARKDOWN_PRESETS = {
+  BLOCK: 'block',
+  RESTRICTED_BLOCK: 'restrictedBlock',
+  INLINE: 'inline',
+  INLINE_LINKS: 'inlineLinks',
+}
+
+export const INLINE_MARKDOWN_DISABLED_RULES = ['link', 'autolink']
+export const INLINE_LINKS_MARKDOWN_DISABLED_RULES = []
+export const RESTRICTED_BLOCK_MARKDOWN_DISABLED_RULES = [
+  'table',
+  'fence',
+  'code',
+  'heading',
+  'lheading',
+]
+
+/**
+ * Renders an image token back as its Markdown source. Disabling the `image`
+ * rule instead would leave a `!` followed by a link, which is more surprising
+ * than the literal text on the surfaces where images aren't allowed.
+ */
+const renderImageAsSource = (tokens, idx) => {
+  const token = tokens[idx]
+  const title = token.attrGet('title')
+  return escapeHtml(
+    `![${token.content}](${token.attrGet('src')}${title ? ` "${title}"` : ''})`
+  )
+}
+
+/**
+ * Creates the Markdown-It renderer rules used by the inline presets. Only the
+ * tokens that survive `renderInline` need styling.
+ */
+export const createApplicationBuilderInlineMarkdownRules = ({
+  builder,
+  mode,
+  links = false,
+}) => {
+  const blockRules = createApplicationBuilderMarkdownRules({ builder, mode })
+  return {
+    code_inline: blockRules.code_inline,
+    image: renderImageAsSource,
+    // Inline surfaces are often nowrap/ellipsis contexts where a `<br>` breaks
+    // the truncation. A backslash-newline still yields a hardbreak even with the
+    // `newline` rule disabled, so both break renderers emit a plain space.
+    hardbreak: () => ' ',
+    softbreak: () => ' ',
+    ...(links ? { link_open: blockRules.link_open } : {}),
+  }
+}
+
+/**
+ * Returns the `MarkdownIt` component props (`inline`, `rules`, `disabledRules`)
+ * for the given preset.
+ */
+export const createApplicationBuilderMarkdownPreset = (
+  preset,
+  { builder, mode }
+) => {
+  switch (preset) {
+    case MARKDOWN_PRESETS.INLINE:
+      return {
+        inline: true,
+        rules: createApplicationBuilderInlineMarkdownRules({ builder, mode }),
+        disabledRules: INLINE_MARKDOWN_DISABLED_RULES,
+      }
+    case MARKDOWN_PRESETS.INLINE_LINKS:
+      return {
+        inline: true,
+        rules: createApplicationBuilderInlineMarkdownRules({
+          builder,
+          mode,
+          links: true,
+        }),
+        disabledRules: INLINE_LINKS_MARKDOWN_DISABLED_RULES,
+      }
+    case MARKDOWN_PRESETS.RESTRICTED_BLOCK:
+      return {
+        inline: false,
+        rules: {
+          ...createApplicationBuilderMarkdownRules({ builder, mode }),
+          image: renderImageAsSource,
+        },
+        disabledRules: RESTRICTED_BLOCK_MARKDOWN_DISABLED_RULES,
+      }
+    case MARKDOWN_PRESETS.BLOCK:
+      return {
+        inline: false,
+        rules: createApplicationBuilderMarkdownRules({ builder, mode }),
+        disabledRules: [],
+      }
+    default:
+      throw new Error(`Unknown markdown preset: ${preset}`)
+  }
+}
+
+/**
+ * Click handler for rendered Markdown: blocks navigation while editing and keeps
+ * internal links inside the SPA router.
+ */
+export const handleMarkdownClick = (event, { mode, router }) => {
+  if (mode === 'editing') {
+    event.preventDefault()
+    return
+  }
+  // The click target can be nested markup inside the link, e.g. the `<strong>`
+  // of `[**terms**](/terms)`, so look up the closest link instead.
+  const link = event.target.closest('a.ab-link')
+  if (link) {
+    const url = link.getAttribute('href')
+
+    if (url.startsWith('/')) {
+      event.preventDefault()
+      router.push(url)
+    }
+  }
+}

--- a/web-frontend/modules/builder/workflowActionTypes.js
+++ b/web-frontend/modules/builder/workflowActionTypes.js
@@ -24,6 +24,7 @@ import { ensureString } from '@baserow/modules/core/utils/validator'
 import { pathParametersInError } from '@baserow/modules/builder/utils/params'
 import { handleDispatchError } from '@baserow/modules/builder/utils/error'
 import { SlackWriteMessageServiceType } from '@baserow/modules/integrations/slack/serviceTypes'
+import { getFormulaFormat } from '@baserow/modules/core/formula/textFormat'
 
 export class NotificationWorkflowActionType extends WorkflowActionType {
   static getType() {
@@ -53,7 +54,9 @@ export class NotificationWorkflowActionType extends WorkflowActionType {
   execute({ workflowAction: { title, description }, resolveFormula }) {
     return this.app.$store.dispatch('builderToast/info', {
       title: ensureString(resolveFormula(title)),
+      titleFormat: getFormulaFormat(title),
       message: ensureString(resolveFormula(description)),
+      messageFormat: getFormulaFormat(description),
     })
   }
 

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_file_input.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_file_input.scss
@@ -14,6 +14,16 @@
   cursor: pointer;
   position: relative;
 
+  // The Markdown help text renders elements that set their own `text-align`
+  // from the theme variables, which would ignore the centering above that the
+  // plain text rendering simply inherits.
+  .markdown .ab-text,
+  .markdown .ab-heading,
+  .markdown .ab-list,
+  .markdown .ab-code {
+    text-align: inherit;
+  }
+
   &:focus {
     border-color: color-mix(
       in srgb,

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_markdown.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_markdown.scss
@@ -1,4 +1,8 @@
-.markdown {
+// The inline rendering carries the `markdown` class too, so the block spacing
+// below must exclude it: its children are `<code>`/`<img>` boxes sitting on the
+// text baseline, where a top margin grows the line box and pushes the whole
+// line down instead of separating blocks.
+.markdown:not(.markdown--inline) {
   & > .ab-blockquote,
   & > .ab-code,
   & > .ab-heading,
@@ -15,6 +19,12 @@
   }
 }
 
-.markdown > *:first-child {
+.markdown:not(.markdown--inline) > *:first-child {
   margin-top: 0;
+}
+
+// Inline Markdown (labels, option names, table headers...) must flow with
+// the surrounding text, e.g. inside an ellipsis container.
+.markdown--inline {
+  display: inline;
 }

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_table.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_table.scss
@@ -115,6 +115,13 @@
   align-items: var(--table-cell-alignment, flex-start);
   padding: var(--table-cell-vertical-padding, 10px)
     var(--table-cell-horizontal-padding, 20px);
+
+  // Markdown paragraphs would otherwise pick up the global `p { line-height }`
+  // and make rows taller than the plain `<span class="ab-text">` rendering,
+  // which simply inherits the page line-height.
+  .markdown > .ab-text {
+    line-height: inherit;
+  }
 }
 
 .ab-table__empty-state {

--- a/web-frontend/modules/core/components/MarkdownIt.vue
+++ b/web-frontend/modules/core/components/MarkdownIt.vue
@@ -1,6 +1,14 @@
 <!-- eslint-disable vue/no-v-html vue/no-v-text-v-html-on-component -->
 <template>
+  <span
+    v-if="inline"
+    :key="contentHash"
+    class="markdown markdown--inline"
+    @click="$emit('click', $event)"
+    v-html="htmlContent"
+  />
   <div
+    v-else
     :key="contentHash"
     class="markdown"
     @click="$emit('click', $event)"
@@ -9,7 +17,7 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { generateHash } from '@baserow/modules/core/utils/hashing'
 import MarkdownIt from 'markdown-it'
 
@@ -25,12 +33,34 @@ const props = defineProps({
     type: Object,
     default: () => ({}),
   },
+  /**
+   * Render the content with `renderInline` inside a `<span>` instead of parsing
+   * block syntax into a `<div>`. Block syntax (headings, lists, tables...) then
+   * stays literal text, which is what single-line surfaces like labels or
+   * dropdown options want.
+   */
+  inline: {
+    required: false,
+    type: Boolean,
+    default: false,
+  },
+  /**
+   * Names of the markdown-it rules to disable, e.g. `['link', 'image']`. The
+   * policy is owned by the caller because it differs per surface.
+   */
+  disabledRules: {
+    required: false,
+    type: Array,
+    default: () => [],
+  },
 })
 
-// Keep a single markdown-it instance per component instance.
+// Keep a single markdown-it instance per component instance, so disabling rules
+// can't leak to other consumers.
 const Markdown = MarkdownIt?.default || MarkdownIt
 const md = new Markdown()
 const baseRules = { ...md.renderer.rules }
+let appliedDisabledRules = []
 
 // The hash makes sure the data is updated if the content changes.
 const contentHash = computed(() => generateHash(props.content))
@@ -39,12 +69,24 @@ const contentHash = computed(() => generateHash(props.content))
 const htmlContent = ref('')
 
 const renderMarkdown = () => {
+  // Re-enable what was disabled by a previous render before applying the
+  // current list, otherwise a changed `disabledRules` would accumulate.
+  md.enable(appliedDisabledRules, true)
+  md.disable(props.disabledRules, true)
+  appliedDisabledRules = [...props.disabledRules]
+
   md.renderer.rules = { ...baseRules, ...props.rules }
-  htmlContent.value = md.render(props.content)
+  htmlContent.value = props.inline
+    ? md.renderInline(props.content)
+    : md.render(props.content)
 }
 
-watch(() => [props.content, props.rules], renderMarkdown, {
-  deep: true,
-  immediate: true,
-})
+watch(
+  () => [props.content, props.rules, props.inline, props.disabledRules],
+  renderMarkdown,
+  {
+    deep: true,
+    immediate: true,
+  }
+)
 </script>

--- a/web-frontend/modules/core/formula/index.js
+++ b/web-frontend/modules/core/formula/index.js
@@ -1,6 +1,7 @@
 import parseBaserowFormula from '@baserow/modules/core/formula/parser/parser'
 import BaserowFormulaExecutionVisitor from '@baserow/modules/core/formula/parser/formulaExecutionVisitor.js'
 import BaserowFormulaValidationVisitor from '@baserow/modules/core/formula/parser/formulaValidationVisitor.js'
+import { stripFormat } from '@baserow/modules/core/formula/textFormat'
 import { FORMULA_TYPE } from '@baserow/modules/core/enums'
 
 // Identical formulas share one parse tree, which avoids re-lexing and
@@ -44,17 +45,21 @@ export const resolveFormula = (
   functions,
   RuntimeFormulaContext
 ) => {
-  if (!formulaCtx.formula) {
-    return formulaCtx.formula
+  // The text format marker is not part of the formula: it is never resolved
+  // and never part of the result.
+  const formula = stripFormat(formulaCtx.formula)
+
+  if (!formula) {
+    return formula
   }
 
   if (formulaCtx.mode === 'raw') {
     // We don't need to resolve the formula for raw mode.
-    return formulaCtx.formula
+    return formula
   }
 
   try {
-    const tree = getCachedParseTree(formulaCtx.formula)
+    const tree = getCachedParseTree(formula)
     return new BaserowFormulaExecutionVisitor(
       functions,
       RuntimeFormulaContext
@@ -85,11 +90,13 @@ export const isFormulaValid = (
   validationContext = {},
   localisedInvalidSyntaxMessage = null
 ) => {
-  if (!formula) {
+  // The text format marker is not part of the formula syntax.
+  const bareFormula = stripFormat(formula)
+  if (!bareFormula) {
     return { scope: null, valid: true, errors: [] }
   }
   try {
-    const tree = parseBaserowFormula(formula)
+    const tree = parseBaserowFormula(bareFormula)
     if (!syntaxOnly) {
       new BaserowFormulaValidationVisitor(functions, validationContext).visit(
         tree

--- a/web-frontend/modules/core/formula/textFormat.js
+++ b/web-frontend/modules/core/formula/textFormat.js
@@ -1,0 +1,78 @@
+/**
+ * The text format of a user-provided text is stored inside the value itself: a
+ * value that begins with the Markdown sentinel below is rendered as Markdown by
+ * the Application Builder. The sentinel is part of the *stored* value only, it
+ * is never part of the formula syntax, never resolved, never validated and
+ * never displayed. Every consumer goes through the helpers of this module,
+ * nothing else should compare against the literal.
+ *
+ * The value is either a formula string (the sentinel goes in front of the
+ * formula, e.g. `__markdown__get('data_source.1.field_2')`) or a plain string
+ * such as a collection field name or a choice option name.
+ */
+
+export const TEXT_FORMATS = {
+  PLAIN: 'plain',
+  MARKDOWN: 'markdown',
+}
+
+export const MARKDOWN_PREFIX = '__markdown__'
+
+/**
+ * Splits a stored value into its text format and the bare value.
+ *
+ * @param {string|any} value The stored value, with or without the sentinel.
+ * @returns {{format: string, value: any}} The format and the bare value.
+ *   Non-string values are returned unchanged with the `plain` format.
+ */
+export const splitFormat = (value) => {
+  if (typeof value === 'string' && value.startsWith(MARKDOWN_PREFIX)) {
+    return {
+      format: TEXT_FORMATS.MARKDOWN,
+      value: value.slice(MARKDOWN_PREFIX.length),
+    }
+  }
+  return { format: TEXT_FORMATS.PLAIN, value }
+}
+
+/**
+ * Returns the bare value, without the sentinel if it has one.
+ */
+export const stripFormat = (value) => splitFormat(value).value
+
+/**
+ * Returns the text format of a stored value.
+ */
+export const getFormat = (value) => splitFormat(value).format
+
+/**
+ * Marks a bare value with the given text format.
+ *
+ * @param {string} bareValue The value without any text format marker.
+ * @param {string} format The text format the value should be rendered with.
+ * @returns {string} The stored representation of the value.
+ */
+export const addPrefix = (bareValue, format = TEXT_FORMATS.MARKDOWN) =>
+  format === TEXT_FORMATS.MARKDOWN
+    ? `${MARKDOWN_PREFIX}${bareValue ?? ''}`
+    : bareValue
+
+/**
+ * Changes the text format of a stored value, keeping its bare value.
+ */
+export const setFormat = (value, format) =>
+  addPrefix(stripFormat(value), format)
+
+/**
+ * Returns the text format of a formula object (`{ formula, mode, version }`).
+ */
+export const getFormulaFormat = (formulaObject) =>
+  getFormat(formulaObject?.formula)
+
+/**
+ * Returns a copy of the formula object with the given text format.
+ */
+export const setFormulaFormat = (formulaObject, format) => ({
+  ...(formulaObject || {}),
+  formula: setFormat(formulaObject?.formula ?? '', format),
+})

--- a/web-frontend/test/unit/builder/components/ApplicationBuilderFormulaInput.spec.js
+++ b/web-frontend/test/unit/builder/components/ApplicationBuilderFormulaInput.spec.js
@@ -1,0 +1,91 @@
+// `builder/enums` and `builder/dataProviderTypes` import each other. Entering
+// the cycle through the component would evaluate the enums first with the data
+// provider types still undefined, so the enums are loaded up front, like the
+// builder plugin does in the app.
+import '@baserow/modules/builder/enums'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { defineComponent, h } from 'vue'
+import ApplicationBuilderFormulaInput from '@baserow/modules/builder/components/ApplicationBuilderFormulaInput.vue'
+import { MARKDOWN_PREFIX } from '@baserow/modules/core/formula/textFormat'
+
+/**
+ * The formula editor is replaced by a stub that renders the formula it is
+ * given and emits whatever the test types.
+ */
+const FormulaInputFieldStub = defineComponent({
+  name: 'FormulaInputField',
+  props: { value: { type: String, default: '' }, mode: { type: String } },
+  emits: ['input'],
+  render() {
+    return h('div', { class: 'formula-input-field-stub' }, this.value)
+  },
+})
+
+describe('ApplicationBuilderFormulaInput', () => {
+  const page = { id: 1, elements: [], _: { dataSourceLoading: false } }
+
+  const mountComponent = (value) =>
+    mountSuspended(ApplicationBuilderFormulaInput, {
+      props: { value, dataProvidersAllowed: [] },
+      global: {
+        provide: {
+          elementPage: page,
+          applicationContext: { page, builder: { id: 1 }, mode: 'editing' },
+        },
+        stubs: { FormulaInputField: FormulaInputFieldStub },
+      },
+    })
+
+  test('never shows the text format marker in the editor', async () => {
+    const wrapper = await mountComponent({
+      formula: `${MARKDOWN_PREFIX}get('page_parameter.id')`,
+      mode: 'simple',
+      version: '0.1',
+    })
+
+    const editor = wrapper.findComponent({ name: 'FormulaInputField' })
+    expect(editor.props('value')).toBe("get('page_parameter.id')")
+    expect(wrapper.text()).not.toContain(MARKDOWN_PREFIX)
+  })
+
+  test('adds the marker back to what the editor emits', async () => {
+    const wrapper = await mountComponent({
+      formula: `${MARKDOWN_PREFIX}get('page_parameter.id')`,
+      mode: 'simple',
+      version: '0.1',
+    })
+
+    const editor = wrapper.findComponent({ name: 'FormulaInputField' })
+    await editor.vm.$emit('input', "concat('a', get('page_parameter.id'))")
+
+    const expected = {
+      formula: `${MARKDOWN_PREFIX}concat('a', get('page_parameter.id'))`,
+      mode: 'simple',
+      version: '0.1',
+    }
+    expect(wrapper.emitted('input')).toEqual([[expected]])
+    expect(wrapper.emitted('update:modelValue')).toEqual([[expected]])
+  })
+
+  test('keeps the marker when the editor is emptied', async () => {
+    const wrapper = await mountComponent({
+      formula: `${MARKDOWN_PREFIX}'a'`,
+      mode: 'simple',
+    })
+
+    const editor = wrapper.findComponent({ name: 'FormulaInputField' })
+    await editor.vm.$emit('input', '')
+
+    expect(wrapper.emitted('input')[0][0].formula).toBe(MARKDOWN_PREFIX)
+  })
+
+  test('leaves plain formulas alone', async () => {
+    const wrapper = await mountComponent({ formula: "'a'", mode: 'simple' })
+
+    const editor = wrapper.findComponent({ name: 'FormulaInputField' })
+    expect(editor.props('value')).toBe("'a'")
+    await editor.vm.$emit('input', "'b'")
+
+    expect(wrapper.emitted('input')[0][0].formula).toBe("'b'")
+  })
+})

--- a/web-frontend/test/unit/builder/components/BuilderToasts.spec.js
+++ b/web-frontend/test/unit/builder/components/BuilderToasts.spec.js
@@ -1,0 +1,59 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import BuilderToasts from '@baserow/modules/builder/components/BuilderToasts.vue'
+
+describe('BuilderToasts', () => {
+  let store = null
+
+  beforeEach(() => {
+    store = useNuxtApp().$store
+  })
+
+  afterEach(async () => {
+    for (const toast of [...store.getters['builderToast/all']]) {
+      await store.dispatch('builderToast/remove', toast)
+    }
+  })
+
+  const mountComponent = () =>
+    mountSuspended(BuilderToasts, {
+      global: { provide: { builder: { id: 1 }, mode: 'public' } },
+    })
+
+  test('renders plain toasts as-is', async () => {
+    await store.dispatch('builderToast/info', {
+      title: '**Saved**',
+      message: 'See [details](/details)',
+    })
+    const wrapper = await mountComponent()
+
+    expect(wrapper.find('.ab-toast__title strong').exists()).toBe(false)
+    expect(wrapper.find('.ab-toast__title').text()).toBe('**Saved**')
+    expect(wrapper.find('.ab-toast__message a').exists()).toBe(false)
+    expect(wrapper.find('.ab-toast__message').text()).toBe(
+      'See [details](/details)'
+    )
+  })
+
+  test('renders a Markdown title inline and a Markdown message as restricted block', async () => {
+    await store.dispatch('builderToast/info', {
+      title: '# **Saved** [x](/x)',
+      titleFormat: 'markdown',
+      message:
+        '# Not a heading\n\nSee [details](/details)\n\n| a |\n|---|\n| 1 |',
+      messageFormat: 'markdown',
+    })
+    const wrapper = await mountComponent()
+
+    const title = wrapper.find('.ab-toast__title')
+    expect(title.find('.markdown--inline strong').text()).toBe('Saved')
+    expect(title.find('a').exists()).toBe(false)
+    expect(title.find('.ab-heading').exists()).toBe(false)
+
+    const message = wrapper.find('.ab-toast__message')
+    expect(message.find('.ab-heading').exists()).toBe(false)
+    expect(message.find('table').exists()).toBe(false)
+    expect(message.find('p.ab-text').exists()).toBe(true)
+    expect(message.find('a.ab-link').attributes('href')).toBe('/details')
+    expect(message.text()).toContain('# Not a heading')
+  })
+})

--- a/web-frontend/test/unit/builder/components/FormattedText.spec.js
+++ b/web-frontend/test/unit/builder/components/FormattedText.spec.js
@@ -1,0 +1,237 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import FormattedText from '@baserow/modules/builder/components/FormattedText.vue'
+
+describe('FormattedText', () => {
+  const builder = { id: 7 }
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const mountComponent = (props, { mode = 'public' } = {}) =>
+    mountSuspended(FormattedText, {
+      props,
+      global: { provide: { builder, mode } },
+    })
+
+  const click = (wrapper, selector) => {
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+    wrapper.find(selector).element.dispatchEvent(event)
+    return event
+  }
+
+  test('renders the raw text when the format is plain', async () => {
+    const wrapper = await mountComponent({ content: '**bold** [x](/x)' })
+
+    expect(wrapper.find('strong').exists()).toBe(false)
+    expect(wrapper.find('a').exists()).toBe(false)
+    expect(wrapper.text()).toBe('**bold** [x](/x)')
+  })
+
+  test('defaults to plain when no format is given', async () => {
+    const wrapper = await mountComponent({ content: '**bold**' })
+
+    expect(wrapper.text()).toBe('**bold**')
+  })
+
+  test('accepts numeric content', async () => {
+    const wrapper = await mountComponent({ content: 5, format: 'markdown' })
+
+    expect(wrapper.text()).toBe('5')
+  })
+
+  test('inline preset renders emphasis but keeps links and block syntax literal', async () => {
+    const wrapper = await mountComponent({
+      content: '# **Urgent** [docs](https://example.com) `code`',
+      format: 'markdown',
+      preset: 'inline',
+    })
+
+    expect(wrapper.element.tagName).toBe('SPAN')
+    expect(wrapper.find('strong').text()).toBe('Urgent')
+    expect(wrapper.find('.ab-code--inline').text()).toBe('code')
+    expect(wrapper.find('a').exists()).toBe(false)
+    expect(wrapper.find('h1').exists()).toBe(false)
+    expect(wrapper.text()).toBe('# Urgent [docs](https://example.com) code')
+  })
+
+  test('inline presets render line breaks as spaces', async () => {
+    const wrapper = await mountComponent({
+      content: 'first  \nsecond\\\nthird',
+      format: 'markdown',
+      preset: 'inline',
+    })
+
+    expect(wrapper.find('br').exists()).toBe(false)
+    expect(wrapper.text()).toBe('first second third')
+  })
+
+  test('inlineLinks preset renders links but keeps images literal', async () => {
+    const wrapper = await mountComponent({
+      content:
+        'Agree to the [terms](/terms) and [docs](https://example.com) ![i](https://example.com/i.png "t")',
+      format: 'markdown',
+      preset: 'inlineLinks',
+    })
+
+    const links = wrapper.findAll('a.ab-link')
+    expect(links).toHaveLength(2)
+    expect(links[0].attributes('href')).toBe('/terms')
+    expect(links[1].attributes('href')).toBe('https://example.com')
+    expect(wrapper.find('img').exists()).toBe(false)
+    expect(wrapper.text()).toContain('![i](https://example.com/i.png "t")')
+  })
+
+  test('prefixes internal links in preview mode', async () => {
+    const wrapper = await mountComponent(
+      { content: '[terms](/terms)', format: 'markdown', preset: 'inlineLinks' },
+      { mode: 'preview' }
+    )
+
+    expect(wrapper.find('a.ab-link').attributes('href')).toBe(
+      '/builder/7/preview/terms'
+    )
+  })
+
+  test('explicit builder and mode props win over the injected ones', async () => {
+    const wrapper = await mountComponent(
+      {
+        content: '[terms](/terms)',
+        format: 'markdown',
+        preset: 'inlineLinks',
+        builder: { id: 9 },
+        mode: 'preview',
+      },
+      { mode: 'public' }
+    )
+
+    expect(wrapper.find('a.ab-link').attributes('href')).toBe(
+      '/builder/9/preview/terms'
+    )
+  })
+
+  test('restrictedBlock preset drops layout-breaking blocks but keeps links and lists', async () => {
+    const content = [
+      '# Heading',
+      '',
+      'Some **text** with [a link](https://example.com)',
+      '',
+      '- item',
+      '',
+      '| a | b |',
+      '|---|---|',
+      '| 1 | 2 |',
+      '',
+      '```',
+      'code',
+      '```',
+      '',
+      '![i](https://example.com/i.png)',
+    ].join('\n')
+    const wrapper = await mountComponent({
+      content,
+      format: 'markdown',
+      preset: 'restrictedBlock',
+    })
+
+    expect(wrapper.element.tagName).toBe('DIV')
+    expect(wrapper.find('.ab-heading').exists()).toBe(false)
+    expect(wrapper.find('table').exists()).toBe(false)
+    expect(wrapper.find('pre').exists()).toBe(false)
+    expect(wrapper.find('img').exists()).toBe(false)
+    expect(wrapper.text()).toContain('![i](https://example.com/i.png)')
+    expect(wrapper.find('p.ab-text').exists()).toBe(true)
+    expect(wrapper.find('strong').text()).toBe('text')
+    expect(wrapper.find('a.ab-link').attributes('href')).toBe(
+      'https://example.com'
+    )
+    expect(wrapper.find('.ab-list__item').text()).toBe('item')
+    expect(wrapper.text()).toContain('# Heading')
+  })
+
+  test('block preset renders the full syntax', async () => {
+    const wrapper = await mountComponent({
+      content: '# Heading\n\n| a |\n|---|\n| 1 |',
+      format: 'markdown',
+      preset: 'block',
+    })
+
+    expect(wrapper.find('.ab-heading').text()).toBe('Heading')
+    expect(wrapper.find('table').exists()).toBe(true)
+  })
+
+  test('blocks link navigation in editing mode', async () => {
+    const wrapper = await mountComponent(
+      { content: '[terms](/terms)', format: 'markdown', preset: 'inlineLinks' },
+      { mode: 'editing' }
+    )
+
+    const event = click(wrapper, 'a.ab-link')
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  test('routes internal links through the router', async () => {
+    const push = vi
+      .spyOn(useNuxtApp().$router, 'push')
+      .mockImplementation(() => Promise.resolve())
+    const wrapper = await mountComponent({
+      content: '[terms](/terms)',
+      format: 'markdown',
+      preset: 'inlineLinks',
+    })
+
+    const event = click(wrapper, 'a.ab-link')
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(push).toHaveBeenCalledWith('/terms')
+  })
+
+  test('routes internal links through the router when nested markup is clicked', async () => {
+    const push = vi
+      .spyOn(useNuxtApp().$router, 'push')
+      .mockImplementation(() => Promise.resolve())
+    const wrapper = await mountComponent({
+      content: '[**terms**](/terms)',
+      format: 'markdown',
+      preset: 'inlineLinks',
+    })
+
+    const event = click(wrapper, 'a.ab-link strong')
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(push).toHaveBeenCalledWith('/terms')
+  })
+
+  test('ignores clicks outside links', async () => {
+    const push = vi
+      .spyOn(useNuxtApp().$router, 'push')
+      .mockImplementation(() => Promise.resolve())
+    const wrapper = await mountComponent({
+      content: '**bold** [terms](/terms)',
+      format: 'markdown',
+      preset: 'inlineLinks',
+    })
+
+    const event = click(wrapper, 'strong')
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  test('leaves external links to the browser', async () => {
+    const push = vi
+      .spyOn(useNuxtApp().$router, 'push')
+      .mockImplementation(() => Promise.resolve())
+    const wrapper = await mountComponent({
+      content: '[docs](https://example.com)',
+      format: 'markdown',
+      preset: 'inlineLinks',
+    })
+
+    const event = click(wrapper, 'a.ab-link')
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(push).not.toHaveBeenCalled()
+  })
+})

--- a/web-frontend/test/unit/builder/components/elements/components/CheckboxElement.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/CheckboxElement.spec.js
@@ -1,0 +1,138 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import CheckboxElement from '@baserow/modules/builder/components/elements/components/CheckboxElement.vue'
+import { MARKDOWN_PREFIX } from '@baserow/modules/core/formula/textFormat'
+
+// A Markdown label is a label formula stored with the Markdown marker in front.
+const markdownLabel = {
+  mode: 'raw',
+  formula: `${MARKDOWN_PREFIX}I agree to the [terms](/terms)`,
+}
+
+describe('CheckboxElement', () => {
+  let store = null
+  let wrapper = null
+
+  beforeEach(() => {
+    store = useNuxtApp().$store
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = null
+  })
+
+  const mountCheckbox = async ({ mode = 'public', ...elementOverrides }) => {
+    const page = { id: 1, elements: [] }
+    const builder = { id: 1, theme: { primary_color: '#ccc' }, pages: [page] }
+    const applicationContext = { builder, page, mode }
+    const element = {
+      id: 42,
+      type: 'checkbox',
+      label: { mode: 'raw', formula: 'I agree to the [terms](/terms)' },
+      default_value: { formula: '' },
+      required: false,
+      page_id: page.id,
+      styles: {},
+      ...elementOverrides,
+    }
+
+    store.dispatch('element/forceCreate', { page, element })
+    const elementType = store.$registry.get('element', 'checkbox')
+    store.dispatch('formData/setFormData', {
+      page,
+      elementId: element.id,
+      payload: {
+        value: false,
+        type: elementType.formDataType(element),
+        isValid: elementType.isValid(element, false, applicationContext),
+        touched: false,
+      },
+    })
+
+    // Attached to the document so that the native `label[for]` activation
+    // behaviour applies when clicking the label.
+    return mountSuspended(CheckboxElement, {
+      props: { element },
+      attachTo: document.body,
+      global: {
+        provide: {
+          builder,
+          currentPage: page,
+          elementPage: page,
+          mode,
+          applicationContext,
+          element,
+          workspace: {},
+        },
+      },
+    })
+  }
+
+  const click = (wrapper, selector) => {
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+    wrapper.find(selector).element.dispatchEvent(event)
+    return event
+  }
+
+  test('renders the raw label when the format is plain', async () => {
+    wrapper = await mountCheckbox({})
+
+    expect(wrapper.find('.ab-checkbox__label a').exists()).toBe(false)
+    expect(wrapper.find('.ab-checkbox__label').text()).toBe(
+      'I agree to the [terms](/terms)'
+    )
+  })
+
+  test('renders a Markdown label with links', async () => {
+    wrapper = await mountCheckbox({ label: markdownLabel })
+
+    const link = wrapper.find('.ab-checkbox__label a.ab-link')
+    expect(link.text()).toBe('terms')
+    expect(link.attributes('href')).toBe('/terms')
+  })
+
+  test('clicking the label text toggles the checkbox, clicking the link does not', async () => {
+    wrapper = await mountCheckbox({ label: markdownLabel })
+    expect(wrapper.vm.inputValue).toBe(false)
+
+    click(wrapper, '.ab-checkbox__label')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.inputValue).toBe(true)
+
+    click(wrapper, '.ab-checkbox__label a.ab-link')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.inputValue).toBe(true)
+  })
+
+  test('a resolved value that begins with the marker is not Markdown', async () => {
+    // Only the stored formula carries the format: a plain label whose
+    // *resolved* text happens to start with the marker renders literally.
+    wrapper = await mountCheckbox({
+      label: { mode: 'simple', formula: `'${MARKDOWN_PREFIX}**terms**'` },
+    })
+
+    expect(wrapper.find('.ab-checkbox__label strong').exists()).toBe(false)
+    expect(wrapper.find('.ab-checkbox__label').text()).toBe(
+      `${MARKDOWN_PREFIX}**terms**`
+    )
+  })
+
+  test('an empty Markdown label renders nothing', async () => {
+    wrapper = await mountCheckbox({
+      label: { mode: 'simple', formula: MARKDOWN_PREFIX },
+    })
+
+    expect(wrapper.find('.ab-checkbox__label').text()).toBe('')
+  })
+
+  test('blocks link navigation in editing mode', async () => {
+    wrapper = await mountCheckbox({
+      label: markdownLabel,
+      mode: 'editing',
+    })
+
+    const event = click(wrapper, '.ab-checkbox__label a.ab-link')
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+})

--- a/web-frontend/test/unit/builder/components/elements/components/ChoiceElement.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/ChoiceElement.spec.js
@@ -1,5 +1,6 @@
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import ChoiceElement from '@baserow/modules/builder/components/elements/components/ChoiceElement.vue'
+import { MARKDOWN_PREFIX } from '@baserow/modules/core/formula/textFormat'
 
 describe('ChoiceElement', () => {
   let testApp = null
@@ -111,11 +112,11 @@ describe('ChoiceElement', () => {
 
     expect(wrapper.vm.optionsResolved).toEqual([
       // An empty string is a valid Value
-      { value: '', name: 'Foo Name' },
+      { value: '', name: 'Foo Name', format: 'plain' },
       // 'bar_name' is a valid Value
-      { value: 'bar_name', name: 'Bar Name' },
+      { value: 'bar_name', name: 'Bar Name', format: 'plain' },
       // null is replaced by the name, i.e. 'Baz Name'
-      { value: 'Baz Name', name: 'Baz Name' },
+      { value: 'Baz Name', name: 'Baz Name', format: 'plain' },
     ])
   })
 
@@ -153,5 +154,191 @@ describe('ChoiceElement', () => {
     })
 
     expect(wrapper.element).toMatchSnapshot()
+  })
+})
+
+describe('ChoiceElement Markdown', () => {
+  let store = null
+
+  // The option names carry their own text format marker.
+  const markdownOptions = [
+    { id: 1, value: '1', name: `${MARKDOWN_PREFIX}**First**` },
+    {
+      id: 2,
+      value: '2',
+      name: `${MARKDOWN_PREFIX}See [docs](https://example.com)`,
+    },
+  ]
+  const markdownLabel = {
+    mode: 'raw',
+    formula: `${MARKDOWN_PREFIX}Pick **one** ([help](/help))`,
+  }
+
+  beforeEach(() => {
+    store = useNuxtApp().$store
+  })
+
+  // The selection is driven by `default_value`: the form element mixin resets
+  // the form data to the resolved default value on mount.
+  const mountChoice = async (elementOverrides, value = null) => {
+    const page = { id: 1, elements: [] }
+    const builder = { id: 1, theme: { primary_color: '#ccc' }, pages: [page] }
+    const mode = 'public'
+    const applicationContext = { builder, page, mode }
+    const element = {
+      id: 43,
+      type: 'choice',
+      label: { mode: 'raw', formula: 'Pick **one** ([help](/help))' },
+      default_value: { formula: '' },
+      placeholder: { formula: '' },
+      required: false,
+      multiple: false,
+      show_as_dropdown: false,
+      option_type: 'manual',
+      options: [
+        { id: 1, value: '1', name: '**First**' },
+        { id: 2, value: '2', name: 'See [docs](https://example.com)' },
+      ],
+      page_id: page.id,
+      styles: {},
+      ...elementOverrides,
+    }
+
+    store.dispatch('element/forceCreate', { page, element })
+    const elementType = store.$registry.get('element', 'choice')
+    store.dispatch('formData/setFormData', {
+      page,
+      elementId: element.id,
+      payload: {
+        value,
+        type: elementType.formDataType(element),
+        isValid: elementType.isValid(element, value, applicationContext),
+        touched: false,
+      },
+    })
+
+    return mountSuspended(ChoiceElement, {
+      props: { element },
+      global: {
+        provide: {
+          builder,
+          currentPage: page,
+          elementPage: page,
+          mode,
+          applicationContext,
+          element,
+          workspace: {},
+        },
+      },
+    })
+  }
+
+  test('renders the label as Markdown with links', async () => {
+    const wrapper = await mountChoice({ label: markdownLabel })
+
+    const label = wrapper.find('.ab-form-group__label')
+    expect(label.find('strong').text()).toBe('one')
+    expect(label.find('a.ab-link').attributes('href')).toBe('/help')
+  })
+
+  test('renders plain option names as-is', async () => {
+    const wrapper = await mountChoice({})
+
+    const [first] = wrapper.findAll('.ab-radio__label')
+    expect(first.find('strong').exists()).toBe(false)
+    expect(first.text()).toBe('**First**')
+  })
+
+  test('renders radio option names as inline Markdown without links', async () => {
+    const wrapper = await mountChoice({ options: markdownOptions })
+
+    const [first, second] = wrapper.findAll('.ab-radio__label')
+    expect(first.find('strong').text()).toBe('First')
+    expect(second.find('a').exists()).toBe(false)
+    expect(second.text()).toBe('See [docs](https://example.com)')
+  })
+
+  test('renders checkbox option names as inline Markdown', async () => {
+    const wrapper = await mountChoice(
+      { options: markdownOptions, multiple: true },
+      []
+    )
+
+    const [first] = wrapper.findAll('.ab-checkbox__label')
+    expect(first.find('strong').text()).toBe('First')
+  })
+
+  test('renders dropdown option names as inline Markdown, keeping the raw name as tooltip', async () => {
+    const wrapper = await mountChoice(
+      {
+        options: markdownOptions,
+        show_as_dropdown: true,
+        default_value: { mode: 'raw', formula: '1' },
+      },
+      '1'
+    )
+
+    const [first, second] = wrapper.findAll('.ab-dropdownitem__item-name-text')
+    expect(first.find('strong').text()).toBe('First')
+    expect(first.attributes('title')).toBe('**First**')
+    expect(second.find('a').exists()).toBe(false)
+
+    // The collapsed dropdown shows the selected option rendered as well. The
+    // dropdown resolves its selection once the items have registered.
+    await wrapper.vm.$nextTick()
+    const selected = wrapper.find('.ab-dropdown__selected-text')
+    expect(selected.find('strong').text()).toBe('First')
+  })
+
+  test('renders formula option names as Markdown when the name formula is marked', async () => {
+    const wrapper = await mountChoice({
+      option_type: 'formulas',
+      formula_value: { mode: 'raw', formula: '1,2' },
+      formula_name: { mode: 'raw', formula: `${MARKDOWN_PREFIX}**A**,**B**` },
+    })
+
+    const [first, second] = wrapper.findAll('.ab-radio__label')
+    expect(first.find('strong').text()).toBe('A')
+    expect(second.find('strong').text()).toBe('B')
+  })
+
+  test('keeps plain formula option names literal', async () => {
+    const wrapper = await mountChoice({
+      option_type: 'formulas',
+      formula_value: { mode: 'raw', formula: '1,2' },
+      formula_name: { mode: 'raw', formula: '**A**,**B**' },
+    })
+
+    const [first] = wrapper.findAll('.ab-radio__label')
+    expect(first.find('strong').exists()).toBe(false)
+    expect(first.text()).toBe('**A**')
+  })
+
+  test('never submits the marker as the value of an option without a value', async () => {
+    const wrapper = await mountChoice({
+      options: [{ id: 1, value: null, name: `${MARKDOWN_PREFIX}**First**` }],
+    })
+
+    expect(wrapper.vm.optionsResolved).toEqual([
+      { name: '**First**', value: '**First**', format: 'markdown' },
+    ])
+    expect(wrapper.find('.ab-radio__label strong').text()).toBe('First')
+  })
+
+  test('renders every selected option in a multiple Markdown dropdown', async () => {
+    const wrapper = await mountChoice(
+      {
+        options: markdownOptions,
+        show_as_dropdown: true,
+        multiple: true,
+        default_value: { mode: 'raw', formula: '1,2' },
+      },
+      ['1', '2']
+    )
+
+    await wrapper.vm.$nextTick()
+    const selected = wrapper.find('.ab-dropdown__selected-text')
+    expect(selected.find('strong').text()).toBe('First')
+    expect(selected.text()).toBe('First, See [docs](https://example.com)')
   })
 })

--- a/web-frontend/test/unit/builder/components/elements/components/InputTextElement.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/InputTextElement.spec.js
@@ -1,5 +1,6 @@
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import InputTextElement from '@baserow/modules/builder/components/elements/components/InputTextElement.vue'
+import { MARKDOWN_PREFIX } from '@baserow/modules/core/formula/textFormat'
 
 describe('InputTextElement', () => {
   let store = null
@@ -62,4 +63,72 @@ describe('InputTextElement', () => {
       expect(wrapper.find('input').element.value).toBe(expected)
     }
   )
+})
+
+describe('InputTextElement label', () => {
+  let store = null
+
+  beforeEach(() => {
+    store = useNuxtApp().$store
+  })
+
+  const mountWithLabel = async (label) => {
+    const page = { id: 1, elements: [] }
+    const builder = { id: 1, theme: { primary_color: '#ccc' }, pages: [page] }
+    const workspace = {}
+    const mode = 'public'
+    const element = {
+      id: 43,
+      type: 'input_text',
+      validation_type: 'any',
+      default_value: { formula: '' },
+      label,
+      placeholder: { formula: '' },
+      required: false,
+      is_multiline: false,
+      rows: 1,
+      input_type: 'text',
+      page_id: page.id,
+      styles: {},
+    }
+
+    store.dispatch('element/forceCreate', { page, element })
+
+    return mountSuspended(InputTextElement, {
+      props: { element },
+      global: {
+        provide: {
+          builder,
+          currentPage: page,
+          elementPage: page,
+          mode,
+          applicationContext: { builder, page, mode },
+          element,
+          workspace,
+        },
+      },
+    })
+  }
+
+  test('renders the raw label by default', async () => {
+    const wrapper = await mountWithLabel({
+      mode: 'raw',
+      formula: 'Your **name** ([why?](/why))',
+    })
+
+    const label = wrapper.find('.ab-form-group__label')
+    expect(label.find('strong').exists()).toBe(false)
+    expect(label.text()).toBe('Your **name** ([why?](/why))')
+  })
+
+  test('renders a Markdown label with links', async () => {
+    const wrapper = await mountWithLabel({
+      mode: 'raw',
+      formula: `${MARKDOWN_PREFIX}Your **name** ([why?](/why))`,
+    })
+
+    const label = wrapper.find('.ab-form-group__label')
+    expect(label.find('strong').text()).toBe('name')
+    expect(label.find('a.ab-link').attributes('href')).toBe('/why')
+  })
 })

--- a/web-frontend/test/unit/builder/components/elements/components/TableElement.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/TableElement.spec.js
@@ -1,0 +1,82 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import TableElement from '@baserow/modules/builder/components/elements/components/TableElement.vue'
+import { MARKDOWN_PREFIX } from '@baserow/modules/core/formula/textFormat'
+
+describe('TableElement', () => {
+  let store = null
+
+  beforeEach(() => {
+    store = useNuxtApp().$store
+  })
+
+  const mountTable = async (fields) => {
+    const page = { id: 1, elements: [], dataSources: [] }
+    const sharedPage = { id: 2, shared: true, elements: [], dataSources: [] }
+    const builder = {
+      id: 1,
+      theme: { primary_color: '#ccc' },
+      pages: [page, sharedPage],
+      integrations: [],
+    }
+    const mode = 'public'
+    const element = {
+      id: 45,
+      type: 'table',
+      data_source_id: null,
+      schema_property: null,
+      items_per_page: 5,
+      button_load_more_label: { formula: '' },
+      orientation: {
+        desktop: 'horizontal',
+        tablet: 'horizontal',
+        smartphone: 'horizontal',
+      },
+      fields: fields.map((field, index) => ({
+        id: index + 1,
+        uid: `uid-${index + 1}`,
+        type: 'text',
+        value: { formula: '' },
+        styles: {},
+        ...field,
+      })),
+      page_id: page.id,
+      styles: {},
+    }
+
+    store.dispatch('element/forceCreate', { page, element })
+
+    return mountSuspended(TableElement, {
+      // Like `ElementPreview`/`PageElement`, the page reaches the collection
+      // element through the application context additions.
+      props: {
+        element,
+        applicationContextAdditions: { recordIndexPath: [], page },
+      },
+      global: {
+        provide: {
+          builder,
+          currentPage: page,
+          elementPage: page,
+          mode,
+          applicationContext: { builder, page, mode, element },
+          element,
+          workspace: {},
+        },
+      },
+    })
+  }
+
+  test('renders column headers as inline Markdown only when the name is marked', async () => {
+    const wrapper = await mountTable([
+      { name: `${MARKDOWN_PREFIX}**Bold** ([docs](https://example.com))` },
+      { name: '**Plain**' },
+    ])
+
+    const [markdown, plain] = wrapper.findAll('th')
+    expect(markdown.find('strong').text()).toBe('Bold')
+    expect(markdown.find('a').exists()).toBe(false)
+    expect(markdown.text()).toBe('Bold ([docs](https://example.com))')
+    expect(plain.find('strong').exists()).toBe(false)
+    expect(plain.text()).toBe('**Plain**')
+  })
+})

--- a/web-frontend/test/unit/builder/components/elements/components/TextField.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/TextField.spec.js
@@ -1,0 +1,51 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import TextField from '@baserow/modules/builder/components/elements/components/collectionField/TextField.vue'
+
+describe('TextField', () => {
+  const page = {}
+  const builder = { id: 1, theme: {} }
+  const mode = 'public'
+  const element = { id: 1, type: 'table', fields: [], styles: {} }
+  const field = { id: 1, uid: 'abc', name: 'Field', type: 'text', styles: {} }
+  const value = '# Heading\n\n`inline code`'
+
+  const mountComponent = (props = {}) =>
+    mountSuspended(TextField, {
+      props: { element, field, value, ...props },
+      global: {
+        provide: {
+          workspace: {},
+          builder,
+          currentPage: page,
+          elementPage: page,
+          mode,
+          applicationContext: { builder, page, mode },
+        },
+      },
+    })
+
+  test('renders Markdown with the Application Builder rules', async () => {
+    const wrapper = await mountComponent({ format: 'markdown' })
+
+    expect(wrapper.find('.ab-heading').text()).toBe('Heading')
+    expect(wrapper.find('.ab-code--inline').text()).toBe('inline code')
+    expect(wrapper.find('span.ab-text').exists()).toBe(false)
+  })
+
+  test('renders the raw text when the format is plain', async () => {
+    const wrapper = await mountComponent({ format: 'plain' })
+
+    const spans = wrapper.findAll('span.ab-text')
+    expect(spans).toHaveLength(1)
+    expect(spans[0].text()).toBe(value)
+    expect(wrapper.find('.ab-heading').exists()).toBe(false)
+    expect(wrapper.find('.markdown').exists()).toBe(false)
+  })
+
+  test('defaults to plain when no format is given', async () => {
+    const wrapper = await mountComponent()
+
+    expect(wrapper.find('span.ab-text').text()).toBe(value)
+    expect(wrapper.find('.ab-heading').exists()).toBe(false)
+  })
+})

--- a/web-frontend/test/unit/builder/components/elements/components/__snapshots__/ChoiceElement.spec.js.snap
+++ b/web-frontend/test/unit/builder/components/elements/components/__snapshots__/ChoiceElement.spec.js.snap
@@ -116,7 +116,9 @@ exports[`ChoiceElement > as manual checkboxes 1`] = `
               for="ab-checkbox-v-0-0-1"
             >
               
+              
               First
+              
               
             </label>
           </div>
@@ -134,7 +136,9 @@ exports[`ChoiceElement > as manual checkboxes 1`] = `
               for="ab-checkbox-v-0-0-2"
             >
               
+              
               Second
+              
               
             </label>
           </div>
@@ -221,7 +225,9 @@ exports[`ChoiceElement > as manual dropdown 1`] = `
                         class="ab-dropdownitem__item-name-text"
                         title="First"
                       >
+                        
                         First
+                        
                       </span>
                       
                     </div>
@@ -246,7 +252,9 @@ exports[`ChoiceElement > as manual dropdown 1`] = `
                         class="ab-dropdownitem__item-name-text"
                         title="Second"
                       >
+                        
                         Second
+                        
                       </span>
                       
                     </div>
@@ -315,7 +323,9 @@ exports[`ChoiceElement > as manual radio 1`] = `
               class="ab-radio__label"
             >
               
+              
               First
+              
               
             </label>
           </div>
@@ -331,7 +341,9 @@ exports[`ChoiceElement > as manual radio 1`] = `
               class="ab-radio__label"
             >
               
+              
               Second
+              
               
             </label>
           </div>

--- a/web-frontend/test/unit/builder/components/elements/components/checkboxElementForm.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/checkboxElementForm.spec.js
@@ -1,0 +1,97 @@
+import { MARKDOWN_PREFIX } from '@baserow/modules/core/formula/textFormat'
+import CheckboxElementForm from '@baserow/modules/builder/components/elements/components/forms/general/CheckboxElementForm'
+
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { h } from 'vue'
+
+describe('CheckboxElementForm', () => {
+  let wrapper
+
+  const defaultProps = {
+    element: { id: 1, type: 'table', fields: [] },
+    baseTheme: {},
+    defaultValues: {
+      label: { formula: 'Agree' },
+      default_value: { formula: '' },
+      required: false,
+      styles: {},
+      // Add some non-allowed properties
+      someOtherProp: 'should not be included',
+      anotherProp: 123,
+    },
+  }
+
+  const mountComponent = (props = {}) => {
+    return mountSuspended(CheckboxElementForm, {
+      props: {
+        ...defaultProps,
+        ...props,
+      },
+      mocks: {
+        $t: (key) => key,
+        $registry: {
+          getOrderedList: () => [],
+        },
+      },
+      global: {
+        provide: {
+          workspace: {},
+          builder: {
+            theme: {},
+          },
+          currentPage: {},
+          elementPage: {},
+          mode: 'edit',
+          formulaComponent: () => h('div', `fake formula component`),
+          dataProvidersAllowed: [],
+          openCustomStyleForm: vi.fn(),
+        },
+      },
+      stubs: {
+        FormGroup: true,
+        RadioGroup: true,
+        InjectedFormulaInput: true,
+        CustomStyle: true,
+      },
+    })
+  }
+
+  beforeEach(async () => {
+    wrapper = await mountComponent()
+  })
+
+  afterEach(() => {
+    wrapper.unmount()
+  })
+
+  test('writes the label format into the label formula', async () => {
+    expect(wrapper.vm.allowedValues).toEqual([
+      'label',
+      'default_value',
+      'required',
+      'styles',
+    ])
+    const formatSelector = wrapper.findComponent({ name: 'TextFormatSelector' })
+    expect(formatSelector.props('modelValue')).toBe('plain')
+
+    await formatSelector.vm.$emit('update:modelValue', 'markdown')
+
+    const emittedValues = wrapper.emitted('values-changed')
+    expect(emittedValues).toBeTruthy()
+    const lastEmittedValues = emittedValues[emittedValues.length - 1][0]
+
+    expect(lastEmittedValues).toEqual({
+      label: { formula: `${MARKDOWN_PREFIX}Agree` },
+      default_value: { formula: '' },
+      required: false,
+      styles: {},
+    })
+    expect(formatSelector.props('modelValue')).toBe('markdown')
+
+    await formatSelector.vm.$emit('update:modelValue', 'plain')
+
+    expect(wrapper.vm.values.label).toEqual({ formula: 'Agree' })
+    expect(lastEmittedValues.someOtherProp).toBeUndefined()
+    expect(lastEmittedValues.anotherProp).toBeUndefined()
+  })
+})

--- a/web-frontend/test/unit/builder/components/elements/components/textFieldForm.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/textFieldForm.spec.js
@@ -1,0 +1,91 @@
+import { MARKDOWN_PREFIX } from '@baserow/modules/core/formula/textFormat'
+import TextFieldForm from '@baserow/modules/builder/components/elements/components/collectionField/form/TextFieldForm'
+
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { h } from 'vue'
+
+describe('TextFieldForm', () => {
+  let wrapper
+
+  const defaultProps = {
+    element: { id: 1, type: 'table', fields: [] },
+    baseTheme: {},
+    defaultValues: {
+      value: { formula: 'test text' },
+      styles: {},
+      // Add some non-allowed properties
+      someOtherProp: 'should not be included',
+      anotherProp: 123,
+    },
+  }
+
+  const mountComponent = (props = {}) => {
+    return mountSuspended(TextFieldForm, {
+      props: {
+        ...defaultProps,
+        ...props,
+      },
+      mocks: {
+        $t: (key) => key,
+        $registry: {
+          getOrderedList: () => [],
+        },
+      },
+      global: {
+        provide: {
+          workspace: {},
+          builder: {
+            theme: {},
+          },
+          currentPage: {},
+          elementPage: {},
+          mode: 'edit',
+          formulaComponent: () => h('div', `fake formula component`),
+          dataProvidersAllowed: [],
+          openCustomStyleForm: vi.fn(),
+        },
+      },
+      stubs: {
+        FormGroup: true,
+        RadioGroup: true,
+        InjectedFormulaInput: true,
+        CustomStyle: true,
+      },
+    })
+  }
+
+  beforeEach(async () => {
+    wrapper = await mountComponent()
+  })
+
+  afterEach(() => {
+    wrapper.unmount()
+  })
+
+  test('writes the format into the value formula', async () => {
+    // Verify initial state
+    expect(wrapper.vm.allowedValues).toEqual(['value', 'styles'])
+    const formatSelector = wrapper.findComponent({ name: 'TextFormatSelector' })
+    expect(formatSelector.props('modelValue')).toBe('plain')
+
+    // Simulate a format change
+    await formatSelector.vm.$emit('update:modelValue', 'markdown')
+
+    // Get the last emitted values-changed event
+    const emittedValues = wrapper.emitted('values-changed')
+    expect(emittedValues).toBeTruthy()
+    const lastEmittedValues = emittedValues[emittedValues.length - 1][0]
+
+    // Verify only allowed values are present
+    expect(Object.keys(lastEmittedValues)).toEqual(['value', 'styles'])
+    expect(lastEmittedValues).toEqual({
+      value: { formula: `${MARKDOWN_PREFIX}test text` },
+      styles: {},
+    })
+    expect(formatSelector.props('modelValue')).toBe('markdown')
+
+    // Verify non-allowed values are not present
+    expect(lastEmittedValues.someOtherProp).toBeUndefined()
+    expect(lastEmittedValues.anotherProp).toBeUndefined()
+  })
+})

--- a/web-frontend/test/unit/builder/components/elements/components/textFormatSelector.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/textFormatSelector.spec.js
@@ -1,0 +1,22 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import TextFormatSelector from '@baserow/modules/builder/components/elements/components/forms/TextFormatSelector.vue'
+
+describe('TextFormatSelector', () => {
+  test('offers the plain and markdown formats and emits the selection', async () => {
+    const wrapper = await mountSuspended(TextFormatSelector, {
+      props: { modelValue: 'plain' },
+      mocks: { $t: (key) => key },
+    })
+
+    const radioGroup = wrapper.findComponent({ name: 'RadioGroup' })
+    expect(radioGroup.props('modelValue')).toBe('plain')
+    expect(radioGroup.props('options').map(({ value }) => value)).toEqual([
+      'plain',
+      'markdown',
+    ])
+
+    await radioGroup.vm.$emit('update:modelValue', 'markdown')
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([['markdown']])
+  })
+})

--- a/web-frontend/test/unit/builder/components/elements/components/valueFormatSelector.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/valueFormatSelector.spec.js
@@ -1,0 +1,71 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import ValueFormatSelector from '@baserow/modules/builder/components/elements/components/forms/ValueFormatSelector.vue'
+import { MARKDOWN_PREFIX } from '@baserow/modules/core/formula/textFormat'
+
+describe('ValueFormatSelector', () => {
+  const mountComponent = (modelValue) =>
+    mountSuspended(ValueFormatSelector, {
+      props: { modelValue },
+      mocks: { $t: (key) => key },
+    })
+
+  test('reads and writes the format of a formula object', async () => {
+    const wrapper = await mountComponent({
+      formula: "get('a')",
+      mode: 'simple',
+      version: '0.1',
+    })
+    const selector = wrapper.findComponent({ name: 'TextFormatSelector' })
+    expect(selector.props('modelValue')).toBe('plain')
+
+    await selector.vm.$emit('update:modelValue', 'markdown')
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([
+      [
+        {
+          formula: `${MARKDOWN_PREFIX}get('a')`,
+          mode: 'simple',
+          version: '0.1',
+        },
+      ],
+    ])
+  })
+
+  test('shows markdown for a marked formula and strips it on plain', async () => {
+    const wrapper = await mountComponent({
+      formula: `${MARKDOWN_PREFIX}get('a')`,
+      mode: 'simple',
+    })
+    const selector = wrapper.findComponent({ name: 'TextFormatSelector' })
+    expect(selector.props('modelValue')).toBe('markdown')
+
+    await selector.vm.$emit('update:modelValue', 'plain')
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([
+      [{ formula: "get('a')", mode: 'simple' }],
+    ])
+  })
+
+  test('reads and writes the format of a plain string', async () => {
+    const wrapper = await mountComponent('Name')
+    const selector = wrapper.findComponent({ name: 'TextFormatSelector' })
+    expect(selector.props('modelValue')).toBe('plain')
+
+    await selector.vm.$emit('update:modelValue', 'markdown')
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([
+      [`${MARKDOWN_PREFIX}Name`],
+    ])
+  })
+
+  test('marks an empty formula object', async () => {
+    const wrapper = await mountComponent({})
+    const selector = wrapper.findComponent({ name: 'TextFormatSelector' })
+
+    await selector.vm.$emit('update:modelValue', 'markdown')
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([
+      [{ formula: MARKDOWN_PREFIX }],
+    ])
+  })
+})

--- a/web-frontend/test/unit/builder/components/workflowAction/notificationWorkflowActionForm.spec.js
+++ b/web-frontend/test/unit/builder/components/workflowAction/notificationWorkflowActionForm.spec.js
@@ -1,0 +1,87 @@
+import { MARKDOWN_PREFIX } from '@baserow/modules/core/formula/textFormat'
+import NotificationWorkflowActionForm from '@baserow/modules/builder/components/workflowAction/NotificationWorkflowActionForm'
+
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { h } from 'vue'
+
+describe('NotificationWorkflowActionForm', () => {
+  let wrapper
+
+  const defaultProps = {
+    element: { id: 1, type: 'table', fields: [] },
+    baseTheme: {},
+    defaultValues: {
+      title: { formula: 'Saved' },
+      description: { formula: 'Done' },
+      // Add some non-allowed properties
+      someOtherProp: 'should not be included',
+      anotherProp: 123,
+    },
+  }
+
+  const mountComponent = (props = {}) => {
+    return mountSuspended(NotificationWorkflowActionForm, {
+      props: {
+        ...defaultProps,
+        ...props,
+      },
+      mocks: {
+        $t: (key) => key,
+        $registry: {
+          getOrderedList: () => [],
+        },
+      },
+      global: {
+        provide: {
+          workspace: {},
+          builder: {
+            theme: {},
+          },
+          currentPage: {},
+          elementPage: {},
+          mode: 'edit',
+          formulaComponent: () => h('div', `fake formula component`),
+          dataProvidersAllowed: [],
+          openCustomStyleForm: vi.fn(),
+        },
+      },
+      stubs: {
+        FormGroup: true,
+        RadioGroup: true,
+        InjectedFormulaInput: true,
+        CustomStyle: true,
+      },
+    })
+  }
+
+  beforeEach(async () => {
+    wrapper = await mountComponent()
+  })
+
+  afterEach(() => {
+    wrapper.unmount()
+  })
+
+  test('writes the formats into the title and description formulas', async () => {
+    expect(wrapper.vm.allowedValues).toEqual(['title', 'description'])
+    const [titleSelector, descriptionSelector] = wrapper.findAllComponents({
+      name: 'TextFormatSelector',
+    })
+    expect(titleSelector.props('modelValue')).toBe('plain')
+    expect(descriptionSelector.props('modelValue')).toBe('plain')
+
+    await titleSelector.vm.$emit('update:modelValue', 'markdown')
+    await descriptionSelector.vm.$emit('update:modelValue', 'markdown')
+
+    const emittedValues = wrapper.emitted('values-changed')
+    expect(emittedValues).toBeTruthy()
+    const lastEmittedValues = emittedValues[emittedValues.length - 1][0]
+
+    expect(lastEmittedValues).toEqual({
+      title: { formula: `${MARKDOWN_PREFIX}Saved` },
+      description: { formula: `${MARKDOWN_PREFIX}Done` },
+    })
+    expect(lastEmittedValues.someOtherProp).toBeUndefined()
+    expect(lastEmittedValues.anotherProp).toBeUndefined()
+  })
+})

--- a/web-frontend/test/unit/builder/elementTypes.spec.js
+++ b/web-frontend/test/unit/builder/elementTypes.spec.js
@@ -985,8 +985,8 @@ describe('elementTypes tests', () => {
 
       // When the Value is non-null, we expect them to be returned verbatim.
       expect(elementType.getOptionsResolved(element)).toEqual([
-        { name: 'Foo Name', value: '' },
-        { name: 'Bar Name', value: 'bar_name' },
+        { name: 'Foo Name', value: '', format: 'plain' },
+        { name: 'Bar Name', value: 'bar_name', format: 'plain' },
       ])
     })
 
@@ -1004,8 +1004,8 @@ describe('elementTypes tests', () => {
       // When Value is null, we assume the user wants it to be the same as
       // the Name. Thus, we return 'Foo Name' instead of null.
       expect(elementType.getOptionsResolved(element)).toEqual([
-        { name: 'Foo Name', value: 'Foo Name' },
-        { name: 'Bar Name', value: 'bar_name' },
+        { name: 'Foo Name', value: 'Foo Name', format: 'plain' },
+        { name: 'Bar Name', value: 'bar_name', format: 'plain' },
       ])
     })
 
@@ -1023,8 +1023,28 @@ describe('elementTypes tests', () => {
       // Since an empty string is a valid Value, if the user has explicitly
       // declared it, we should return an empty string.
       expect(elementType.getOptionsResolved(element)).toEqual([
-        { name: 'Foo Name', value: '' },
-        { name: 'Bar Name', value: 'bar_name' },
+        { name: 'Foo Name', value: '', format: 'plain' },
+        { name: 'Bar Name', value: 'bar_name', format: 'plain' },
+      ])
+    })
+
+    test('getOptionsResolved strips the text format marker from the Name.', () => {
+      const elementType = new ChoiceElementType()
+      const element = {
+        required: true,
+        option_type: CHOICE_OPTION_TYPES.MANUAL,
+        options: [
+          { id: 1, value: null, name: '__markdown__**Foo**' },
+          { id: 2, value: 'bar_name', name: '__markdown__Bar' },
+          { id: 3, value: null, name: 'Baz' },
+        ],
+      }
+
+      // The marker is neither displayed nor used as the fallback Value.
+      expect(elementType.getOptionsResolved(element)).toEqual([
+        { name: '**Foo**', value: '**Foo**', format: 'markdown' },
+        { name: 'Bar', value: 'bar_name', format: 'markdown' },
+        { name: 'Baz', value: 'Baz', format: 'plain' },
       ])
     })
   })

--- a/web-frontend/test/unit/core/components/markdownIt.spec.js
+++ b/web-frontend/test/unit/core/components/markdownIt.spec.js
@@ -1,0 +1,67 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import MarkdownIt from '@baserow/modules/core/components/MarkdownIt.vue'
+
+describe('MarkdownIt', () => {
+  const mountComponent = (props) => mountSuspended(MarkdownIt, { props })
+
+  test('renders block Markdown in a div by default', async () => {
+    const wrapper = await mountComponent({
+      content: '# Title\n\nSome **bold** text',
+    })
+
+    expect(wrapper.element.tagName).toBe('DIV')
+    expect(wrapper.classes()).not.toContain('markdown--inline')
+    expect(wrapper.find('h1').text()).toBe('Title')
+    expect(wrapper.find('strong').text()).toBe('bold')
+  })
+
+  test('renders inline Markdown in a span and keeps block syntax literal', async () => {
+    const wrapper = await mountComponent({
+      content: '# Not a heading with **bold**',
+      inline: true,
+    })
+
+    expect(wrapper.element.tagName).toBe('SPAN')
+    expect(wrapper.classes()).toContain('markdown--inline')
+    expect(wrapper.find('h1').exists()).toBe(false)
+    expect(wrapper.find('strong').text()).toBe('bold')
+    expect(wrapper.text()).toBe('# Not a heading with bold')
+  })
+
+  test('disables the given rules', async () => {
+    const content =
+      'See [docs](https://example.com) and ![img](https://example.com/i.png)'
+    const wrapper = await mountComponent({
+      content,
+      inline: true,
+      disabledRules: ['link', 'image'],
+    })
+
+    expect(wrapper.find('a').exists()).toBe(false)
+    expect(wrapper.find('img').exists()).toBe(false)
+    expect(wrapper.text()).toBe(content)
+  })
+
+  test('re-enables rules when disabledRules changes', async () => {
+    const wrapper = await mountComponent({
+      content: '[docs](https://example.com)',
+      inline: true,
+      disabledRules: ['link'],
+    })
+    expect(wrapper.find('a').exists()).toBe(false)
+
+    await wrapper.setProps({ disabledRules: [] })
+
+    expect(wrapper.find('a').exists()).toBe(true)
+  })
+
+  test('escapes raw HTML in inline mode', async () => {
+    const wrapper = await mountComponent({
+      content: '<b>not bold</b>',
+      inline: true,
+    })
+
+    expect(wrapper.find('b').exists()).toBe(false)
+    expect(wrapper.text()).toBe('<b>not bold</b>')
+  })
+})

--- a/web-frontend/test/unit/core/formula/textFormat.spec.js
+++ b/web-frontend/test/unit/core/formula/textFormat.spec.js
@@ -1,0 +1,97 @@
+import { isFormulaValid, resolveFormula } from '@baserow/modules/core/formula'
+import {
+  MARKDOWN_PREFIX,
+  TEXT_FORMATS,
+  addPrefix,
+  getFormat,
+  getFormulaFormat,
+  setFormat,
+  setFormulaFormat,
+  splitFormat,
+  stripFormat,
+} from '@baserow/modules/core/formula/textFormat'
+
+describe('textFormat helpers', () => {
+  test.each([
+    [`${MARKDOWN_PREFIX}get('a.b')`, TEXT_FORMATS.MARKDOWN, "get('a.b')"],
+    [MARKDOWN_PREFIX, TEXT_FORMATS.MARKDOWN, ''],
+    ["get('a.b')", TEXT_FORMATS.PLAIN, "get('a.b')"],
+    // Only a leading marker counts, a marker inside a literal is text.
+    [
+      `'${MARKDOWN_PREFIX}**a**'`,
+      TEXT_FORMATS.PLAIN,
+      `'${MARKDOWN_PREFIX}**a**'`,
+    ],
+    ['', TEXT_FORMATS.PLAIN, ''],
+    [undefined, TEXT_FORMATS.PLAIN, undefined],
+    [null, TEXT_FORMATS.PLAIN, null],
+    [5, TEXT_FORMATS.PLAIN, 5],
+  ])('splits %p', (value, format, bare) => {
+    expect(splitFormat(value)).toEqual({ format, value: bare })
+    expect(getFormat(value)).toBe(format)
+    expect(stripFormat(value)).toBe(bare)
+  })
+
+  test('adds and changes the format of a string', () => {
+    expect(addPrefix("get('a')")).toBe(`${MARKDOWN_PREFIX}get('a')`)
+    expect(addPrefix("get('a')", TEXT_FORMATS.PLAIN)).toBe("get('a')")
+    expect(addPrefix('', TEXT_FORMATS.MARKDOWN)).toBe(MARKDOWN_PREFIX)
+    expect(addPrefix(undefined, TEXT_FORMATS.MARKDOWN)).toBe(MARKDOWN_PREFIX)
+    expect(setFormat(`${MARKDOWN_PREFIX}Name`, TEXT_FORMATS.PLAIN)).toBe('Name')
+    expect(setFormat('Name', TEXT_FORMATS.MARKDOWN)).toBe(
+      `${MARKDOWN_PREFIX}Name`
+    )
+    expect(setFormat(`${MARKDOWN_PREFIX}Name`, TEXT_FORMATS.MARKDOWN)).toBe(
+      `${MARKDOWN_PREFIX}Name`
+    )
+  })
+
+  test('reads and writes the format of a formula object', () => {
+    const formula = { formula: "get('a')", mode: 'simple', version: '0.1' }
+
+    expect(getFormulaFormat(formula)).toBe(TEXT_FORMATS.PLAIN)
+    expect(getFormulaFormat({})).toBe(TEXT_FORMATS.PLAIN)
+    expect(getFormulaFormat(undefined)).toBe(TEXT_FORMATS.PLAIN)
+
+    const markdown = setFormulaFormat(formula, TEXT_FORMATS.MARKDOWN)
+    expect(markdown).toEqual({
+      formula: `${MARKDOWN_PREFIX}get('a')`,
+      mode: 'simple',
+      version: '0.1',
+    })
+    // The input is left untouched.
+    expect(formula.formula).toBe("get('a')")
+    expect(getFormulaFormat(markdown)).toBe(TEXT_FORMATS.MARKDOWN)
+    expect(setFormulaFormat(markdown, TEXT_FORMATS.PLAIN)).toEqual(formula)
+    expect(setFormulaFormat({}, TEXT_FORMATS.MARKDOWN)).toEqual({
+      formula: MARKDOWN_PREFIX,
+    })
+  })
+})
+
+describe('resolveFormula with the text format marker', () => {
+  const resolve = (formulaCtx) => resolveFormula(formulaCtx, {}, {})
+
+  test.each([
+    ["'**a**'", 'simple', '**a**'],
+    [`${MARKDOWN_PREFIX}'**a**'`, 'simple', '**a**'],
+    // A marker inside the resolved output is just text.
+    [`'${MARKDOWN_PREFIX}**a**'`, 'simple', `${MARKDOWN_PREFIX}**a**`],
+    ['**a**', 'raw', '**a**'],
+    [`${MARKDOWN_PREFIX}**a**`, 'raw', '**a**'],
+    ['', 'simple', ''],
+    [MARKDOWN_PREFIX, 'simple', ''],
+    [MARKDOWN_PREFIX, 'raw', ''],
+  ])('resolves %p in %s mode to %p', (formula, mode, expected) => {
+    expect(resolve({ formula, mode })).toBe(expected)
+  })
+})
+
+describe('isFormulaValid with the text format marker', () => {
+  test('validates the formula behind the marker', () => {
+    expect(isFormulaValid(`${MARKDOWN_PREFIX}'a'`, {}).valid).toBe(true)
+    expect(isFormulaValid(MARKDOWN_PREFIX, {}).valid).toBe(true)
+    expect(isFormulaValid(`${MARKDOWN_PREFIX}'a`, {}).valid).toBe(false)
+    expect(isFormulaValid("'a", {}).valid).toBe(false)
+  })
+})


### PR DESCRIPTION
### What is in this PR
Implement option A - prefix

### How to test this PR
- E.g. a short series of steps on how to test the features/bug fixes in this PR.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
