### PR TITLE
fix: Fix dashboard fetching of new datasources

### DIFF
--- a/web-frontend/modules/dashboard/realtime.js
+++ b/web-frontend/modules/dashboard/realtime.js
@@ -3,7 +3,9 @@ export const registerRealtimeEvents = (realtime) => {
     if (
       data.dashboard_id === store.getters['dashboardApplication/getDashboardId']
     ) {
-      store.dispatch('dashboardApplication/handleNewWidgetCreated', data.widget)
+      store.dispatch('dashboardApplication/handleNewWidgetCreated', {
+        createdWidget: data.widget,
+      })
     }
   })
   realtime.registerEvent('widget_updated', ({ store }, data) => {

--- a/web-frontend/modules/dashboard/store/dashboardApplication.js
+++ b/web-frontend/modules/dashboard/store/dashboardApplication.js
@@ -231,12 +231,23 @@ export const actions = {
     return createdWidget
   },
   async handleNewWidgetCreated(
-    { commit, dispatch },
-    { tempWidgetId, createdWidget }
+    { commit, dispatch, getters, state },
+    { tempWidgetId = null, createdWidget }
   ) {
-    commit('UPDATE_WIDGET', { widgetId: tempWidgetId, values: createdWidget })
-    dispatch('selectWidget', createdWidget.id)
-    await dispatch('fetchNewDataSources', createdWidget.dashboard_id)
+    if (tempWidgetId !== null && getters.getWidgetById(tempWidgetId)) {
+      // Created by this client, so the optimistically added widget is
+      // replaced by the real one and selected.
+      commit('UPDATE_WIDGET', { widgetId: tempWidgetId, values: createdWidget })
+      dispatch('selectWidget', createdWidget.id)
+    } else if (!getters.getWidgetById(createdWidget.id)) {
+      // Created elsewhere, e.g. by a collaborator or a trash restore, and
+      // received over realtime, so there is nothing to replace.
+      commit('ADD_WIDGET', createdWidget)
+    }
+    await dispatch('fetchNewDataSources', {
+      dashboardId: createdWidget.dashboard_id,
+      requestId: state.fetchRequestId,
+    })
   },
   async dispatchDataSource({ commit }, dataSourceId) {
     const { $client } = this

--- a/web-frontend/test/unit/dashboard/store/dashboardApplication.spec.js
+++ b/web-frontend/test/unit/dashboard/store/dashboardApplication.spec.js
@@ -1,0 +1,99 @@
+import { expect } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import MockAdapter from 'axios-mock-adapter'
+
+describe('dashboardApplication store', () => {
+  const dashboardId = 1
+  const dataSource = {
+    id: 10,
+    dashboard_id: dashboardId,
+    type: 'local_baserow_aggregate_rows',
+  }
+  const dataSourceResult = { result: 42 }
+  const createdWidget = {
+    id: 5,
+    dashboard_id: dashboardId,
+    type: 'summary',
+    data_source_id: dataSource.id,
+  }
+
+  let store = null
+  let mock = null
+
+  beforeEach(async () => {
+    const { $store, $client } = useNuxtApp()
+    store = $store
+    mock = new MockAdapter($client, { onNoMatch: 'throwException' })
+
+    mock.onGet(`/dashboard/${dashboardId}/widgets/`).reply(200, [])
+    mock.onGet(`/dashboard/${dashboardId}/data-sources/`).replyOnce(200, [])
+    await store.dispatch('dashboardApplication/fetchInitial', {
+      dashboardId,
+      forEditing: false,
+    })
+
+    // The data source that belongs to the widget created afterwards.
+    mock
+      .onGet(`/dashboard/${dashboardId}/data-sources/`)
+      .reply(200, [dataSource])
+    mock
+      .onPost(`/dashboard/data-sources/${dataSource.id}/dispatch/`)
+      .reply(200, dataSourceResult)
+  })
+
+  afterEach(() => {
+    mock.restore()
+  })
+
+  test('handleNewWidgetCreated replaces the optimistic widget and fetches its data source', async () => {
+    const tempWidgetId = 99999
+    store.commit('dashboardApplication/ADD_WIDGET', {
+      id: tempWidgetId,
+      type: 'summary',
+    })
+
+    await store.dispatch('dashboardApplication/handleNewWidgetCreated', {
+      tempWidgetId,
+      createdWidget,
+    })
+    await flushPromises()
+
+    expect(mock.history.get.map((request) => request.url)).toContain(
+      `/dashboard/${dashboardId}/data-sources/`
+    )
+    expect(
+      store.getters['dashboardApplication/getWidgetById'](tempWidgetId)
+    ).toBeUndefined()
+    expect(
+      store.getters['dashboardApplication/getWidgetById'](createdWidget.id)
+    ).toMatchObject(createdWidget)
+    expect(store.getters['dashboardApplication/getSelectedWidgetId']).toBe(
+      createdWidget.id
+    )
+    expect(
+      store.getters['dashboardApplication/getDataSourceById'](dataSource.id)
+    ).toMatchObject(dataSource)
+    expect(store.state.dashboardApplication.data[dataSource.id]).toEqual(
+      dataSourceResult
+    )
+  })
+
+  test('handleNewWidgetCreated adds a widget created elsewhere without selecting it', async () => {
+    await store.dispatch('dashboardApplication/handleNewWidgetCreated', {
+      createdWidget,
+    })
+    await flushPromises()
+
+    expect(store.state.dashboardApplication.widgets).toHaveLength(1)
+    expect(
+      store.getters['dashboardApplication/getWidgetById'](createdWidget.id)
+    ).toMatchObject(createdWidget)
+    expect(store.getters['dashboardApplication/getSelectedWidgetId']).toBe(null)
+    expect(
+      store.getters['dashboardApplication/getDataSourceById'](dataSource.id)
+    ).toMatchObject(dataSource)
+    expect(store.state.dashboardApplication.data[dataSource.id]).toEqual(
+      dataSourceResult
+    )
+  })
+})


### PR DESCRIPTION
### What is in this PR
We recently [merged in a feature](https://github.com/baserow/baserow/pull/6023) that refactored the `fetchNewDataSources` store action.

It was previously accepting just a int arg, but it was updated to accept an object. The Dashboard code calls that action, but was still passing an int.

### How to test this PR
In `develop`, create a new Dashboard app and add a Summary widget. You'll notice this error:
```
POST http://baserow-test.net:8000/api/dashboard/undefined/data-sources/ 404 (Not Found)
```

Note the `undefined`.

In this PR, we now return a 400 `ERROR_DASHBOARD_DATA_SOURCE_IMPROPERLY_CONFIGURED`, which is expected because the data source isn't picked yet.

No change log because the bug hasn't deployed yet.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
