### PR TITLE
feat: Allow markdown in more Builder elements and fields (option a2 - prefix on text itself)

### DIFF
--- a/backend/tests/baserow/api/formula/test_formula_serializers.py
+++ b/backend/tests/baserow/api/formula/test_formula_serializers.py
@@ -1,6 +1,8 @@
 import pytest
 from rest_framework.exceptions import ValidationError
 
+from baserow.contrib.builder.application_types import BuilderApplicationType
+from baserow.core.formula.exceptions import InvalidRuntimeFormula
 from baserow.core.formula.field import BASEROW_FORMULA_VERSION_INITIAL
 from baserow.core.formula.serializers import FormulaSerializerField
 from baserow.core.formula.types import BASEROW_FORMULA_MODE_SIMPLE
@@ -22,3 +24,51 @@ def test_formula_serializer_field_without_context(context):
         "The formula serializer field requires "
         "an application type context to validate the formula arguments."
     )
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "'__markdown__**a**'",
+        "concat('__markdown__', get('data_source.123.field_456'))",
+    ],
+)
+def test_formula_serializer_field_accepts_the_markdown_marker_as_content(formula):
+    """
+    The Application Builder renders a text surface as Markdown when its
+    resolved text starts with `__markdown__`. The marker is content the builder
+    types: it lives inside a string literal, so the parser and the validator
+    treat the formula like any other.
+    """
+
+    field = FormulaSerializerField()
+    field._context = {"application_type": BuilderApplicationType}
+
+    result = field.to_internal_value(
+        {
+            "formula": formula,
+            "version": BASEROW_FORMULA_VERSION_INITIAL,
+            "mode": BASEROW_FORMULA_MODE_SIMPLE,
+        }
+    )
+
+    assert result["formula"] == formula
+
+
+def test_formula_serializer_field_still_rejects_the_marker_as_a_function():
+    """
+    Outside a string literal the marker is an unknown function, which is why
+    it is typed into the text and not prepended to the formula.
+    """
+
+    field = FormulaSerializerField()
+    field._context = {"application_type": BuilderApplicationType}
+
+    with pytest.raises(InvalidRuntimeFormula, match="__markdown__concat"):
+        field.to_internal_value(
+            {
+                "formula": "__markdown__concat('a')",
+                "version": BASEROW_FORMULA_VERSION_INITIAL,
+                "mode": BASEROW_FORMULA_MODE_SIMPLE,
+            }
+        )

--- a/backend/tests/baserow/contrib/builder/api/domains/test_domain_public_views.py
+++ b/backend/tests/baserow/contrib/builder/api/domains/test_domain_public_views.py
@@ -2370,3 +2370,82 @@ def test_public_dispatch_data_source_with_refinements_referencing_trashed_field(
         "detail": "A data source sort is misconfigured: "
         "One or more sorted properties no longer exist.",
     }
+
+
+@pytest.mark.django_db
+def test_public_dispatch_data_source_view_returns_the_field_inside_a_markdown_marker_concat(
+    data_fixture,
+    api_client,
+    user_source_user_fixture,
+):
+    """
+    The `__markdown__` marker of a Markdown label is a string literal in the
+    formula, so the field referenced next to it is allowlisted end to end.
+    """
+
+    user = user_source_user_fixture["user"]
+    table, fields, rows = data_fixture.build_table(
+        user=user,
+        columns=[("Food", "text"), ("Spiciness", "number")],
+        rows=[["Paneer Tikka", 5], ["Gobi Manchurian", 8]],
+    )
+    page = user_source_user_fixture["page"]
+    data_source = data_fixture.create_builder_local_baserow_list_rows_data_source(
+        user=user,
+        page=page,
+        integration=user_source_user_fixture["integration"],
+        table=table,
+    )
+    data_fixture.create_builder_input_text_element(
+        page=page,
+        label=(
+            "concat('__markdown__', "
+            f"get('data_source.{data_source.id}.*.field_{fields[0].id}'))"
+        ),
+    )
+
+    builder = user_source_user_fixture["builder"]
+    builder.workspace = None
+    builder.save()
+    data_fixture.create_builder_custom_domain(published_to=builder)
+
+    url = reverse(
+        "api:builder:domains:public_dispatch",
+        kwargs={"data_source_id": data_source.id},
+    )
+    user_token = user_source_user_fixture["user_source_user_token"]
+    response = api_client.post(url, HTTP_AUTHORIZATION=f"JWT {user_token}")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "has_next_page": False,
+        "results": [
+            {fields[0].name: "Paneer Tikka"},
+            {fields[0].name: "Gobi Manchurian"},
+        ],
+    }
+
+
+@pytest.mark.django_db
+def test_get_elements_of_public_builder_keeps_the_markdown_marker_in_the_label(
+    api_client, data_fixture
+):
+    user = data_fixture.create_user()
+    builder_from = data_fixture.create_builder_application(user=user)
+    builder_to = data_fixture.create_builder_application(user=user, workspace=None)
+    page = data_fixture.create_builder_page(builder=builder_to, user=user)
+    formula = "concat('__markdown__', get('data_source.1.field_2'))"
+    element = data_fixture.create_builder_input_text_element(page=page, label=formula)
+    data_fixture.create_builder_custom_domain(
+        domain_name="test.getbaserow.io",
+        published_to=page.builder,
+        builder=builder_from,
+    )
+
+    url = reverse("api:builder:domains:list_elements", kwargs={"page_id": page.id})
+    response = api_client.get(url, format="json")
+
+    assert response.status_code == HTTP_200_OK
+    [serialized] = response.json()
+    assert serialized["id"] == element.id
+    assert serialized["label"]["formula"] == formula

--- a/backend/tests/baserow/contrib/builder/elements/test_element_types.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_element_types.py
@@ -1665,3 +1665,37 @@ def test_element_type_get_event_names(data_fixture):
     assert get_event_names(form) == ["submit"]
     assert get_event_names(table) == [f"{button_field.uid}_click"]
     assert get_event_names(menu) == [f"{button_item_uid}_click"]
+
+
+@pytest.mark.django_db
+def test_choice_element_is_valid_keeps_the_markdown_marker_in_the_name_fallback(
+    data_fixture,
+):
+    """
+    An option without an explicit value submits its name. The `__markdown__`
+    marker a builder types at the start of the name to render it as Markdown
+    is content, so it is part of the submitted value on both sides; a builder
+    who wants a clean value sets one explicitly.
+    """
+
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    choice = ElementService().create_element(
+        user=user,
+        element_type=element_type_registry.get("choice"),
+        page=page,
+    )
+    choice.choiceelementoption_set.create(value=None, name="__markdown__**Bold**")
+    choice.choiceelementoption_set.create(value="plain", name="__markdown__*Plain*")
+
+    assert (
+        ChoiceElementType().is_valid(choice, "__markdown__**Bold**", {})
+        == "__markdown__**Bold**"
+    )
+    assert ChoiceElementType().is_valid(choice, "plain", {}) == "plain"
+
+    with pytest.raises(ValueError):
+        ChoiceElementType().is_valid(choice, "**Bold**", {})
+
+    with pytest.raises(ValueError):
+        ChoiceElementType().is_valid(choice, "__markdown__*Plain*", {})

--- a/backend/tests/baserow/contrib/builder/test_formula_importer.py
+++ b/backend/tests/baserow/contrib/builder/test_formula_importer.py
@@ -25,6 +25,12 @@ FORMULAS = [
         "output2": "get('test_provider.10.42')",
     },
     {"input": "concat('foo','bar')", "output": "concat('foo','bar')"},
+    {"input": "'__markdown__**a**'", "output": "'__markdown__**a**'"},
+    {
+        "input": "concat('__markdown__', get('test_provider.1.10'))",
+        "output": "concat('__markdown__',get('test_provider.1.10'))",
+        "output2": "concat('__markdown__',get('test_provider.10.42'))",
+    },
     {
         "input": "concat(get('test_provider.1.10'),'bar')",
         "output": "concat(get('test_provider.1.10'),'bar')",

--- a/backend/tests/baserow/contrib/builder/test_formula_property_extractor.py
+++ b/backend/tests/baserow/contrib/builder/test_formula_property_extractor.py
@@ -1130,3 +1130,39 @@ def test_get_builder_used_property_names_returns_merged_property_names_integrati
             ],  # From workflow_action2
         },
     }
+
+
+@pytest.mark.django_db
+def test_get_element_property_names_finds_the_get_inside_a_markdown_marker_concat(
+    data_fixture,
+):
+    """
+    A label rendered as Markdown reads `concat('__markdown__', get(...))`. The
+    marker is a string literal, so the `get()` next to it is found and the
+    field ends up in the public-page allowlist like any other.
+    """
+
+    user = data_fixture.create_user()
+    table, fields, _ = data_fixture.build_table(
+        user=user,
+        columns=[("Fruit", "text"), ("Color", "text")],
+        rows=[["Apple", "Green"]],
+    )
+    builder = data_fixture.create_builder_application(user=user)
+    page = data_fixture.create_builder_page(user=user, builder=builder)
+    data_source = data_fixture.create_builder_local_baserow_list_rows_data_source(
+        user=user, page=page, table=table
+    )
+    input_text_element = data_fixture.create_builder_input_text_element(
+        page=page,
+        label=(
+            "concat('__markdown__', "
+            f"get('data_source.{data_source.id}.0.field_{fields[0].id}'))"
+        ),
+    )
+
+    result = get_element_property_names([input_text_element], {})
+
+    assert result == {
+        "external": {data_source.service.id: [f"field_{fields[0].id}"]},
+    }

--- a/changelog/entries/unreleased/feature/4330_allow_markdown_formatting_in_the_text_field_of_the_table_ele.json
+++ b/changelog/entries/unreleased/feature/4330_allow_markdown_formatting_in_the_text_field_of_the_table_ele.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Allow Markdown formatting in more Application Builder texts: the Text field and column headers of the Table element, form field labels, Choice element options, the notification toast and the File input help text.",
+    "issue_origin": "github",
+    "issue_number": 4330,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-08-25"
+}

--- a/enterprise/web-frontend/modules/baserow_enterprise/builder/components/elements/FileInputElement.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/builder/components/elements/FileInputElement.vue
@@ -7,13 +7,20 @@
     :required="element.required"
     :style="getStyleOverride('input')"
   >
+    <template #label>
+      <FormattedText :content="resolvedLabel" preset="inlineLinks" />
+    </template>
     <ABFileInput
       v-model="computedInputValue"
       :multiple="element.multiple"
       :help-text="resolvedHelpText"
       :accept="allowedExtensions"
       :preview="element.preview"
-    />
+    >
+      <template #help-text>
+        <FormattedText :content="resolvedHelpText" preset="block" />
+      </template>
+    </ABFileInput>
   </ABFormGroup>
 </template>
 
@@ -21,11 +28,13 @@
 import formElement from '@baserow/modules/builder/mixins/formElement'
 import { ensureString } from '@baserow/modules/core/utils/validator'
 import UserFileService from '@baserow/modules/core/services/userFile'
