### PR TITLE
fix: Ensure time is not truncated in Datetime picker

### DIFF
--- a/changelog/entries/unreleased/bug/fixed_a_bug_that_caused_the_time_to_be_truncated_in_the_date.json
+++ b/changelog/entries/unreleased/bug/fixed_a_bug_that_caused_the_time_to_be_truncated_in_the_date.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed a bug that caused the time to be truncated in the Datetime picker.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-09-09"
+}

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_datetime_picker.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_datetime_picker.scss
@@ -34,12 +34,12 @@
 
   &--date.ab-input {
     min-width: 5ch;
-    flex-basis: 11ch;
+    flex-basis: 12ch;
   }
 
   &--time.ab-input {
     min-width: 2ch;
-    flex-basis: 5ch;
+    flex-basis: 9ch;
   }
 }
 


### PR DESCRIPTION
### What is in this PR
This PR fixes a bug in the Datetime picker. When time is used in the picker, even if there is plenty of space, the time is truncated:
> <img width="213" height="63" alt="image" src="https://github.com/user-attachments/assets/c747076d-024a-46bf-8e2e-16ef952e5dbc" />

Now, the time is always visible:
> <img width="1291" height="312" alt="image" src="https://github.com/user-attachments/assets/f6fe2cfa-928e-4195-acea-2be520ed33a5" />

### How to test this PR
In `develop`, create a Datetime picker element and enable time. You'll notice that both in editor and preview/publish modes, the time is truncated.

It is fixed in this branch.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