+import FormattedText from '@baserow/modules/builder/components/FormattedText'
 
 import { FileInputElementType } from '@baserow_enterprise/builder/elementTypes'
 
 export default {
   name: 'FileInputElement',
+  components: { FormattedText },
   mixins: [formElement],
   props: {
     /**

--- a/enterprise/web-frontend/modules/baserow_enterprise/builder/components/elements/FileInputElementForm.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/builder/components/elements/FileInputElementForm.vue
@@ -9,6 +9,7 @@
     />
     <FormGroup
       :label="$t('generalForm.labelTitle')"
+      :helper-text="$t('markdownMarker.hint')"
       class="margin-bottom-2"
       required
       small-label
@@ -20,6 +21,7 @@
     </FormGroup>
     <FormGroup
       :label="$t('fileInputElementForm.helpTextTitle')"
+      :helper-text="$t('markdownMarker.hint')"
       class="margin-bottom-2"
       required
       small-label

--- a/enterprise/web-frontend/test/unit/enterprise/builder/components/fileInputElement.spec.js
+++ b/enterprise/web-frontend/test/unit/enterprise/builder/components/fileInputElement.spec.js
@@ -1,0 +1,76 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import FileInputElement from '@baserow_enterprise/builder/components/elements/FileInputElement.vue'
+
+describe('FileInputElement', () => {
+  let store = null
+
+  beforeEach(() => {
+    store = useNuxtApp().$store
+  })
+
+  const mountFileInput = async (elementOverrides = {}) => {
+    const page = { id: 1, elements: [] }
+    const builder = { id: 1, theme: { primary_color: '#ccc' }, pages: [page] }
+    const mode = 'public'
+    const element = {
+      id: 44,
+      type: 'input_file',
+      label: { mode: 'raw', formula: 'Your **CV** ([tips](/tips))' },
+      help_text: { mode: 'raw', formula: '# Drop it\n\nPDF **only**' },
+      default_url: { formula: '' },
+      default_name: { formula: '' },
+      required: false,
+      multiple: false,
+      preview: false,
+      allowed_filetypes: [],
+      max_filesize: 5,
+      page_id: page.id,
+      styles: {},
+      ...elementOverrides,
+    }
+
+    store.dispatch('element/forceCreate', { page, element })
+
+    return mountSuspended(FileInputElement, {
+      props: { element },
+      global: {
+        provide: {
+          builder,
+          currentPage: page,
+          elementPage: page,
+          mode,
+          applicationContext: { builder, page, mode },
+          element,
+          workspace: {},
+        },
+      },
+    })
+  }
+
+  test('renders the label and help text as-is without the marker', async () => {
+    const wrapper = await mountFileInput()
+
+    expect(wrapper.find('.ab-form-group__label').text()).toBe(
+      'Your **CV** ([tips](/tips))'
+    )
+    expect(wrapper.find('.ab-file-input .ab-heading').exists()).toBe(false)
+    expect(wrapper.find('.ab-file-input').text()).toContain('# Drop it')
+  })
+
+  test('renders a marked label with links and marked block Markdown help text', async () => {
+    const wrapper = await mountFileInput({
+      label: { mode: 'raw', formula: '__markdown__Your **CV** ([tips](/tips))' },
+      help_text: { mode: 'raw', formula: '__markdown__# Drop it\n\nPDF **only**' },
+    })
+
+    const label = wrapper.find('.ab-form-group__label')
+    expect(label.find('strong').text()).toBe('CV')
+    expect(label.find('a.ab-link').attributes('href')).toBe('/tips')
+    expect(label.text()).not.toContain('__markdown__')
+
+    const helpText = wrapper.find('.ab-file-input')
+    expect(helpText.find('.ab-heading').text()).toBe('Drop it')
+    expect(helpText.find('strong').text()).toBe('only')
+    expect(helpText.text()).not.toContain('__markdown__')
+  })
+})

--- a/web-frontend/modules/builder/components/BuilderToasts.vue
+++ b/web-frontend/modules/builder/components/BuilderToasts.vue
@@ -8,8 +8,22 @@
       close-button
       @close="closeToast(toast)"
     >
-      <template #title>{{ toast.title }}</template>
-      <div>{{ toast.message }}</div>
+      <template #title>
+        <FormattedText
+          :content="toast.title"
+          preset="inline"
+          :builder="builder"
+          :mode="mode"
+        />
+      </template>
+      <div>
+        <FormattedText
+          :content="toast.message"
+          preset="restrictedBlock"
+          :builder="builder"
+          :mode="mode"
+        />
+      </div>
       <details v-if="toast.details" class="ab-toast__details">
         <summary class="ab-toast__details-summary">
           {{ $t('builderToast.details') }}
@@ -26,11 +40,19 @@
 import { mapGetters } from 'vuex'
 
 import BuilderToast from '@baserow/modules/builder/components/BuilderToast'
+import FormattedText from '@baserow/modules/builder/components/FormattedText'
 
 export default {
   name: 'BuilderToasts',
   components: {
     BuilderToast,
+    FormattedText,
+  },
+  // Needed to resolve links in Markdown toasts. The public page provides both,
+  // the editor preview only provides the builder.
+  inject: {
+    builder: { default: null },
+    mode: { default: 'editing' },
   },
   computed: {
     ...mapGetters({

--- a/web-frontend/modules/builder/components/FormattedText.vue
+++ b/web-frontend/modules/builder/components/FormattedText.vue
@@ -1,0 +1,107 @@
+<template>
+  <MarkdownIt
+    v-if="isMarkdown"
+    :content="text"
+    :inline="markdownPreset.inline"
+    :rules="markdownPreset.rules"
+    :disabled-rules="markdownPreset.disabledRules"
+    @click="onMarkdownClick"
+  />
+  <slot v-else name="plain" :text="text">{{ text }}</slot>
+</template>
+
+<script>
+import { TEXT_FORMAT_TYPES } from '@baserow/modules/builder/enums'
+import {
+  MARKDOWN_PRESETS,
+  createApplicationBuilderMarkdownPreset,
+  handleMarkdownClick,
+  splitTextMarker,
+} from '@baserow/modules/builder/utils/markdown'
+
+/**
+ * Renders a user-provided text either as-is or as Markdown, using one of the
+ * Application Builder rendering presets.
+ *
+ * The text renders as Markdown when the `format` prop says so (the Text element
+ * keeps its own setting) or when the resolved text starts with the Markdown
+ * marker, see `splitTextMarker`. The marker is stripped in both cases. Every
+ * other surface passes only `content` and `preset`.
+ *
+ * The optional `plain` scoped slot customises the plain rendering, e.g. to keep
+ * a styled wrapper around the text. The default is the bare text.
+ *
+ * `builder` and `mode` are needed to resolve internal links; they're injected
+ * from the surrounding element by default, and can be passed explicitly by
+ * consumers living outside an element (e.g. the toasts).
+ */
+export default {
+  name: 'FormattedText',
+  inject: {
+    injectedBuilder: { from: 'builder', default: null },
+    injectedMode: { from: 'mode', default: null },
+  },
+  props: {
+    content: {
+      type: [String, Number],
+      required: false,
+      default: '',
+    },
+    format: {
+      type: String,
+      required: false,
+      default: TEXT_FORMAT_TYPES.PLAIN,
+    },
+    preset: {
+      type: String,
+      required: false,
+      default: MARKDOWN_PRESETS.BLOCK,
+      validator: (value) => Object.values(MARKDOWN_PRESETS).includes(value),
+    },
+    builder: {
+      type: Object,
+      required: false,
+      default: null,
+    },
+    mode: {
+      type: String,
+      required: false,
+      default: null,
+    },
+  },
+  computed: {
+    markedContent() {
+      return splitTextMarker(this.content)
+    },
+    text() {
+      return this.markedContent.text
+    },
+    isMarkdown() {
+      return (
+        this.format === TEXT_FORMAT_TYPES.MARKDOWN ||
+        this.markedContent.format === TEXT_FORMAT_TYPES.MARKDOWN
+      )
+    },
+    resolvedBuilder() {
+      return this.builder || this.injectedBuilder
+    },
+    resolvedMode() {
+      return this.mode || this.injectedMode
+    },
+    markdownPreset() {
+      return createApplicationBuilderMarkdownPreset(this.preset, {
+        builder: this.resolvedBuilder,
+        mode: this.resolvedMode,
+      })
+    },
+  },
+  methods: {
+    onMarkdownClick(event) {
+      handleMarkdownClick(event, {
+        mode: this.resolvedMode,
+        router: this.$router,
+      })
+    },
+  },
+}
+</script>

--- a/web-frontend/modules/builder/components/elements/baseComponents/ABFileInput.vue
+++ b/web-frontend/modules/builder/components/elements/baseComponents/ABFileInput.vue
@@ -12,7 +12,9 @@
       @keydown.enter.prevent="triggerFileInput"
       @keydown.space.prevent="triggerFileInput"
     >
-      <div>{{ helpText }}</div>
+      <div>
+        <slot name="help-text">{{ helpText }}</slot>
+      </div>
       <input
         ref="fileInputRef"
         type="file"
@@ -171,7 +173,12 @@ export default {
     onDragLeave() {
       this.isDragOver = false
     },
-    triggerFileInput() {
+    triggerFileInput(event) {
+      // A link inside the help text navigates on its own, it shouldn't also
+      // open the file picker.
+      if (event?.target?.closest?.('a')) {
+        return
+      }
       this.$refs.fileInputRef.click()
     },
     removeFile(index) {

--- a/web-frontend/modules/builder/components/elements/baseComponents/ABFormGroup.vue
+++ b/web-frontend/modules/builder/components/elements/baseComponents/ABFormGroup.vue
@@ -14,7 +14,7 @@
       class="ab-form-group__label"
       :class="{ 'ab-form-group__label--small': smallLabel }"
     >
-      {{ label }}
+      <slot name="label">{{ label }}</slot>
       <span v-if="required" :title="$t('error.requiredField')">*</span>
     </label>
     <div class="ab-form-group__children">
@@ -36,6 +36,10 @@ export default {
       required: false,
       default: null,
     },
+    /**
+     * The label text. The optional `label` slot customises its rendering, the
+     * prop still decides whether the label is shown at all.
+     */
     label: {
       type: String,
       required: false,

--- a/web-frontend/modules/builder/components/elements/components/CheckboxElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/CheckboxElement.vue
@@ -8,7 +8,10 @@
       :required="element.required"
       :read-only="isEditMode"
     >
-      {{ resolvedLabel }}
+      <FormattedText
+        :content="resolvedLabel"
+        preset="inlineLinks"
+      />
       <span
         v-if="element.label && element.required"
         :title="$t('error.requiredField')"
@@ -20,10 +23,12 @@
 
 <script>
 import formElement from '@baserow/modules/builder/mixins/formElement'
+import FormattedText from '@baserow/modules/builder/components/FormattedText'
 import { ensureString } from '@baserow/modules/core/utils/validator'
 
 export default {
   name: 'CheckboxElement',
+  components: { FormattedText },
   mixins: [formElement],
   computed: {
     resolvedLabel() {

--- a/web-frontend/modules/builder/components/elements/components/ChoiceElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/ChoiceElement.vue
@@ -5,6 +5,9 @@
     :error-message="displayFormDataError ? $t('error.requiredField') : ''"
     :style="getStyleOverride('input')"
   >
+    <template #label>
+      <FormattedText :content="labelResolved" preset="inlineLinks" />
+    </template>
     <ABDropdown
       v-if="element.show_as_dropdown"
       v-model="inputValue"
@@ -17,12 +20,31 @@
       :clearable="!element.multiple && !element.required"
       @hide="onFormElementTouch"
     >
+      <template v-if="hasMarkdownOptions" #value>
+        <span class="ab-dropdown__selected-text">
+          <template v-for="(name, index) in selectedOptionNames" :key="index">
+            <template v-if="index > 0">, </template>
+            <FormattedText :content="name" preset="inline" />
+          </template>
+        </span>
+      </template>
       <ABDropdownItem
         v-for="option in optionsResolved"
         :key="option.id"
-        :name="option.name || (option.value ? `${option.value}` : '')"
+        :name="bareOptionName(option)"
         :value="option.value"
-      />
+      >
+        <!--
+        The search and the tooltip use the option name without the Markdown
+        marker; only the visible text is rendered.
+        -->
+        <span
+          class="ab-dropdownitem__item-name-text"
+          :title="bareOptionName(option)"
+        >
+          <FormattedText :content="dropdownOptionName(option)" preset="inline" />
+        </span>
+      </ABDropdownItem>
     </ABDropdown>
     <template v-else>
       <template v-if="canHaveOptions">
@@ -35,7 +57,7 @@
             :model-value="inputValue.includes(option.value)"
             @update:model-value="onOptionChange(option, $event)"
           >
-            {{ option.name || option.value }}
+            <FormattedText :content="optionName(option)" preset="inline" />
           </ABCheckbox>
         </template>
         <template v-else>
@@ -47,7 +69,7 @@
             :model-value="option.value === inputValue"
             @update:model-value="onOptionChange(option, $event)"
           >
-            {{ option.name || option.value }}
+            <FormattedText :content="optionName(option)" preset="inline" />
           </ABRadio>
         </template>
       </template>
@@ -59,9 +81,13 @@
 <script>
 import formElement from '@baserow/modules/builder/mixins/formElement'
 import { ensureString } from '@baserow/modules/core/utils/validator'
+import { TEXT_FORMAT_TYPES } from '@baserow/modules/builder/enums'
+import { splitTextMarker } from '@baserow/modules/builder/utils/markdown'
+import FormattedText from '@baserow/modules/builder/components/FormattedText'
 
 export default {
   name: 'ChoiceElement',
+  components: { FormattedText },
   mixins: [formElement],
   props: {
     /**
@@ -98,6 +124,32 @@ export default {
         this.applicationContext
       )
     },
+    /**
+     * Whether any option name, manual or resolved from the name formula, asks
+     * for Markdown. Only then is the collapsed dropdown rendered by hand.
+     */
+    hasMarkdownOptions() {
+      return this.optionsResolved.some(
+        (option) =>
+          splitTextMarker(this.dropdownOptionName(option)).format ===
+          TEXT_FORMAT_TYPES.MARKDOWN
+      )
+    },
+    /**
+     * The names of the selected options, in the order the values are stored,
+     * used to render the collapsed dropdown when the options are Markdown.
+     */
+    selectedOptionNames() {
+      const values = this.element.multiple
+        ? this.inputValue || []
+        : [this.inputValue]
+      return values
+        .map((value) =>
+          this.optionsResolved.find((option) => option.value === value)
+        )
+        .filter(Boolean)
+        .map((option) => this.dropdownOptionName(option))
+    },
   },
   watch: {
     'element.multiple'() {
@@ -105,6 +157,15 @@ export default {
     },
   },
   methods: {
+    optionName(option) {
+      return ensureString(option.name || option.value)
+    },
+    dropdownOptionName(option) {
+      return option.name || (option.value ? `${option.value}` : '')
+    },
+    bareOptionName(option) {
+      return splitTextMarker(this.dropdownOptionName(option)).text
+    },
     onOptionChange(option, value) {
       if (value) {
         if (this.element.multiple) {

--- a/web-frontend/modules/builder/components/elements/components/DateTimePickerElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/DateTimePickerElement.vue
@@ -5,6 +5,9 @@
     :required="element.required"
     :style="getStyleOverride('input')"
   >
+    <template #label>
+      <FormattedText :content="resolvedLabel" preset="inlineLinks" />
+    </template>
     <ABDateTimePicker
       ref="datePicker"
       v-model="inputValue"
@@ -20,12 +23,13 @@
 <script>
 import formElement from '@baserow/modules/builder/mixins/formElement'
 import ABDateTimePicker from '@baserow/modules/builder/components/elements/baseComponents/ABDateTimePicker.vue'
+import FormattedText from '@baserow/modules/builder/components/FormattedText'
 import { DATE_FORMATS, TIME_FORMATS } from '@baserow/modules/builder/enums'
 import { ensureString } from '@baserow/modules/core/utils/validator'
 
 export default {
   name: 'DateTimePickerElement',
-  components: { ABDateTimePicker },
+  components: { ABDateTimePicker, FormattedText },
   mixins: [formElement],
   props: {
     /**

--- a/web-frontend/modules/builder/components/elements/components/InputTextElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/InputTextElement.vue
@@ -6,6 +6,12 @@
     :required="element.required"
     :style="getStyleOverride('input')"
   >
+    <template #label>
+      <FormattedText
+        :content="resolvedLabel"
+        preset="inlineLinks"
+      />
+    </template>
     <ABInput
       v-model="computedValue"
       :placeholder="resolvedPlaceholder"
@@ -19,6 +25,7 @@
 
 <script>
 import formElement from '@baserow/modules/builder/mixins/formElement'
+import FormattedText from '@baserow/modules/builder/components/FormattedText'
 import {
   ensureNumeric,
   ensureString,
@@ -27,6 +34,7 @@ import { parseLocalizedNumber } from '@baserow/modules/core/utils/string'
 
 export default {
   name: 'InputTextElement',
+  components: { FormattedText },
   mixins: [formElement],
   props: {
     /**

--- a/web-frontend/modules/builder/components/elements/components/RatingInputElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/RatingInputElement.vue
@@ -4,6 +4,12 @@
     :required="element.required"
     :error-message="displayFormDataError ? $t('error.requiredField') : ''"
   >
+    <template #label>
+      <FormattedText
+        :content="labelResolved"
+        preset="inlineLinks"
+      />
+    </template>
     <Rating
       :value="inputValue"
       :max-value="element.max_value"
@@ -17,6 +23,7 @@
 
 <script>
 import Rating from '@baserow/modules/database/components/Rating'
+import FormattedText from '@baserow/modules/builder/components/FormattedText'
 import formElement from '@baserow/modules/builder/mixins/formElement'
 import { ensureString } from '@baserow/modules/core/utils/validator'
 import { useVuelidate } from '@vuelidate/core'
@@ -26,6 +33,7 @@ export default {
   name: 'RatingInputElement',
   components: {
     Rating,
+    FormattedText,
   },
   mixins: [formElement],
   setup() {

--- a/web-frontend/modules/builder/components/elements/components/RecordSelectorElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/RecordSelectorElement.vue
@@ -5,6 +5,12 @@
     :error-message="getErrorMessage()"
     :style="getStyleOverride('input')"
   >
+    <template #label>
+      <FormattedText
+        :content="resolvedLabel"
+        preset="inlineLinks"
+      />
+    </template>
     <ABDropdown
       ref="recordSelectorDropdown"
       v-model="inputValue"
@@ -73,12 +79,13 @@ import formElement from '@baserow/modules/builder/mixins/formElement'
 import collectionElement from '@baserow/modules/builder/mixins/collectionElement'
 import RuntimeFormulaContext from '@baserow/modules/core/runtimeFormulaContext'
 import InfiniteScroll from '@baserow/modules/core/components/helpers/InfiniteScroll.vue'
+import FormattedText from '@baserow/modules/builder/components/FormattedText'
 import DataSourceService from '@baserow/modules/builder/services/dataSource'
 import { handleDispatchError } from '@baserow/modules/builder/utils/error'
 
 export default {
   name: 'RecordSelectorElement',
-  components: { InfiniteScroll },
+  components: { InfiniteScroll, FormattedText },
   mixins: [formElement, collectionElement],
   props: {
     /**

--- a/web-frontend/modules/builder/components/elements/components/TableElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/TableElement.vue
@@ -14,6 +14,12 @@
       :style="getStyleOverride('table')"
       :orientation="orientation"
     >
+      <template #field-name="{ field }">
+        <FormattedText
+          :content="field.name"
+          preset="inline"
+        />
+      </template>
       <template #cell-content="{ rowIndex, field, value, row }">
         <!--
         -- We force-self-alignment to `auto` here to prevent some self-positioning
@@ -70,11 +76,12 @@ import { uuid } from '@baserow/modules/core/utils/string'
 import BaserowTable from '@baserow/modules/builder/components/elements/components/BaserowTable'
 import { ensureString } from '@baserow/modules/core/utils/validator'
 import CollectionElementHeader from '@baserow/modules/builder/components/elements/components/CollectionElementHeader'
+import FormattedText from '@baserow/modules/builder/components/FormattedText'
 import { useCollectionElement } from '@baserow/modules/builder/composables/useCollectionElement'
 
 export default {
   name: 'TableElement',
-  components: { CollectionElementHeader, BaserowTable },
+  components: { CollectionElementHeader, BaserowTable, FormattedText },
   props: {
     /**
      * @type {Object}

--- a/web-frontend/modules/builder/components/elements/components/TextElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/TextElement.vue
@@ -6,15 +6,15 @@
     }"
     :style="getStyleOverride('typography')"
   >
-    <template v-if="element.format === TEXT_FORMAT_TYPES.MARKDOWN">
+    <template v-if="isMarkdown">
       <MarkdownIt
         v-if="element.value"
         :content="
-          resolvedValue ||
+          displayValue ||
           (mode === 'editing' ? $t('textElement.emptyValue') : '&nbsp;')
         "
-        :rules="rules"
-        @click="onClick"
+        :rules="markdownRules"
+        @click="onMarkdownClick"
       ></MarkdownIt>
       <ABParagraph v-else>{{ $t('textElement.missingValue') }}</ABParagraph>
     </template>
@@ -37,7 +37,8 @@ import element from '@baserow/modules/builder/mixins/element'
 import { generateHash } from '@baserow/modules/core/utils/hashing'
 import { ensureString } from '@baserow/modules/core/utils/validator'
 import { TEXT_FORMAT_TYPES } from '@baserow/modules/builder/enums'
-import { createApplicationBuilderMarkdownRules } from '@baserow/modules/builder/utils/markdown'
+import { splitTextMarker } from '@baserow/modules/builder/utils/markdown'
+import markdownContent from '@baserow/modules/builder/mixins/markdownContent'
 
 /**
  * @typedef Text
@@ -47,7 +48,7 @@ import { createApplicationBuilderMarkdownRules } from '@baserow/modules/builder/
 
 export default {
   name: 'TextElement',
-  mixins: [element],
+  mixins: [element, markdownContent],
   props: {
     /**
      * @type {Object}
@@ -68,8 +69,25 @@ export default {
         return ''
       }
     },
+    /**
+     * The Text element keeps its own `format` setting, but it follows the rule
+     * of every other text surface too: a resolved value starting with the
+     * Markdown marker renders as Markdown, minus the marker.
+     */
+    markedValue() {
+      return splitTextMarker(this.resolvedValue)
+    },
+    displayValue() {
+      return this.markedValue.text
+    },
+    isMarkdown() {
+      return (
+        this.element.format === TEXT_FORMAT_TYPES.MARKDOWN ||
+        this.markedValue.format === TEXT_FORMAT_TYPES.MARKDOWN
+      )
+    },
     paragraphs() {
-      return this.resolvedValue
+      return this.displayValue
         .split('\n')
         .map((line) => line.trim())
         .filter((line) => line)
@@ -77,34 +95,6 @@ export default {
           content: line,
           id: generateHash(line + index),
         }))
-    },
-    TEXT_FORMAT_TYPES() {
-      return TEXT_FORMAT_TYPES
-    },
-    // Custom rules to pass down to `MarkdownIt` element.
-    // The goal is to make the styling of the rendered markdown content
-    // consistent with the rest of the application builder CSS classes
-    rules() {
-      return createApplicationBuilderMarkdownRules({
-        builder: this.builder,
-        mode: this.mode,
-      })
-    },
-  },
-  methods: {
-    onClick(event) {
-      if (this.mode === 'editing') {
-        event.preventDefault()
-        return
-      }
-      if (event.target.classList.contains('ab-link')) {
-        const url = event.target.getAttribute('href')
-
-        if (url.startsWith('/')) {
-          event.preventDefault()
-          this.$router.push(url)
-        }
-      }
     },
   },
 }

--- a/web-frontend/modules/builder/components/elements/components/collectionField/TextField.vue
+++ b/web-frontend/modules/builder/components/elements/components/collectionField/TextField.vue
@@ -1,12 +1,18 @@
 <template>
-  <span class="ab-text">{{ value }}</span>
+  <FormattedText :content="value" preset="block">
+    <template #plain="{ text }">
+      <span class="ab-text">{{ text }}</span>
+    </template>
+  </FormattedText>
 </template>
 
 <script>
 import collectionField from '@baserow/modules/builder/mixins/collectionField'
+import FormattedText from '@baserow/modules/builder/components/FormattedText'
 
 export default {
   name: 'TextField',
+  components: { FormattedText },
   mixins: [collectionField],
   props: {
     value: {

--- a/web-frontend/modules/builder/components/elements/components/collectionField/form/TextFieldForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/collectionField/form/TextFieldForm.vue
@@ -3,6 +3,7 @@
     <FormGroup
       small-label
       :label="$t('textFieldForm.fieldValueLabel')"
+      :helper-text="$t('markdownMarker.hint')"
       class="margin-bottom-2"
       horizontal
       required

--- a/web-frontend/modules/builder/components/elements/components/forms/general/CheckboxElementForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/forms/general/CheckboxElementForm.vue
@@ -10,6 +10,7 @@
     <FormGroup
       small-label
       :label="$t('checkboxElementForm.labelTitle')"
+      :helper-text="$t('markdownMarker.hint')"
       class="margin-bottom-2"
       required
     >

--- a/web-frontend/modules/builder/components/elements/components/forms/general/ChoiceElementForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/forms/general/ChoiceElementForm.vue
@@ -9,6 +9,7 @@
     <FormGroup
       small-label
       :label="$t('generalForm.labelTitle')"
+      :helper-text="$t('markdownMarker.hint')"
       class="margin-bottom-2"
       required
     >
@@ -118,6 +119,9 @@
             <ButtonIcon icon="iconoir-bin" @click="deleteOption(option)" />
           </div>
         </div>
+        <p class="control__helper-text margin-bottom-1">
+          {{ $t('markdownMarker.hint') }}
+        </p>
       </template>
       <template v-else>
         <div class="row" style="--gap: 6px">
@@ -140,6 +144,7 @@
       <FormGroup
         small-label
         :label="$t('choiceOptionSelector.name')"
+        :helper-text="$t('markdownMarker.hint')"
         class="margin-bottom-2"
       >
         <InjectedFormulaInput

--- a/web-frontend/modules/builder/components/elements/components/forms/general/DateTimePickerElementForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/forms/general/DateTimePickerElementForm.vue
@@ -9,6 +9,7 @@
     <FormGroup
       small-label
       :label="$t('generalForm.labelTitle')"
+      :helper-text="$t('markdownMarker.hint')"
       class="margin-bottom-2"
       required
     >

--- a/web-frontend/modules/builder/components/elements/components/forms/general/InputTextElementForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/forms/general/InputTextElementForm.vue
@@ -8,6 +8,7 @@
     />
     <FormGroup
       :label="$t('generalForm.labelTitle')"
+      :helper-text="$t('markdownMarker.hint')"
       class="margin-bottom-2"
       required
       small-label

--- a/web-frontend/modules/builder/components/elements/components/forms/general/RatingInputElementForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/forms/general/RatingInputElementForm.vue
@@ -3,6 +3,7 @@
     <FormGroup
       small-label
       :label="$t('generalForm.labelTitle')"
+      :helper-text="$t('markdownMarker.hint')"
       required
       class="margin-bottom-2"
     >

--- a/web-frontend/modules/builder/components/elements/components/forms/general/RecordSelectorElementForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/forms/general/RecordSelectorElementForm.vue
@@ -66,6 +66,7 @@
       small-label
       class="margin-bottom-2"
       :label="$t('generalForm.labelTitle')"
+      :helper-text="$t('markdownMarker.hint')"
       required
     >
       <InjectedFormulaInput

--- a/web-frontend/modules/builder/components/elements/components/forms/general/TableElementForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/forms/general/TableElementForm.vue
@@ -134,6 +134,7 @@
                 required
                 class="margin-bottom-2"
                 :label="$t('tableElementForm.name')"
+                :helper-text="$t('markdownMarker.hint')"
                 :error-message="v$.values.fields.$each.$message[index]?.[0]"
               >
                 <FormInput

--- a/web-frontend/modules/builder/components/workflowAction/NotificationWorkflowActionForm.vue
+++ b/web-frontend/modules/builder/components/workflowAction/NotificationWorkflowActionForm.vue
@@ -3,6 +3,7 @@
     <FormGroup
       small-label
       :label="$t('notificationWorkflowActionForm.titleLabel')"
+      :helper-text="$t('markdownMarker.hint')"
       class="margin-bottom-2"
       required
     >
@@ -14,6 +15,7 @@
     <FormGroup
       small-label
       :label="$t('notificationWorkflowActionForm.descriptionLabel')"
+      :helper-text="$t('markdownMarker.hint')"
       class="margin-bottom-2"
       required
     >

--- a/web-frontend/modules/builder/locales/en.json
+++ b/web-frontend/modules/builder/locales/en.json
@@ -254,6 +254,9 @@
     "textFormatTypePlain": "Plain text",
     "textFormatTypeMarkdown": "Markdown"
   },
+  "markdownMarker": {
+    "hint": "Start the text with __markdown__ to render it as Markdown."
+  },
   "orientations": {
     "label": "Orientation",
     "horizontal": "Horizontal",

--- a/web-frontend/modules/builder/mixins/markdownContent.js
+++ b/web-frontend/modules/builder/mixins/markdownContent.js
@@ -1,0 +1,31 @@
+import {
+  createApplicationBuilderMarkdownRules,
+  handleMarkdownClick,
+} from '@baserow/modules/builder/utils/markdown'
+
+/**
+ * Shared behaviour for elements and collection fields that render Markdown
+ * through the global `MarkdownIt` component: the Application Builder renderer
+ * rules and the click handler that keeps internal links inside the SPA router.
+ *
+ * Requires `builder` and `mode` on the component, which are both provided by
+ * the `element` / `collectionField` mixins via inject.
+ */
+export default {
+  computed: {
+    // Custom rules to pass down to the `MarkdownIt` component. The goal is to
+    // make the styling of the rendered markdown content consistent with the
+    // rest of the application builder CSS classes.
+    markdownRules() {
+      return createApplicationBuilderMarkdownRules({
+        builder: this.builder,
+        mode: this.mode,
+      })
+    },
+  },
+  methods: {
+    onMarkdownClick(event) {
+      handleMarkdownClick(event, { mode: this.mode, router: this.$router })
+    },
+  },
+}

--- a/web-frontend/modules/builder/utils/markdown.js
+++ b/web-frontend/modules/builder/utils/markdown.js
@@ -1,5 +1,6 @@
 import { escapeHtml } from '@baserow/modules/core/utils/string'
 import { prefixInternalResolvedUrl } from '@baserow/modules/builder/utils/urlResolution'
+import { TEXT_FORMAT_TYPES } from '@baserow/modules/builder/enums'
 
 /**
  * Creates the Markdown-It renderer rules used by Application Builder content.
@@ -91,3 +92,161 @@ export const createApplicationBuilderMarkdownRules = ({ builder, mode }) => ({
     return renderer.renderToken(tokens, idx, options)
   },
 })
+
+/**
+ * The rendering presets available for Application Builder Markdown surfaces.
+ *
+ * - `block`: the full Markdown syntax, for free-flowing text (Text element, Text
+ *   collection field, file input help text).
+ * - `restrictedBlock`: block mode without the layout-breaking blocks (tables,
+ *   code blocks, images, headings), for the notification toast description.
+ * - `inline`: emphasis, strikethrough and inline code only, for selectable or
+ *   truncated single-line content (option names, table headers, toast title).
+ *   Links are disabled, as these contexts are either already wrapped in
+ *   an `<a>`, or select something on click.
+ * - `inlineLinks`: inline mode with links, for descriptive single-line content
+ *   such as form field labels ("I agree to the [terms](...)").
+ */
+export const MARKDOWN_PRESETS = {
+  BLOCK: 'block',
+  RESTRICTED_BLOCK: 'restrictedBlock',
+  INLINE: 'inline',
+  INLINE_LINKS: 'inlineLinks',
+}
+
+export const INLINE_MARKDOWN_DISABLED_RULES = ['link', 'autolink']
+export const INLINE_LINKS_MARKDOWN_DISABLED_RULES = []
+export const RESTRICTED_BLOCK_MARKDOWN_DISABLED_RULES = [
+  'table',
+  'fence',
+  'code',
+  'heading',
+  'lheading',
+]
+
+/**
+ * Renders an image token back as its Markdown source. Disabling the `image`
+ * rule instead would leave a `!` followed by a link, which is more surprising
+ * than the literal text on the surfaces where images aren't allowed.
+ */
+const renderImageAsSource = (tokens, idx) => {
+  const token = tokens[idx]
+  const title = token.attrGet('title')
+  return escapeHtml(
+    `![${token.content}](${token.attrGet('src')}${title ? ` "${title}"` : ''})`
+  )
+}
+
+/**
+ * Creates the Markdown-It renderer rules used by the inline presets. Only the
+ * tokens that survive `renderInline` need styling.
+ */
+export const createApplicationBuilderInlineMarkdownRules = ({
+  builder,
+  mode,
+  links = false,
+}) => {
+  const blockRules = createApplicationBuilderMarkdownRules({ builder, mode })
+  return {
+    code_inline: blockRules.code_inline,
+    image: renderImageAsSource,
+    // Inline surfaces are often nowrap/ellipsis contexts where a `<br>` breaks
+    // the truncation. A backslash-newline still yields a hardbreak even with the
+    // `newline` rule disabled, so both break renderers emit a plain space.
+    hardbreak: () => ' ',
+    softbreak: () => ' ',
+    ...(links ? { link_open: blockRules.link_open } : {}),
+  }
+}
+
+/**
+ * Returns the `MarkdownIt` component props (`inline`, `rules`, `disabledRules`)
+ * for the given preset.
+ */
+export const createApplicationBuilderMarkdownPreset = (
+  preset,
+  { builder, mode }
+) => {
+  switch (preset) {
+    case MARKDOWN_PRESETS.INLINE:
+      return {
+        inline: true,
+        rules: createApplicationBuilderInlineMarkdownRules({ builder, mode }),
+        disabledRules: INLINE_MARKDOWN_DISABLED_RULES,
+      }
+    case MARKDOWN_PRESETS.INLINE_LINKS:
+      return {
+        inline: true,
+        rules: createApplicationBuilderInlineMarkdownRules({
+          builder,
+          mode,
+          links: true,
+        }),
+        disabledRules: INLINE_LINKS_MARKDOWN_DISABLED_RULES,
+      }
+    case MARKDOWN_PRESETS.RESTRICTED_BLOCK:
+      return {
+        inline: false,
+        rules: {
+          ...createApplicationBuilderMarkdownRules({ builder, mode }),
+          image: renderImageAsSource,
+        },
+        disabledRules: RESTRICTED_BLOCK_MARKDOWN_DISABLED_RULES,
+      }
+    case MARKDOWN_PRESETS.BLOCK:
+      return {
+        inline: false,
+        rules: createApplicationBuilderMarkdownRules({ builder, mode }),
+        disabledRules: [],
+      }
+    default:
+      throw new Error(`Unknown markdown preset: ${preset}`)
+  }
+}
+
+/**
+ * Click handler for rendered Markdown: blocks navigation while editing and keeps
+ * internal links inside the SPA router.
+ */
+export const handleMarkdownClick = (event, { mode, router }) => {
+  if (mode === 'editing') {
+    event.preventDefault()
+    return
+  }
+  // The click target can be nested markup inside the link, e.g. the `<strong>`
+  // of `[**terms**](/terms)`, so look up the closest link instead.
+  const link = event.target.closest('a.ab-link')
+  if (link) {
+    const url = link.getAttribute('href')
+
+    if (url.startsWith('/')) {
+      event.preventDefault()
+      router.push(url)
+    }
+  }
+}
+
+/**
+ * The marker a builder types at the start of a text to have it rendered as
+ * Markdown. It's content: the formula stores it as an ordinary string literal
+ * (`'__markdown__**Terms**'`, or `concat('__markdown__', get(...))` when a data
+ * node follows), the backend never treats it specially and the API has no
+ * notion of it. Detection happens once, at render time, on the resolved text.
+ */
+export const MARKDOWN_TEXT_MARKER = '__markdown__'
+
+/**
+ * Splits the Markdown marker off a resolved text. Returns the format the text
+ * asks for and the text without the marker. Nothing else compares against the
+ * marker literal.
+ */
+export const splitTextMarker = (content) => {
+  const text = content === null || content === undefined ? '' : String(content)
+  if (text.startsWith(MARKDOWN_TEXT_MARKER)) {
+    return {
+      format: TEXT_FORMAT_TYPES.MARKDOWN,
+      text: text.slice(MARKDOWN_TEXT_MARKER.length),
+    }
+  }
+  return { format: TEXT_FORMAT_TYPES.PLAIN, text }
+}

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_file_input.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_file_input.scss
@@ -14,6 +14,16 @@
   cursor: pointer;
   position: relative;
 
+  // The Markdown help text renders elements that set their own `text-align`
+  // from the theme variables, which would ignore the centering above that the
+  // plain text rendering simply inherits.
+  .markdown .ab-text,
+  .markdown .ab-heading,
+  .markdown .ab-list,
+  .markdown .ab-code {
+    text-align: inherit;
+  }
+
   &:focus {
     border-color: color-mix(
       in srgb,

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_markdown.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_markdown.scss
@@ -1,4 +1,8 @@
-.markdown {
+// The inline rendering carries the `markdown` class too, so the block spacing
+// below must exclude it: its children are `<code>`/`<img>` boxes sitting on the
+// text baseline, where a top margin grows the line box and pushes the whole
+// line down instead of separating blocks.
+.markdown:not(.markdown--inline) {
   & > .ab-blockquote,
   & > .ab-code,
   & > .ab-heading,
@@ -15,6 +19,12 @@
   }
 }
 
-.markdown > *:first-child {
+.markdown:not(.markdown--inline) > *:first-child {
   margin-top: 0;
+}
+
+// Inline Markdown (labels, option names, table headers...) must flow with
+// the surrounding text, e.g. inside an ellipsis container.
+.markdown--inline {
+  display: inline;
 }

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_table.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_table.scss
@@ -115,6 +115,13 @@
   align-items: var(--table-cell-alignment, flex-start);
   padding: var(--table-cell-vertical-padding, 10px)
     var(--table-cell-horizontal-padding, 20px);
+
+  // Markdown paragraphs would otherwise pick up the global `p { line-height }`
+  // and make rows taller than the plain `<span class="ab-text">` rendering,
+  // which simply inherits the page line-height.
+  .markdown > .ab-text {
+    line-height: inherit;
+  }
 }
 
 .ab-table__empty-state {

--- a/web-frontend/modules/core/components/MarkdownIt.vue
+++ b/web-frontend/modules/core/components/MarkdownIt.vue
@@ -1,6 +1,14 @@
 <!-- eslint-disable vue/no-v-html vue/no-v-text-v-html-on-component -->
 <template>
+  <span
+    v-if="inline"
+    :key="contentHash"
+    class="markdown markdown--inline"
+    @click="$emit('click', $event)"
+    v-html="htmlContent"
+  />
   <div
+    v-else
     :key="contentHash"
     class="markdown"
     @click="$emit('click', $event)"
@@ -9,7 +17,7 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { generateHash } from '@baserow/modules/core/utils/hashing'
 import MarkdownIt from 'markdown-it'
 
@@ -25,12 +33,34 @@ const props = defineProps({
     type: Object,
     default: () => ({}),
   },
+  /**
+   * Render the content with `renderInline` inside a `<span>` instead of parsing
+   * block syntax into a `<div>`. Block syntax (headings, lists, tables...) then
+   * stays literal text, which is what single-line surfaces like labels or
+   * dropdown options want.
+   */
+  inline: {
+    required: false,
+    type: Boolean,
+    default: false,
+  },
+  /**
+   * Names of the markdown-it rules to disable, e.g. `['link', 'image']`. The
+   * policy is owned by the caller because it differs per surface.
+   */
+  disabledRules: {
+    required: false,
+    type: Array,
+    default: () => [],
+  },
 })
 
-// Keep a single markdown-it instance per component instance.
+// Keep a single markdown-it instance per component instance, so disabling rules
+// can't leak to other consumers.
 const Markdown = MarkdownIt?.default || MarkdownIt
 const md = new Markdown()
 const baseRules = { ...md.renderer.rules }
+let appliedDisabledRules = []
 
 // The hash makes sure the data is updated if the content changes.
 const contentHash = computed(() => generateHash(props.content))
@@ -39,12 +69,24 @@ const contentHash = computed(() => generateHash(props.content))
 const htmlContent = ref('')
 
 const renderMarkdown = () => {
+  // Re-enable what was disabled by a previous render before applying the
+  // current list, otherwise a changed `disabledRules` would accumulate.
+  md.enable(appliedDisabledRules, true)
+  md.disable(props.disabledRules, true)
+  appliedDisabledRules = [...props.disabledRules]
+
   md.renderer.rules = { ...baseRules, ...props.rules }
-  htmlContent.value = md.render(props.content)
+  htmlContent.value = props.inline
+    ? md.renderInline(props.content)
+    : md.render(props.content)
 }
 
-watch(() => [props.content, props.rules], renderMarkdown, {
-  deep: true,
-  immediate: true,
-})
+watch(
+  () => [props.content, props.rules, props.inline, props.disabledRules],
+  renderMarkdown,
+  {
+    deep: true,
+    immediate: true,
+  }
+)
 </script>

--- a/web-frontend/test/unit/builder/components/BuilderToasts.spec.js
+++ b/web-frontend/test/unit/builder/components/BuilderToasts.spec.js
@@ -1,0 +1,71 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import BuilderToasts from '@baserow/modules/builder/components/BuilderToasts.vue'
+
+describe('BuilderToasts', () => {
+  let store = null
+
+  beforeEach(() => {
+    store = useNuxtApp().$store
+  })
+
+  afterEach(async () => {
+    for (const toast of [...store.getters['builderToast/all']]) {
+      await store.dispatch('builderToast/remove', toast)
+    }
+  })
+
+  const mountComponent = () =>
+    mountSuspended(BuilderToasts, {
+      global: { provide: { builder: { id: 1 }, mode: 'public' } },
+    })
+
+  test('renders plain toasts as-is', async () => {
+    await store.dispatch('builderToast/info', {
+      title: '**Saved**',
+      message: 'See [details](/details)',
+    })
+    const wrapper = await mountComponent()
+
+    expect(wrapper.find('.ab-toast__title strong').exists()).toBe(false)
+    expect(wrapper.find('.ab-toast__title').text()).toBe('**Saved**')
+    expect(wrapper.find('.ab-toast__message a').exists()).toBe(false)
+    expect(wrapper.find('.ab-toast__message').text()).toBe(
+      'See [details](/details)'
+    )
+  })
+
+  test('renders a marked title inline and a marked message as restricted block', async () => {
+    await store.dispatch('builderToast/info', {
+      title: '__markdown__# **Saved** [x](/x)',
+      message:
+        '__markdown__# Not a heading\n\nSee [details](/details)\n\n| a |\n|---|\n| 1 |',
+    })
+    const wrapper = await mountComponent()
+
+    const title = wrapper.find('.ab-toast__title')
+    expect(title.find('.markdown--inline strong').text()).toBe('Saved')
+    expect(title.find('a').exists()).toBe(false)
+    expect(title.find('.ab-heading').exists()).toBe(false)
+    expect(title.text()).not.toContain('__markdown__')
+
+    const message = wrapper.find('.ab-toast__message')
+    expect(message.find('.ab-heading').exists()).toBe(false)
+    expect(message.find('table').exists()).toBe(false)
+    expect(message.find('p.ab-text').exists()).toBe(true)
+    expect(message.find('a.ab-link').attributes('href')).toBe('/details')
+    expect(message.text()).toContain('# Not a heading')
+    expect(message.text()).not.toContain('__markdown__')
+  })
+
+  test('renders the title and the message independently', async () => {
+    await store.dispatch('builderToast/info', {
+      title: '__markdown__**Saved**',
+      message: '**Done**',
+    })
+    const wrapper = await mountComponent()
+
+    expect(wrapper.find('.ab-toast__title strong').text()).toBe('Saved')
+    expect(wrapper.find('.ab-toast__message strong').exists()).toBe(false)
+    expect(wrapper.find('.ab-toast__message').text()).toBe('**Done**')
+  })
+})

--- a/web-frontend/test/unit/builder/components/FormattedText.spec.js
+++ b/web-frontend/test/unit/builder/components/FormattedText.spec.js
@@ -1,0 +1,323 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { h } from 'vue'
+import FormattedText from '@baserow/modules/builder/components/FormattedText.vue'
+
+describe('FormattedText', () => {
+  const builder = { id: 7 }
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const mountComponent = (props, { mode = 'public', slots = {} } = {}) =>
+    mountSuspended(FormattedText, {
+      props,
+      slots,
+      global: { provide: { builder, mode } },
+    })
+
+  const click = (wrapper, selector) => {
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+    wrapper.find(selector).element.dispatchEvent(event)
+    return event
+  }
+
+  test('renders the raw text when the format is plain', async () => {
+    const wrapper = await mountComponent({ content: '**bold** [x](/x)' })
+
+    expect(wrapper.find('strong').exists()).toBe(false)
+    expect(wrapper.find('a').exists()).toBe(false)
+    expect(wrapper.text()).toBe('**bold** [x](/x)')
+  })
+
+  test('defaults to plain when no format is given', async () => {
+    const wrapper = await mountComponent({ content: '**bold**' })
+
+    expect(wrapper.text()).toBe('**bold**')
+  })
+
+  test('accepts numeric content', async () => {
+    const plain = await mountComponent({ content: 5 })
+    expect(plain.text()).toBe('5')
+
+    const markdown = await mountComponent({ content: 5, format: 'markdown' })
+    expect(markdown.text()).toBe('5')
+  })
+
+  describe('the Markdown marker', () => {
+    test('renders Markdown, minus the marker, when the content starts with it', async () => {
+      const wrapper = await mountComponent({
+        content: '__markdown__**bold** [x](/x)',
+        preset: 'inlineLinks',
+      })
+
+      expect(wrapper.find('strong').text()).toBe('bold')
+      expect(wrapper.find('a.ab-link').attributes('href')).toBe('/x')
+      expect(wrapper.text()).toBe('bold x')
+    })
+
+    test('keeps a marker elsewhere in the content as literal text', async () => {
+      const content = 'See __markdown__**bold**'
+      const wrapper = await mountComponent({ content, preset: 'inline' })
+
+      expect(wrapper.find('strong').exists()).toBe(false)
+      expect(wrapper.find('.markdown').exists()).toBe(false)
+      expect(wrapper.text()).toBe(content)
+    })
+
+    test('renders nothing for the marker alone', async () => {
+      const wrapper = await mountComponent({
+        content: '__markdown__',
+        preset: 'inline',
+      })
+
+      expect(wrapper.text()).toBe('')
+    })
+
+    test('renders Markdown when the format is plain but the content is marked', async () => {
+      const wrapper = await mountComponent({
+        content: '__markdown__**bold**',
+        format: 'plain',
+        preset: 'inline',
+      })
+
+      expect(wrapper.find('strong').text()).toBe('bold')
+      expect(wrapper.text()).toBe('bold')
+    })
+
+    test('strips the marker when the format is markdown too', async () => {
+      const wrapper = await mountComponent({
+        content: '__markdown__**bold**',
+        format: 'markdown',
+        preset: 'inline',
+      })
+
+      expect(wrapper.find('strong').text()).toBe('bold')
+      expect(wrapper.text()).toBe('bold')
+    })
+
+    test('does not turn a plain surface into Markdown without the marker', async () => {
+      const wrapper = await mountComponent({
+        content: '**bold**',
+        format: 'plain',
+        preset: 'inline',
+      })
+
+      expect(wrapper.find('strong').exists()).toBe(false)
+      expect(wrapper.text()).toBe('**bold**')
+    })
+  })
+
+  test('renders the plain slot with the bare text', async () => {
+    const wrapper = await mountComponent(
+      { content: '**bold**' },
+      {
+        slots: {
+          plain: ({ text }) => h('span', { class: 'ab-text' }, text),
+        },
+      }
+    )
+
+    expect(wrapper.find('span.ab-text').text()).toBe('**bold**')
+  })
+
+  test('ignores the plain slot when rendering Markdown', async () => {
+    const wrapper = await mountComponent(
+      { content: '__markdown__**bold**', preset: 'inline' },
+      {
+        slots: {
+          plain: ({ text }) => h('span', { class: 'ab-text' }, text),
+        },
+      }
+    )
+
+    expect(wrapper.find('span.ab-text').exists()).toBe(false)
+    expect(wrapper.find('strong').text()).toBe('bold')
+  })
+
+  test('inline preset renders emphasis but keeps links and block syntax literal', async () => {
+    const wrapper = await mountComponent({
+      content: '# **Urgent** [docs](https://example.com) `code`',
+      format: 'markdown',
+      preset: 'inline',
+    })
+
+    expect(wrapper.element.tagName).toBe('SPAN')
+    expect(wrapper.find('strong').text()).toBe('Urgent')
+    expect(wrapper.find('.ab-code--inline').text()).toBe('code')
+    expect(wrapper.find('a').exists()).toBe(false)
+    expect(wrapper.find('h1').exists()).toBe(false)
+    expect(wrapper.text()).toBe('# Urgent [docs](https://example.com) code')
+  })
+
+  test('inline presets render line breaks as spaces', async () => {
+    const wrapper = await mountComponent({
+      content: '__markdown__first  \nsecond\\\nthird',
+      preset: 'inline',
+    })
+
+    expect(wrapper.find('br').exists()).toBe(false)
+    expect(wrapper.text()).toBe('first second third')
+  })
+
+  test('inlineLinks preset renders links but keeps images literal', async () => {
+    const wrapper = await mountComponent({
+      content:
+        '__markdown__Agree to the [terms](/terms) and [docs](https://example.com) ![i](https://example.com/i.png "t")',
+      preset: 'inlineLinks',
+    })
+
+    const links = wrapper.findAll('a.ab-link')
+    expect(links).toHaveLength(2)
+    expect(links[0].attributes('href')).toBe('/terms')
+    expect(links[1].attributes('href')).toBe('https://example.com')
+    expect(wrapper.find('img').exists()).toBe(false)
+    expect(wrapper.text()).toContain('![i](https://example.com/i.png "t")')
+  })
+
+  test('prefixes internal links in preview mode', async () => {
+    const wrapper = await mountComponent(
+      { content: '__markdown__[terms](/terms)', preset: 'inlineLinks' },
+      { mode: 'preview' }
+    )
+
+    expect(wrapper.find('a.ab-link').attributes('href')).toBe(
+      '/builder/7/preview/terms'
+    )
+  })
+
+  test('explicit builder and mode props win over the injected ones', async () => {
+    const wrapper = await mountComponent(
+      {
+        content: '__markdown__[terms](/terms)',
+        preset: 'inlineLinks',
+        builder: { id: 9 },
+        mode: 'preview',
+      },
+      { mode: 'public' }
+    )
+
+    expect(wrapper.find('a.ab-link').attributes('href')).toBe(
+      '/builder/9/preview/terms'
+    )
+  })
+
+  test('restrictedBlock preset drops layout-breaking blocks but keeps links and lists', async () => {
+    const content = [
+      '__markdown__# Heading',
+      '',
+      'Some **text** with [a link](https://example.com)',
+      '',
+      '- item',
+      '',
+      '| a | b |',
+      '|---|---|',
+      '| 1 | 2 |',
+      '',
+      '```',
+      'code',
+      '```',
+      '',
+      '![i](https://example.com/i.png)',
+    ].join('\n')
+    const wrapper = await mountComponent({
+      content,
+      preset: 'restrictedBlock',
+    })
+
+    expect(wrapper.element.tagName).toBe('DIV')
+    expect(wrapper.find('.ab-heading').exists()).toBe(false)
+    expect(wrapper.find('table').exists()).toBe(false)
+    expect(wrapper.find('pre').exists()).toBe(false)
+    expect(wrapper.find('img').exists()).toBe(false)
+    expect(wrapper.text()).toContain('![i](https://example.com/i.png)')
+    expect(wrapper.find('p.ab-text').exists()).toBe(true)
+    expect(wrapper.find('strong').text()).toBe('text')
+    expect(wrapper.find('a.ab-link').attributes('href')).toBe(
+      'https://example.com'
+    )
+    expect(wrapper.find('.ab-list__item').text()).toBe('item')
+    expect(wrapper.text()).toContain('# Heading')
+  })
+
+  test('block preset renders the full syntax', async () => {
+    const wrapper = await mountComponent({
+      content: '__markdown__# Heading\n\n| a |\n|---|\n| 1 |',
+      preset: 'block',
+    })
+
+    expect(wrapper.find('.ab-heading').text()).toBe('Heading')
+    expect(wrapper.find('table').exists()).toBe(true)
+  })
+
+  test('blocks link navigation in editing mode', async () => {
+    const wrapper = await mountComponent(
+      { content: '__markdown__[terms](/terms)', preset: 'inlineLinks' },
+      { mode: 'editing' }
+    )
+
+    const event = click(wrapper, 'a.ab-link')
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  test('routes internal links through the router', async () => {
+    const push = vi
+      .spyOn(useNuxtApp().$router, 'push')
+      .mockImplementation(() => Promise.resolve())
+    const wrapper = await mountComponent({
+      content: '__markdown__[terms](/terms)',
+      preset: 'inlineLinks',
+    })
+
+    const event = click(wrapper, 'a.ab-link')
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(push).toHaveBeenCalledWith('/terms')
+  })
+
+  test('routes internal links through the router when nested markup is clicked', async () => {
+    const push = vi
+      .spyOn(useNuxtApp().$router, 'push')
+      .mockImplementation(() => Promise.resolve())
+    const wrapper = await mountComponent({
+      content: '__markdown__[**terms**](/terms)',
+      preset: 'inlineLinks',
+    })
+
+    const event = click(wrapper, 'a.ab-link strong')
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(push).toHaveBeenCalledWith('/terms')
+  })
+
+  test('ignores clicks outside links', async () => {
+    const push = vi
+      .spyOn(useNuxtApp().$router, 'push')
+      .mockImplementation(() => Promise.resolve())
+    const wrapper = await mountComponent({
+      content: '__markdown__**bold** [terms](/terms)',
+      preset: 'inlineLinks',
+    })
+
+    const event = click(wrapper, 'strong')
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  test('leaves external links to the browser', async () => {
+    const push = vi
+      .spyOn(useNuxtApp().$router, 'push')
+      .mockImplementation(() => Promise.resolve())
+    const wrapper = await mountComponent({
+      content: '__markdown__[docs](https://example.com)',
+      preset: 'inlineLinks',
+    })
+
+    const event = click(wrapper, 'a.ab-link')
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(push).not.toHaveBeenCalled()
+  })
+})

--- a/web-frontend/test/unit/builder/components/applicationBuilderFormulaInput.spec.js
+++ b/web-frontend/test/unit/builder/components/applicationBuilderFormulaInput.spec.js
@@ -1,0 +1,73 @@
+// `builder/enums.js` and `builder/dataProviderTypes.js` import each other, so
+// the enums must be evaluated before the formula input pulls in the providers.
+import { TEXT_FORMAT_TYPES } from '@baserow/modules/builder/enums'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { splitTextMarker } from '@baserow/modules/builder/utils/markdown'
+import ApplicationBuilderFormulaInput from '@baserow/modules/builder/components/ApplicationBuilderFormulaInput.vue'
+import FormulaInputField from '@baserow/modules/core/components/formula/FormulaInputField.vue'
+
+describe('ApplicationBuilderFormulaInput with the Markdown marker', () => {
+  const mountInput = (value) => {
+    const page = {
+      id: 1,
+      elements: [],
+      dataSources: [],
+      path_params: [{ name: 'id', type: 'text' }],
+      query_params: [],
+      _: { dataSourceLoading: false, dataSourceContentLoading: false },
+    }
+    const builder = { id: 1, theme: {}, pages: [page] }
+    const mode = 'editing'
+
+    return mountSuspended(ApplicationBuilderFormulaInput, {
+      props: { modelValue: value, dataProvidersAllowed: ['page_parameter'] },
+      attachTo: document.body,
+      global: {
+        provide: {
+          workspace: {},
+          builder,
+          currentPage: page,
+          elementPage: page,
+          mode,
+          applicationContext: { builder, page, mode },
+        },
+      },
+    })
+  }
+
+  const roundTrip = async (wrapper) => {
+    wrapper.findComponent(FormulaInputField).vm.emitChange()
+    await wrapper.vm.$nextTick()
+    return wrapper.emitted('update:modelValue').at(-1)[0]
+  }
+
+  test('shows the marker in a literal and keeps the formula through a round trip', async () => {
+    const value = { formula: "'__markdown__**Terms**'", mode: 'simple' }
+    const wrapper = await mountInput(value)
+
+    expect(wrapper.find('.formula-input-field').text()).toContain(
+      '__markdown__**Terms**'
+    )
+    expect(await roundTrip(wrapper)).toEqual(value)
+    expect(splitTextMarker('__markdown__**Terms**').format).toBe(
+      TEXT_FORMAT_TYPES.MARKDOWN
+    )
+
+    wrapper.unmount()
+  })
+
+  test('shows the marker before a data node and keeps the formula through a round trip', async () => {
+    const value = {
+      formula: "concat('__markdown__', get('page_parameter.id'))",
+      mode: 'simple',
+    }
+    const wrapper = await mountInput(value)
+
+    expect(wrapper.find('.formula-input-field').text()).toContain(
+      '__markdown__'
+    )
+    expect(await roundTrip(wrapper)).toEqual(value)
+
+    wrapper.unmount()
+  })
+})

--- a/web-frontend/test/unit/builder/components/elements/components/CheckboxElement.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/CheckboxElement.spec.js
@@ -1,0 +1,146 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import CheckboxElement from '@baserow/modules/builder/components/elements/components/CheckboxElement.vue'
+
+describe('CheckboxElement', () => {
+  let store = null
+  let wrapper = null
+
+  beforeEach(() => {
+    store = useNuxtApp().$store
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = null
+  })
+
+  const mountCheckbox = async ({
+    mode = 'public',
+    pageParameters = {},
+    ...elementOverrides
+  }) => {
+    const page = { id: 1, elements: [] }
+    const builder = { id: 1, theme: { primary_color: '#ccc' }, pages: [page] }
+    const applicationContext = { builder, page, mode }
+    const element = {
+      id: 42,
+      type: 'checkbox',
+      label: { mode: 'raw', formula: 'I agree to the [terms](/terms)' },
+      default_value: { formula: '' },
+      required: false,
+      page_id: page.id,
+      styles: {},
+      ...elementOverrides,
+    }
+
+    store.dispatch('element/forceCreate', { page, element })
+    for (const [name, value] of Object.entries(pageParameters)) {
+      await store.dispatch('pageParameter/setParameter', { page, name, value })
+    }
+    const elementType = store.$registry.get('element', 'checkbox')
+    store.dispatch('formData/setFormData', {
+      page,
+      elementId: element.id,
+      payload: {
+        value: false,
+        type: elementType.formDataType(element),
+        isValid: elementType.isValid(element, false, applicationContext),
+        touched: false,
+      },
+    })
+
+    // Attached to the document so that the native `label[for]` activation
+    // behaviour applies when clicking the label.
+    return mountSuspended(CheckboxElement, {
+      props: { element },
+      attachTo: document.body,
+      global: {
+        provide: {
+          builder,
+          currentPage: page,
+          elementPage: page,
+          mode,
+          applicationContext,
+          element,
+          workspace: {},
+        },
+      },
+    })
+  }
+
+  const click = (wrapper, selector) => {
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+    wrapper.find(selector).element.dispatchEvent(event)
+    return event
+  }
+
+  test('renders the raw label without the marker', async () => {
+    wrapper = await mountCheckbox({})
+
+    expect(wrapper.find('.ab-checkbox__label a').exists()).toBe(false)
+    expect(wrapper.find('.ab-checkbox__label').text()).toBe(
+      'I agree to the [terms](/terms)'
+    )
+  })
+
+  test('renders a marked literal label as Markdown with links', async () => {
+    wrapper = await mountCheckbox({
+      label: {
+        mode: 'raw',
+        formula: '__markdown__I agree to the [terms](/terms)',
+      },
+    })
+
+    const label = wrapper.find('.ab-checkbox__label')
+    const link = label.find('a.ab-link')
+    expect(link.text()).toBe('terms')
+    expect(link.attributes('href')).toBe('/terms')
+    expect(label.text()).not.toContain('__markdown__')
+  })
+
+  test('renders a marked data-fed label as Markdown', async () => {
+    wrapper = await mountCheckbox({
+      label: {
+        mode: 'simple',
+        formula: "concat('__markdown__', get('page_parameter.terms'))",
+      },
+      pageParameters: { terms: 'I agree to the [terms](/terms)' },
+    })
+
+    const label = wrapper.find('.ab-checkbox__label')
+    expect(label.find('a.ab-link').attributes('href')).toBe('/terms')
+    expect(label.text()).not.toContain('__markdown__')
+  })
+
+  test('clicking the label text toggles the checkbox, clicking the link does not', async () => {
+    wrapper = await mountCheckbox({
+      label: {
+        mode: 'raw',
+        formula: '__markdown__I agree to the [terms](/terms)',
+      },
+    })
+    expect(wrapper.vm.inputValue).toBe(false)
+
+    click(wrapper, '.ab-checkbox__label')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.inputValue).toBe(true)
+
+    click(wrapper, '.ab-checkbox__label a.ab-link')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.inputValue).toBe(true)
+  })
+
+  test('blocks link navigation in editing mode', async () => {
+    wrapper = await mountCheckbox({
+      label: {
+        mode: 'raw',
+        formula: '__markdown__I agree to the [terms](/terms)',
+      },
+      mode: 'editing',
+    })
+
+    const event = click(wrapper, '.ab-checkbox__label a.ab-link')
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+})

--- a/web-frontend/test/unit/builder/components/elements/components/ChoiceElement.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/ChoiceElement.spec.js
@@ -155,3 +155,193 @@ describe('ChoiceElement', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 })
+
+describe('ChoiceElement Markdown marker', () => {
+  let store = null
+
+  beforeEach(() => {
+    store = useNuxtApp().$store
+  })
+
+  // The selection is driven by `default_value`: the form element mixin resets
+  // the form data to the resolved default value on mount.
+  const mountChoice = async (elementOverrides, value = null) => {
+    const page = { id: 1, elements: [] }
+    const builder = { id: 1, theme: { primary_color: '#ccc' }, pages: [page] }
+    const mode = 'public'
+    const applicationContext = { builder, page, mode }
+    const element = {
+      id: 43,
+      type: 'choice',
+      label: { mode: 'raw', formula: 'Pick **one** ([help](/help))' },
+      default_value: { formula: '' },
+      placeholder: { formula: '' },
+      required: false,
+      multiple: false,
+      show_as_dropdown: false,
+      option_type: 'manual',
+      options: [
+        { id: 1, value: '1', name: '__markdown__**First**' },
+        { id: 2, value: '2', name: 'See [docs](https://example.com)' },
+        { id: 3, value: '3', name: '__markdown__[no](https://example.com) link' },
+      ],
+      formula_name: { formula: '' },
+      formula_value: { formula: '' },
+      page_id: page.id,
+      styles: {},
+      ...elementOverrides,
+    }
+
+    store.dispatch('element/forceCreate', { page, element })
+    const elementType = store.$registry.get('element', 'choice')
+    store.dispatch('formData/setFormData', {
+      page,
+      elementId: element.id,
+      payload: {
+        value,
+        type: elementType.formDataType(element),
+        isValid: elementType.isValid(element, value, applicationContext),
+        touched: false,
+      },
+    })
+
+    return mountSuspended(ChoiceElement, {
+      props: { element },
+      global: {
+        provide: {
+          builder,
+          currentPage: page,
+          elementPage: page,
+          mode,
+          applicationContext,
+          element,
+          workspace: {},
+        },
+      },
+    })
+  }
+
+  test('renders the raw label without the marker', async () => {
+    const wrapper = await mountChoice({})
+
+    const label = wrapper.find('.ab-form-group__label')
+    expect(label.find('strong').exists()).toBe(false)
+    expect(label.text()).toBe('Pick **one** ([help](/help))')
+  })
+
+  test('renders a marked label as Markdown with links', async () => {
+    const wrapper = await mountChoice({
+      label: { mode: 'raw', formula: '__markdown__Pick **one** ([help](/help))' },
+    })
+
+    const label = wrapper.find('.ab-form-group__label')
+    expect(label.find('strong').text()).toBe('one')
+    expect(label.find('a.ab-link').attributes('href')).toBe('/help')
+  })
+
+  test('renders radio option names as inline Markdown, per option, without links', async () => {
+    const wrapper = await mountChoice({})
+
+    const [first, second, third] = wrapper.findAll('.ab-radio__label')
+    expect(first.find('strong').text()).toBe('First')
+    expect(first.text()).toBe('First')
+    expect(second.find('a').exists()).toBe(false)
+    expect(second.text()).toBe('See [docs](https://example.com)')
+    expect(third.find('a').exists()).toBe(false)
+    expect(third.text()).toBe('[no](https://example.com) link')
+  })
+
+  test('renders checkbox option names as inline Markdown, per option', async () => {
+    const wrapper = await mountChoice({ multiple: true }, [])
+
+    const [first, second] = wrapper.findAll('.ab-checkbox__label')
+    expect(first.find('strong').text()).toBe('First')
+    expect(second.find('strong').exists()).toBe(false)
+    expect(second.text()).toBe('See [docs](https://example.com)')
+  })
+
+  test('renders formula-fed option names as inline Markdown, per option', async () => {
+    const wrapper = await mountChoice({
+      option_type: 'formulas',
+      formula_value: { mode: 'raw', formula: '1,2' },
+      formula_name: { mode: 'raw', formula: '__markdown__**One**,**Two**' },
+    })
+
+    const [first, second] = wrapper.findAll('.ab-radio__label')
+    expect(first.find('strong').text()).toBe('One')
+    expect(second.find('strong').exists()).toBe(false)
+    expect(second.text()).toBe('**Two**')
+  })
+
+  test('renders dropdown option names as inline Markdown, keeping the bare name for the tooltip and the search', async () => {
+    const wrapper = await mountChoice(
+      { show_as_dropdown: true, default_value: { mode: 'raw', formula: '1' } },
+      '1'
+    )
+
+    const [first, second] = wrapper.findAll('.ab-dropdownitem__item-name-text')
+    expect(first.find('strong').text()).toBe('First')
+    expect(first.attributes('title')).toBe('**First**')
+    expect(second.find('a').exists()).toBe(false)
+    expect(second.attributes('title')).toBe('See [docs](https://example.com)')
+
+    const [firstItem] = wrapper.findAllComponents({ name: 'ABDropdownItem' })
+    expect(firstItem.props('name')).toBe('**First**')
+
+    // The collapsed dropdown shows the selected option rendered as well. The
+    // dropdown resolves its selection once the items have registered.
+    await wrapper.vm.$nextTick()
+    const selected = wrapper.find('.ab-dropdown__selected-text')
+    expect(selected.find('strong').text()).toBe('First')
+    expect(selected.text()).toBe('First')
+  })
+
+  test('renders every selected option in a multiple dropdown', async () => {
+    const wrapper = await mountChoice(
+      {
+        show_as_dropdown: true,
+        multiple: true,
+        default_value: { mode: 'raw', formula: '1,2' },
+      },
+      ['1', '2']
+    )
+
+    await wrapper.vm.$nextTick()
+    const selected = wrapper.find('.ab-dropdown__selected-text')
+    expect(selected.find('strong').text()).toBe('First')
+    expect(selected.text()).toBe('First, See [docs](https://example.com)')
+  })
+
+  test('leaves the collapsed dropdown to the base component without marked options', async () => {
+    const wrapper = await mountChoice(
+      {
+        show_as_dropdown: true,
+        options: [{ id: 1, value: '1', name: '**First**' }],
+        default_value: { mode: 'raw', formula: '1' },
+      },
+      '1'
+    )
+
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.hasMarkdownOptions).toBe(false)
+    expect(wrapper.find('.ab-dropdown__selected-text').text()).toBe('**First**')
+  })
+
+  // Known limitation, pinned: an option without an explicit value submits its
+  // name, marker included. Setting an explicit value avoids it.
+  test('an option named with the marker and no explicit value submits the marked name', async () => {
+    const wrapper = await mountChoice({
+      options: [{ id: 1, value: null, name: '__markdown__**First**' }],
+    })
+
+    expect(wrapper.vm.optionsResolved).toEqual([
+      { name: '__markdown__**First**', value: '__markdown__**First**' },
+    ])
+    expect(wrapper.find('.ab-radio__label strong').text()).toBe('First')
+
+    wrapper.vm.onOptionChange(wrapper.vm.optionsResolved[0], true)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.inputValue).toBe('__markdown__**First**')
+  })
+})

--- a/web-frontend/test/unit/builder/components/elements/components/InputTextElement.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/InputTextElement.spec.js
@@ -63,3 +63,113 @@ describe('InputTextElement', () => {
     }
   )
 })
+
+describe('InputTextElement label', () => {
+  let store = null
+
+  beforeEach(() => {
+    store = useNuxtApp().$store
+  })
+
+  const mountWithLabel = async (label, pageParameters = {}) => {
+    const page = { id: 1, elements: [] }
+    const builder = { id: 1, theme: { primary_color: '#ccc' }, pages: [page] }
+    const workspace = {}
+    const mode = 'public'
+    const element = {
+      id: 43,
+      type: 'input_text',
+      validation_type: 'any',
+      default_value: { formula: '' },
+      label,
+      placeholder: { formula: '' },
+      required: false,
+      is_multiline: false,
+      rows: 1,
+      input_type: 'text',
+      page_id: page.id,
+      styles: {},
+    }
+
+    store.dispatch('element/forceCreate', { page, element })
+    for (const [name, value] of Object.entries(pageParameters)) {
+      await store.dispatch('pageParameter/setParameter', { page, name, value })
+    }
+
+    return mountSuspended(InputTextElement, {
+      props: { element },
+      global: {
+        provide: {
+          builder,
+          currentPage: page,
+          elementPage: page,
+          mode,
+          applicationContext: { builder, page, mode },
+          element,
+          workspace,
+        },
+      },
+    })
+  }
+
+  test('renders the raw label by default', async () => {
+    const wrapper = await mountWithLabel({
+      mode: 'raw',
+      formula: 'Your **name** ([why?](/why))',
+    })
+
+    const label = wrapper.find('.ab-form-group__label')
+    expect(label.find('strong').exists()).toBe(false)
+    expect(label.text()).toBe('Your **name** ([why?](/why))')
+  })
+
+  test('renders a marked literal label as Markdown with links', async () => {
+    const wrapper = await mountWithLabel({
+      mode: 'raw',
+      formula: '__markdown__Your **name** ([why?](/why))',
+    })
+
+    const label = wrapper.find('.ab-form-group__label')
+    expect(label.find('strong').text()).toBe('name')
+    expect(label.find('a.ab-link').attributes('href')).toBe('/why')
+    expect(label.text()).not.toContain('__markdown__')
+  })
+
+  test('renders a marked data-fed label as Markdown', async () => {
+    const wrapper = await mountWithLabel(
+      {
+        mode: 'simple',
+        formula: "concat('__markdown__', get('page_parameter.label'))",
+      },
+      { label: 'Your **name**' }
+    )
+
+    const label = wrapper.find('.ab-form-group__label')
+    expect(label.find('strong').text()).toBe('name')
+    expect(label.text()).toBe('Your name')
+  })
+
+  // Pinned on purpose: the marker is detected on the resolved text, so a data
+  // value decides the rendering of a surface whose formula has no marker.
+  test('a data value starting with the marker renders as Markdown', async () => {
+    const wrapper = await mountWithLabel(
+      { mode: 'simple', formula: "get('page_parameter.label')" },
+      { label: '__markdown__Your **name**' }
+    )
+
+    const label = wrapper.find('.ab-form-group__label')
+    expect(label.find('strong').text()).toBe('name')
+    expect(label.text()).toBe('Your name')
+  })
+
+  test('a data value with the marker mid-string stays plain', async () => {
+    const wrapper = await mountWithLabel(
+      { mode: 'simple', formula: "get('page_parameter.label')" },
+      { label: 'Your __markdown__**name**' }
+    )
+
+    const label = wrapper.find('.ab-form-group__label')
+    expect(label.find('strong').exists()).toBe(false)
+    expect(label.text()).toBe('Your __markdown__**name**')
+  })
+})

--- a/web-frontend/test/unit/builder/components/elements/components/TableElement.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/TableElement.spec.js
@@ -1,0 +1,84 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import TableElement from '@baserow/modules/builder/components/elements/components/TableElement.vue'
+
+describe('TableElement', () => {
+  let store = null
+
+  beforeEach(() => {
+    store = useNuxtApp().$store
+  })
+
+  const mountTable = async (fields) => {
+    const page = { id: 1, elements: [], dataSources: [] }
+    const sharedPage = { id: 2, shared: true, elements: [], dataSources: [] }
+    const builder = {
+      id: 1,
+      theme: { primary_color: '#ccc' },
+      pages: [page, sharedPage],
+      integrations: [],
+    }
+    const mode = 'public'
+    const element = {
+      id: 45,
+      type: 'table',
+      data_source_id: null,
+      schema_property: null,
+      items_per_page: 5,
+      button_load_more_label: { formula: '' },
+      orientation: {
+        desktop: 'horizontal',
+        tablet: 'horizontal',
+        smartphone: 'horizontal',
+      },
+      fields: fields.map((field, index) => ({
+        id: index + 1,
+        uid: `uid-${index + 1}`,
+        type: 'text',
+        value: { formula: '' },
+        styles: {},
+        ...field,
+      })),
+      page_id: page.id,
+      styles: {},
+    }
+
+    store.dispatch('element/forceCreate', { page, element })
+
+    return mountSuspended(TableElement, {
+      // Like `ElementPreview`/`PageElement`, the page reaches the collection
+      // element through the application context additions.
+      props: {
+        element,
+        applicationContextAdditions: { recordIndexPath: [], page },
+      },
+      global: {
+        provide: {
+          builder,
+          currentPage: page,
+          elementPage: page,
+          mode,
+          applicationContext: { builder, page, mode, element },
+          element,
+          workspace: {},
+        },
+      },
+    })
+  }
+
+  test('renders column headers as inline Markdown only when the name starts with the marker', async () => {
+    const wrapper = await mountTable([
+      { name: '__markdown__**Bold** ([docs](https://example.com))' },
+      { name: '**Plain**' },
+      { name: 'Legacy __markdown__**mid**' },
+    ])
+
+    const [markdown, plain, legacy] = wrapper.findAll('th')
+    expect(markdown.find('strong').text()).toBe('Bold')
+    expect(markdown.find('a').exists()).toBe(false)
+    expect(markdown.text()).toBe('Bold ([docs](https://example.com))')
+    expect(plain.find('strong').exists()).toBe(false)
+    expect(plain.text()).toBe('**Plain**')
+    expect(legacy.find('strong').exists()).toBe(false)
+    expect(legacy.text()).toBe('Legacy __markdown__**mid**')
+  })
+})

--- a/web-frontend/test/unit/builder/components/elements/components/TextElement.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/TextElement.spec.js
@@ -2,20 +2,13 @@ import { mountSuspended } from '@nuxt/test-utils/runtime'
 import TextElement from '@baserow/modules/builder/components/elements/components/TextElement.vue'
 
 describe('TextElement', () => {
-  test('renders Markdown with the Application Builder rules', async () => {
+  const mountText = (element) => {
     const page = {}
     const builder = { id: 1, theme: {} }
     const mode = 'public'
-    const element = {
-      id: 1,
-      type: 'text',
-      value: { mode: 'raw', formula: '# Heading\n\n`inline code`' },
-      format: 'markdown',
-      styles: {},
-    }
 
-    const wrapper = await mountSuspended(TextElement, {
-      props: { element },
+    return mountSuspended(TextElement, {
+      props: { element: { id: 1, type: 'text', styles: {}, ...element } },
       global: {
         provide: {
           workspace: {},
@@ -27,8 +20,59 @@ describe('TextElement', () => {
         },
       },
     })
+  }
+
+  test('renders Markdown with the Application Builder rules', async () => {
+    const wrapper = await mountText({
+      value: { mode: 'raw', formula: '# Heading\n\n`inline code`' },
+      format: 'markdown',
+    })
 
     expect(wrapper.find('.ab-heading').text()).toBe('Heading')
     expect(wrapper.find('.ab-code--inline').text()).toBe('inline code')
+  })
+
+  test('renders plain text as paragraphs', async () => {
+    const wrapper = await mountText({
+      value: { mode: 'raw', formula: '# Heading\n\n`inline code`' },
+      format: 'plain',
+    })
+
+    expect(wrapper.find('.ab-heading').exists()).toBe(false)
+    expect(wrapper.findAll('p')).toHaveLength(2)
+    expect(wrapper.text()).toContain('# Heading')
+  })
+
+  // The Text element keeps its own format setting, and follows the marker
+  // rule of every other text surface on top of it. Pinned on purpose.
+  test('renders a plain-format element as Markdown when its value starts with the marker', async () => {
+    const wrapper = await mountText({
+      value: { mode: 'raw', formula: '__markdown__# Heading\n\n`inline code`' },
+      format: 'plain',
+    })
+
+    expect(wrapper.find('.ab-heading').text()).toBe('Heading')
+    expect(wrapper.find('.ab-code--inline').text()).toBe('inline code')
+    expect(wrapper.text()).not.toContain('__markdown__')
+  })
+
+  test('strips the marker from a markdown-format element too', async () => {
+    const wrapper = await mountText({
+      value: { mode: 'raw', formula: '__markdown__# Heading' },
+      format: 'markdown',
+    })
+
+    expect(wrapper.find('.ab-heading').text()).toBe('Heading')
+    expect(wrapper.text()).not.toContain('__markdown__')
+  })
+
+  test('keeps a marker elsewhere in a plain-format element as text', async () => {
+    const wrapper = await mountText({
+      value: { mode: 'raw', formula: 'See __markdown__# Heading' },
+      format: 'plain',
+    })
+
+    expect(wrapper.find('.ab-heading').exists()).toBe(false)
+    expect(wrapper.text()).toContain('See __markdown__# Heading')
   })
 })

--- a/web-frontend/test/unit/builder/components/elements/components/TextField.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/TextField.spec.js
@@ -1,0 +1,52 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import TextField from '@baserow/modules/builder/components/elements/components/collectionField/TextField.vue'
+
+describe('TextField', () => {
+  const page = {}
+  const builder = { id: 1, theme: {} }
+  const mode = 'public'
+  const element = { id: 1, type: 'table', fields: [], styles: {} }
+  const field = { id: 1, uid: 'abc', name: 'Field', type: 'text', styles: {} }
+  const value = '# Heading\n\n`inline code`'
+
+  const mountComponent = (props = {}) =>
+    mountSuspended(TextField, {
+      props: { element, field, value, ...props },
+      global: {
+        provide: {
+          workspace: {},
+          builder,
+          currentPage: page,
+          elementPage: page,
+          mode,
+          applicationContext: { builder, page, mode },
+        },
+      },
+    })
+
+  test('renders a marked value as Markdown with the Application Builder rules', async () => {
+    const wrapper = await mountComponent({ value: `__markdown__${value}` })
+
+    expect(wrapper.find('.ab-heading').text()).toBe('Heading')
+    expect(wrapper.find('.ab-code--inline').text()).toBe('inline code')
+    expect(wrapper.find('span.ab-text').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('__markdown__')
+  })
+
+  test('renders the raw text in the text span without the marker', async () => {
+    const wrapper = await mountComponent()
+
+    const spans = wrapper.findAll('span.ab-text')
+    expect(spans).toHaveLength(1)
+    expect(spans[0].text()).toBe(value)
+    expect(wrapper.find('.ab-heading').exists()).toBe(false)
+    expect(wrapper.find('.markdown').exists()).toBe(false)
+  })
+
+  test('keeps a marker elsewhere in the value as text', async () => {
+    const wrapper = await mountComponent({ value: 'See __markdown__**x**' })
+
+    expect(wrapper.find('span.ab-text').text()).toBe('See __markdown__**x**')
+    expect(wrapper.find('strong').exists()).toBe(false)
+  })
+})

--- a/web-frontend/test/unit/builder/components/elements/components/__snapshots__/ChoiceElement.spec.js.snap
+++ b/web-frontend/test/unit/builder/components/elements/components/__snapshots__/ChoiceElement.spec.js.snap
@@ -116,7 +116,9 @@ exports[`ChoiceElement > as manual checkboxes 1`] = `
               for="ab-checkbox-v-0-0-1"
             >
               
+              
               First
+              
               
             </label>
           </div>
@@ -134,7 +136,9 @@ exports[`ChoiceElement > as manual checkboxes 1`] = `
               for="ab-checkbox-v-0-0-2"
             >
               
+              
               Second
+              
               
             </label>
           </div>
@@ -221,7 +225,9 @@ exports[`ChoiceElement > as manual dropdown 1`] = `
                         class="ab-dropdownitem__item-name-text"
                         title="First"
                       >
+                        
                         First
+                        
                       </span>
                       
                     </div>
@@ -246,7 +252,9 @@ exports[`ChoiceElement > as manual dropdown 1`] = `
                         class="ab-dropdownitem__item-name-text"
                         title="Second"
                       >
+                        
                         Second
+                        
                       </span>
                       
                     </div>
@@ -315,7 +323,9 @@ exports[`ChoiceElement > as manual radio 1`] = `
               class="ab-radio__label"
             >
               
+              
               First
+              
               
             </label>
           </div>
@@ -331,7 +341,9 @@ exports[`ChoiceElement > as manual radio 1`] = `
               class="ab-radio__label"
             >
               
+              
               Second
+              
               
             </label>
           </div>

--- a/web-frontend/test/unit/builder/components/elements/components/checkboxElementForm.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/checkboxElementForm.spec.js
@@ -1,0 +1,60 @@
+import CheckboxElementForm from '@baserow/modules/builder/components/elements/components/forms/general/CheckboxElementForm'
+
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { h } from 'vue'
+
+describe('CheckboxElementForm', () => {
+  let wrapper
+
+  const mountComponent = () =>
+    mountSuspended(CheckboxElementForm, {
+      props: {
+        element: { id: 1, type: 'checkbox' },
+        baseTheme: {},
+        defaultValues: {
+          label: { formula: 'Agree' },
+          default_value: { formula: '' },
+          required: false,
+          styles: {},
+        },
+      },
+      global: {
+        provide: {
+          workspace: {},
+          builder: { theme: {} },
+          currentPage: {},
+          elementPage: {},
+          mode: 'edit',
+          formulaComponent: () => h('div', `fake formula component`),
+          dataProvidersAllowed: [],
+          openCustomStyleForm: vi.fn(),
+        },
+        stubs: { InjectedFormulaInput: true, CustomStyleButton: true },
+      },
+    })
+
+  beforeEach(async () => {
+    wrapper = await mountComponent()
+  })
+
+  afterEach(() => {
+    wrapper.unmount()
+  })
+
+  test('hints at the Markdown marker under the label and stores no format', () => {
+    const hints = wrapper.findAll('.control__helper-text')
+    expect(hints).toHaveLength(1)
+    expect(hints[0].text()).toBe(useNuxtApp().$i18n.t('markdownMarker.hint'))
+    expect(
+      wrapper.find('.control__helper-text').element.closest('.control')
+    ).toBe(wrapper.findAll('.control')[0].element)
+
+    expect(wrapper.vm.allowedValues).toEqual([
+      'label',
+      'default_value',
+      'required',
+      'styles',
+    ])
+    expect(wrapper.findComponent({ name: 'RadioGroup' }).exists()).toBe(false)
+  })
+})

--- a/web-frontend/test/unit/builder/components/elements/components/textFieldForm.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/textFieldForm.spec.js
@@ -1,0 +1,59 @@
+import TextFieldForm from '@baserow/modules/builder/components/elements/components/collectionField/form/TextFieldForm'
+
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { h } from 'vue'
+
+describe('TextFieldForm', () => {
+  let wrapper
+
+  const mountComponent = () =>
+    mountSuspended(TextFieldForm, {
+      props: {
+        element: { id: 1, type: 'table', fields: [] },
+        baseTheme: {},
+        defaultValues: {
+          value: { formula: 'test text' },
+          styles: {},
+          // Add some non-allowed properties
+          someOtherProp: 'should not be included',
+        },
+      },
+      global: {
+        provide: {
+          workspace: {},
+          builder: { theme: {} },
+          currentPage: {},
+          elementPage: {},
+          mode: 'edit',
+          formulaComponent: () => h('div', `fake formula component`),
+          dataProvidersAllowed: [],
+          openCustomStyleForm: vi.fn(),
+        },
+        stubs: { InjectedFormulaInput: true, CustomStyleButton: true },
+      },
+    })
+
+  beforeEach(async () => {
+    wrapper = await mountComponent()
+  })
+
+  afterEach(() => {
+    wrapper.unmount()
+  })
+
+  test('hints at the Markdown marker under the value and stores no format', async () => {
+    const hints = wrapper.findAll('.control__helper-text')
+    expect(hints).toHaveLength(1)
+    expect(hints[0].text()).toBe(useNuxtApp().$i18n.t('markdownMarker.hint'))
+    expect(wrapper.vm.allowedValues).toEqual(['value', 'styles'])
+
+    await wrapper.setData({ values: { styles: { color: 'red' } } })
+
+    const emittedValues = wrapper.emitted('values-changed')
+    expect(emittedValues).toBeTruthy()
+    expect(emittedValues[emittedValues.length - 1][0]).toEqual({
+      value: { formula: 'test text' },
+      styles: { color: 'red' },
+    })
+  })
+})

--- a/web-frontend/test/unit/builder/components/workflowAction/notificationWorkflowActionForm.spec.js
+++ b/web-frontend/test/unit/builder/components/workflowAction/notificationWorkflowActionForm.spec.js
@@ -1,0 +1,48 @@
+import NotificationWorkflowActionForm from '@baserow/modules/builder/components/workflowAction/NotificationWorkflowActionForm'
+
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { h } from 'vue'
+
+describe('NotificationWorkflowActionForm', () => {
+  let wrapper
+
+  const mountComponent = () =>
+    mountSuspended(NotificationWorkflowActionForm, {
+      props: {
+        defaultValues: {
+          title: { formula: 'Saved' },
+          description: { formula: 'Done' },
+        },
+      },
+      global: {
+        provide: {
+          workspace: {},
+          builder: { theme: {} },
+          currentPage: {},
+          elementPage: {},
+          mode: 'edit',
+          formulaComponent: () => h('div', `fake formula component`),
+          dataProvidersAllowed: [],
+        },
+        stubs: { InjectedFormulaInput: true },
+      },
+    })
+
+  beforeEach(async () => {
+    wrapper = await mountComponent()
+  })
+
+  afterEach(() => {
+    wrapper.unmount()
+  })
+
+  test('hints at the Markdown marker under the title and the description and stores no format', () => {
+    const hints = wrapper.findAll('.control__helper-text')
+    expect(hints).toHaveLength(2)
+    hints.forEach((hint) =>
+      expect(hint.text()).toBe(useNuxtApp().$i18n.t('markdownMarker.hint'))
+    )
+    expect(Object.keys(wrapper.vm.values)).toEqual(['title', 'description'])
+    expect(wrapper.findComponent({ name: 'RadioGroup' }).exists()).toBe(false)
+  })
+})

--- a/web-frontend/test/unit/core/components/markdownIt.spec.js
+++ b/web-frontend/test/unit/core/components/markdownIt.spec.js
@@ -1,0 +1,67 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import MarkdownIt from '@baserow/modules/core/components/MarkdownIt.vue'
+
+describe('MarkdownIt', () => {
+  const mountComponent = (props) => mountSuspended(MarkdownIt, { props })
+
+  test('renders block Markdown in a div by default', async () => {
+    const wrapper = await mountComponent({
+      content: '# Title\n\nSome **bold** text',
+    })
+
+    expect(wrapper.element.tagName).toBe('DIV')
+    expect(wrapper.classes()).not.toContain('markdown--inline')
+    expect(wrapper.find('h1').text()).toBe('Title')
+    expect(wrapper.find('strong').text()).toBe('bold')
+  })
+
+  test('renders inline Markdown in a span and keeps block syntax literal', async () => {
+    const wrapper = await mountComponent({
+      content: '# Not a heading with **bold**',
+      inline: true,
+    })
+
+    expect(wrapper.element.tagName).toBe('SPAN')
+    expect(wrapper.classes()).toContain('markdown--inline')
+    expect(wrapper.find('h1').exists()).toBe(false)
+    expect(wrapper.find('strong').text()).toBe('bold')
+    expect(wrapper.text()).toBe('# Not a heading with bold')
+  })
+
+  test('disables the given rules', async () => {
+    const content =
+      'See [docs](https://example.com) and ![img](https://example.com/i.png)'
+    const wrapper = await mountComponent({
+      content,
+      inline: true,
+      disabledRules: ['link', 'image'],
+    })
+
+    expect(wrapper.find('a').exists()).toBe(false)
+    expect(wrapper.find('img').exists()).toBe(false)
+    expect(wrapper.text()).toBe(content)
+  })
+
+  test('re-enables rules when disabledRules changes', async () => {
+    const wrapper = await mountComponent({
+      content: '[docs](https://example.com)',
+      inline: true,
+      disabledRules: ['link'],
+    })
+    expect(wrapper.find('a').exists()).toBe(false)
+
+    await wrapper.setProps({ disabledRules: [] })
+
+    expect(wrapper.find('a').exists()).toBe(true)
+  })
+
+  test('escapes raw HTML in inline mode', async () => {
+    const wrapper = await mountComponent({
+      content: '<b>not bold</b>',
+      inline: true,
+    })
+
+    expect(wrapper.find('b').exists()).toBe(false)
+    expect(wrapper.text()).toBe('<b>not bold</b>')
+  })
+})


### PR DESCRIPTION
### What is in this PR
Option a2 - prefix on text itself

### How to test this PR
- E.g. a short series of steps on how to test the features/bug fixes in this PR.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
