### PR TITLE
feat: Reject decorative characters in name and workspace

### DIFF
--- a/backend/src/baserow/api/user/validators.py
+++ b/backend/src/baserow/api/user/validators.py
@@ -4,14 +4,18 @@ from django.core.exceptions import ValidationError
 
 from rest_framework import serializers
 
-from baserow.api.validators import EMAIL_LIKE_NAME_REGEX, no_url_validation
+from baserow.api.validators import (
+    EMAIL_LIKE_NAME_REGEX,
+    no_spam_validation,
+    no_url_validation,
+)
 
 
 def name_validation(value):
     """
-    Rejects names containing URL-like content or control characters to prevent
-    abuse of transactional emails for phishing, and email addresses because
-    they're not a name.
+    Rejects names containing URL-like content, control characters or spam patterns
+    to prevent abuse of transactional emails, and email addresses because they're
+    not a name.
     """
 
     if EMAIL_LIKE_NAME_REGEX.match(value):
@@ -20,7 +24,8 @@ def name_validation(value):
             code="name_is_email",
         )
 
-    return no_url_validation(value)
+    no_url_validation(value)
+    return no_spam_validation(value)
 
 
 def password_validation(value):

--- a/backend/src/baserow/api/validators.py
+++ b/backend/src/baserow/api/validators.py
@@ -1,4 +1,5 @@
 import re
+import unicodedata
 
 from rest_framework import serializers
 
@@ -15,6 +16,23 @@ URL_LIKE_NAME_REGEX = re.compile(
 )
 EMAIL_LIKE_NAME_REGEX = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 CONTROL_CHARS_REGEX = re.compile(r"[\x00-\x1f\x7f]")
+# Decorative letters and digits (circled, negative circled, squared, sub/superscript
+# and mathematical alphanumerics). Spammers use them to spell out contact details
+# while evading filters, and they never occur in real names. Regional indicators
+# (flag emoji) are deliberately excluded from the enclosed alphanumeric supplement.
+STYLIZED_CHARS_REGEX = re.compile(
+    "["
+    "\u2070-\u209f"  # superscripts and subscripts
+    "\u2460-\u24ff"  # enclosed alphanumerics
+    "\u2776-\u2793"  # dingbat circled digits
+    "\u3251-\u32bf"  # enclosed CJK numbers 21-50
+    "\U0001d400-\U0001d7ff"  # mathematical alphanumeric symbols
+    "\U0001f100-\U0001f1e5"  # enclosed alphanumeric supplement
+    "]"
+)
+# Contact IDs (QQ, WhatsApp, phone numbers) embedded in a name to advertise them via
+# transactional emails. Short numbers like `Team 2026` or `2025-2026` stay allowed.
+LONG_DIGIT_RUN_REGEX = re.compile(r"\d{6,}")
 
 
 def no_url_validation(value):
@@ -24,9 +42,31 @@ def no_url_validation(value):
     emails sent to others.
     """
 
-    if CONTROL_CHARS_REGEX.search(value) or URL_LIKE_NAME_REGEX.search(value):
+    # NFKC folds lookalike characters (fullwidth, sub/superscript, mathematical
+    # letters) into their ASCII form so they can't be used to evade the URL check.
+    normalized = unicodedata.normalize("NFKC", value)
+
+    if CONTROL_CHARS_REGEX.search(value) or URL_LIKE_NAME_REGEX.search(normalized):
         raise serializers.ValidationError(
             "Names can't contain links, domains or web addresses.",
+            code="invalid_name",
+        )
+
+    return value
+
+
+def no_spam_validation(value):
+    """
+    Rejects values containing decorative characters or long numbers, because spam
+    accounts use them to spell out contact details in names that end up in
+    invitation emails.
+    """
+
+    normalized = unicodedata.normalize("NFKC", value)
+
+    if STYLIZED_CHARS_REGEX.search(value) or LONG_DIGIT_RUN_REGEX.search(normalized):
+        raise serializers.ValidationError(
+            "Names can't contain decorative characters or long numbers.",
             code="invalid_name",
         )
 

--- a/backend/src/baserow/api/validators.py
+++ b/backend/src/baserow/api/validators.py
@@ -35,6 +35,20 @@ STYLIZED_CHARS_REGEX = re.compile(
 LONG_DIGIT_RUN_REGEX = re.compile(r"\d{6,}")
 
 
+def _normalize_name(value: str) -> str:
+    """
+    NFKC folds lookalike characters (fullwidth, sub/superscript, mathematical
+    letters) into their ASCII form, and invisible format characters (zero-width
+    spaces, joiners, bidi controls) are stripped because they can be inserted
+    between digits or letters to break up a pattern without changing how the name
+    renders. They're stripped rather than rejected because zero-width joiners are
+    legitimate in emoji sequences and some scripts.
+    """
+
+    normalized = unicodedata.normalize("NFKC", value)
+    return "".join(c for c in normalized if unicodedata.category(c) != "Cf")
+
+
 def no_url_validation(value):
     """
     Rejects values containing URL-like content or control characters to prevent abuse
@@ -42,9 +56,7 @@ def no_url_validation(value):
     emails sent to others.
     """
 
-    # NFKC folds lookalike characters (fullwidth, sub/superscript, mathematical
-    # letters) into their ASCII form so they can't be used to evade the URL check.
-    normalized = unicodedata.normalize("NFKC", value)
+    normalized = _normalize_name(value)
 
     if CONTROL_CHARS_REGEX.search(value) or URL_LIKE_NAME_REGEX.search(normalized):
         raise serializers.ValidationError(
@@ -62,7 +74,7 @@ def no_spam_validation(value):
     invitation emails.
     """
 
-    normalized = unicodedata.normalize("NFKC", value)
+    normalized = _normalize_name(value)
 
     if STYLIZED_CHARS_REGEX.search(value) or LONG_DIGIT_RUN_REGEX.search(normalized):
         raise serializers.ValidationError(

--- a/backend/src/baserow/api/workspaces/serializers.py
+++ b/backend/src/baserow/api/workspaces/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from baserow.api.mixins import UnknownFieldRaisesExceptionSerializerMixin
-from baserow.api.validators import no_url_validation
+from baserow.api.validators import no_spam_validation, no_url_validation
 from baserow.core.generative_ai.registries import generative_ai_model_type_registry
 from baserow.core.models import Workspace
 
@@ -28,7 +28,7 @@ class WorkspaceSerializer(serializers.ModelSerializer):
         extra_kwargs = {
             "id": {"read_only": True},
             "generative_ai_models_enabled": {"read_only": True},
-            "name": {"validators": [no_url_validation]},
+            "name": {"validators": [no_url_validation, no_spam_validation]},
         }
 
     def get_generative_ai_models_enabled(self, object):

--- a/backend/tests/baserow/api/groups/test_workspace_views.py
+++ b/backend/tests/baserow/api/groups/test_workspace_views.py
@@ -401,6 +401,10 @@ def test_workspace_name_validation(api_client, data_fixture):
         "www.evil.com",
         "https://evil.com",
         "bad\nname",
+        "🅰🅱🅲-❶❷❸❹❺❻◆⓿◆🅐❶❷'s workspace",
+        "💬🅰🅱🅲-❶❷❸-₁₂₃🅂❹❺.'s workspace",
+        "群1234567890聯絡加入's workspace",
+        "優惠活動1234567890加群12's workspace",
     ]
     for invalid_name in invalid_names:
         response = api_client.post(
@@ -428,8 +432,17 @@ def test_workspace_name_validation(api_client, data_fixture):
     workspace.refresh_from_db()
     assert workspace.name == "Old name"
 
-    # Dotted names without a high risk TLD or path must still be allowed.
-    valid_names = ["Dept. Marketing", "rocket.ia", "team.exenra"]
+    # Dotted names without a high risk TLD or path, emoji, flags and short numbers
+    # must still be allowed.
+    valid_names = [
+        "Dept. Marketing",
+        "rocket.ia",
+        "team.exenra",
+        "🚀 Marketing",
+        "🇳🇱 Sales",
+        "2025-2026 Budget",
+        "12345 Main",
+    ]
     for valid_name in valid_names:
         url = reverse("api:workspaces:item", kwargs={"workspace_id": workspace.id})
         response = api_client.patch(

--- a/backend/tests/baserow/api/groups/test_workspace_views.py
+++ b/backend/tests/baserow/api/groups/test_workspace_views.py
@@ -405,6 +405,7 @@ def test_workspace_name_validation(api_client, data_fixture):
         "💬🅰🅱🅲-❶❷❸-₁₂₃🅂❹❺.'s workspace",
         "群1234567890聯絡加入's workspace",
         "優惠活動1234567890加群12's workspace",
+        "call 0\u200b6\u200b1\u200b2\u200b3\u200b4\u200b5\u200b6",
     ]
     for invalid_name in invalid_names:
         response = api_client.post(
@@ -442,6 +443,7 @@ def test_workspace_name_validation(api_client, data_fixture):
         "🇳🇱 Sales",
         "2025-2026 Budget",
         "12345 Main",
+        "👨\u200d👩\u200d👧 Family",
     ]
     for valid_name in valid_names:
         url = reverse("api:workspaces:item", kwargs={"workspace_id": workspace.id})

--- a/backend/tests/baserow/api/users/test_user_views.py
+++ b/backend/tests/baserow/api/users/test_user_views.py
@@ -227,6 +227,13 @@ def test_create_user_with_url_in_name_is_rejected(client, data_fixture):
         "evil.click",
         "unknown-tld.weirdtld/path",
         "bad\nname",
+        "ｅｖｉｌ．ｃｏｍ",
+        "🅰🅱🅲-❶❷❸❹❺❻◆⓿◆🅐❶❷",
+        "💬🅰🅱🅲-❶❷❸-₁₂₃🅂❹❺.",
+        "𝐉𝐨𝐢𝐧 𝐦𝐞 𝐧𝐨𝐰",
+        "群1234567890聯絡加入",
+        "優惠活動1234567890加群12",
+        "call 0612345678",
     ]
     for invalid_name in invalid_names:
         response = client.post(
@@ -256,6 +263,10 @@ def test_create_user_with_url_in_name_is_rejected(client, data_fixture):
         "something.AI",
         "b.something",
         "startup.ai",
+        "Zoë Müller",
+        "山田太郎",
+        "John 2026",
+        "Ｊｏｈｎ",
     ]
     for index, valid_name in enumerate(valid_names):
         response = client.post(

--- a/backend/tests/baserow/api/users/test_user_views.py
+++ b/backend/tests/baserow/api/users/test_user_views.py
@@ -234,6 +234,8 @@ def test_create_user_with_url_in_name_is_rejected(client, data_fixture):
         "群1234567890聯絡加入",
         "優惠活動1234567890加群12",
         "call 0612345678",
+        "call 0\u200b6\u200b1\u200b2\u200b3\u200b4\u200b5\u200b6",
+        "evil\u200b.com",
     ]
     for invalid_name in invalid_names:
         response = client.post(
@@ -267,6 +269,7 @@ def test_create_user_with_url_in_name_is_rejected(client, data_fixture):
         "山田太郎",
         "John 2026",
         "Ｊｏｈｎ",
+        "John 👨\u200d👩\u200d👧",
     ]
     for index, valid_name in enumerate(valid_names):
         response = client.post(

--- a/changelog/entries/unreleased/bug/reject_decorative_characters_and_long_numbers_in_names.json
+++ b/changelog/entries/unreleased/bug/reject_decorative_characters_and_long_numbers_in_names.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Reject decorative characters and long numbers in user and workspace names",
+  "issue_origin": "github",
+  "issue_number": null,
+  "domain": "core",
+  "bullet_points": [],
+  "created_at": "2026-09-11"
+}

--- a/e2e-tests/tests/database/ai_field_provider_realtime.spec.ts
+++ b/e2e-tests/tests/database/ai_field_provider_realtime.spec.ts
@@ -83,7 +83,7 @@ test("AI field availability stays synchronized while visiting admin settings", a
     );
     const workspace = await createWorkspace(
       staffUser,
-      `AI realtime ${Date.now()}`,
+      `AI realtime ${Date.now().toString(36)}`,
     );
     workspaceId = workspace.id;
     const database = await createDatabase(

--- a/web-frontend/locales/en.json
+++ b/web-frontend/locales/en.json
@@ -116,6 +116,7 @@
     "maxLength": "A maximum of {max} characters is allowed here.",
     "minMaxLength": "A minimum of {min} and a maximum of {max} characters is allowed here.",
     "nameContainsUrl": "Names can't contain links, domains or web addresses.",
+    "nameContainsSpam": "Names can't contain decorative characters or long numbers.",
     "nameCantBeEmail": "Please enter your name, not your email address.",
     "invalidCharacters": "This field contains invalid characters.",
     "requiredField": "This field is required.",

--- a/web-frontend/modules/core/components/admin/users/forms/UserForm.vue
+++ b/web-frontend/modules/core/components/admin/users/forms/UserForm.vue
@@ -32,6 +32,9 @@
         <span v-else-if="v$.values.name.nameContainsNoUrl.$invalid">
           {{ $t('error.nameContainsUrl') }}
         </span>
+        <span v-else-if="v$.values.name.nameContainsNoSpam.$invalid">
+          {{ $t('error.nameContainsSpam') }}
+        </span>
       </template>
     </FormGroup>
 
@@ -151,6 +154,7 @@ import { email, maxLength, minLength, required } from '@vuelidate/validators'
 
 import form from '@baserow/modules/core/mixins/form'
 import {
+  nameContainsNoSpam,
   nameContainsNoUrl,
   nameIsNotEmail,
 } from '@baserow/modules/core/validators'
@@ -187,6 +191,7 @@ export default {
           maxLength: maxLength(60),
           nameIsNotEmail,
           nameContainsNoUrl,
+          nameContainsNoSpam,
         },
         username: {
           required,

--- a/web-frontend/modules/core/components/auth/PasswordRegister.vue
+++ b/web-frontend/modules/core/components/auth/PasswordRegister.vue
@@ -83,6 +83,14 @@
           >
             {{ $t('error.nameContainsUrl') }}
           </span>
+          <span
+            v-else-if="
+              v$.account.name.nameContainsNoSpam &&
+              v$.account.name.nameContainsNoSpam.$invalid
+            "
+          >
+            {{ $t('error.nameContainsSpam') }}
+          </span>
           <span v-else>
             {{ $t('error.minMaxLength', { min: 2, max: 60 }) }}
           </span>
@@ -143,6 +151,7 @@ import error from '@baserow/modules/core/mixins/error'
 import PasswordInput from '@baserow/modules/core/components/helpers/PasswordInput'
 import CaptchaWidget from '@baserow/modules/core/components/auth/CaptchaWidget'
 import {
+  nameContainsNoSpam,
   nameContainsNoUrl,
   nameIsNotEmail,
   passwordValidation,
@@ -183,6 +192,7 @@ export default {
           maxLength: maxLength(60),
           nameIsNotEmail,
           nameContainsNoUrl,
+          nameContainsNoSpam,
         },
         password: passwordValidation,
       },

--- a/web-frontend/modules/core/components/settings/AccountForm.vue
+++ b/web-frontend/modules/core/components/settings/AccountForm.vue
@@ -46,6 +46,7 @@ import { useI18n } from 'vue-i18n'
 
 import form from '@baserow/modules/core/mixins/form'
 import {
+  nameContainsNoSpam,
   nameContainsNoUrl,
   nameIsNotEmail,
 } from '@baserow/modules/core/validators'
@@ -100,6 +101,10 @@ export default {
           nameContainsNoUrl: helpers.withMessage(
             this.$t('error.nameContainsUrl'),
             nameContainsNoUrl
+          ),
+          nameContainsNoSpam: helpers.withMessage(
+            this.$t('error.nameContainsSpam'),
+            nameContainsNoSpam
           ),
         },
       },

--- a/web-frontend/modules/core/components/workspace/WorkspaceForm.vue
+++ b/web-frontend/modules/core/components/workspace/WorkspaceForm.vue
@@ -26,7 +26,10 @@ import { useVuelidate } from '@vuelidate/core'
 import { required, helpers } from '@vuelidate/validators'
 
 import form from '@baserow/modules/core/mixins/form'
-import { nameContainsNoUrl } from '@baserow/modules/core/validators'
+import {
+  nameContainsNoSpam,
+  nameContainsNoUrl,
+} from '@baserow/modules/core/validators'
 
 export default {
   name: 'WorkspaceForm',
@@ -59,6 +62,10 @@ export default {
           nameContainsNoUrl: helpers.withMessage(
             this.$t('error.nameContainsUrl'),
             nameContainsNoUrl
+          ),
+          nameContainsNoSpam: helpers.withMessage(
+            this.$t('error.nameContainsSpam'),
+            nameContainsNoSpam
           ),
         },
       },

--- a/web-frontend/modules/core/mixins/editWorkspace.js
+++ b/web-frontend/modules/core/mixins/editWorkspace.js
@@ -1,5 +1,8 @@
 import { notifyIf } from '@baserow/modules/core/utils/error'
-import { nameContainsNoUrl } from '@baserow/modules/core/validators'
+import {
+  nameContainsNoSpam,
+  nameContainsNoUrl,
+} from '@baserow/modules/core/validators'
 
 /**
  * Some helper methods to modify workspaces used by the dashboard.
@@ -17,11 +20,16 @@ export default {
       // The name is edited inline without a form, so there is no place to show
       // a validation error. Show a toast notification instead and revert the
       // name.
-      if (!nameContainsNoUrl(event.value)) {
+      const invalidNameMessage = !nameContainsNoUrl(event.value)
+        ? this.$t('error.nameContainsUrl')
+        : !nameContainsNoSpam(event.value)
+          ? this.$t('error.nameContainsSpam')
+          : null
+      if (invalidNameMessage) {
         this.$refs.rename.set(event.oldValue)
         this.$store.dispatch('toast/error', {
           title: this.$t('editWorkspace.invalidNameTitle'),
-          message: this.$t('error.nameContainsUrl'),
+          message: invalidNameMessage,
         })
         return
       }

--- a/web-frontend/modules/core/validators.js
+++ b/web-frontend/modules/core/validators.js
@@ -50,13 +50,21 @@ const STYLIZED_CHARS_REGEX = new RegExp(
 // transactional emails. Short numbers like `Team 2026` or `2025-2026` stay allowed.
 const LONG_DIGIT_RUN_REGEX = /\d{6,}/
 
+// NFKC folds lookalike characters (fullwidth, sub/superscript, mathematical
+// letters) into their ASCII form, and invisible format characters (zero-width
+// spaces, joiners, bidi controls) are stripped because they can be inserted
+// between digits or letters to break up a pattern without changing how the name
+// renders. They're stripped rather than rejected because zero-width joiners are
+// legitimate in emoji sequences and some scripts.
+const normalizeName = (value) => value.normalize('NFKC').replace(/\p{Cf}/gu, '')
+
 export const nameContainsNoUrl = (value) =>
-  !URL_LIKE_NAME_REGEX.test(value.normalize('NFKC')) &&
+  !URL_LIKE_NAME_REGEX.test(normalizeName(value)) &&
   !CONTROL_CHARS_REGEX.test(value)
 
 export const nameContainsNoSpam = (value) =>
   !STYLIZED_CHARS_REGEX.test(value) &&
-  !LONG_DIGIT_RUN_REGEX.test(value.normalize('NFKC'))
+  !LONG_DIGIT_RUN_REGEX.test(normalizeName(value))
 
 export const nameIsNotEmail = (value) =>
   !EMAIL_LIKE_NAME_REGEX.test(value.trim())

--- a/web-frontend/modules/core/validators.js
+++ b/web-frontend/modules/core/validators.js
@@ -30,8 +30,33 @@ const EMAIL_LIKE_NAME_REGEX = /^[^@\s]+@[^@\s]+\.[^@\s]+$/
 // eslint-disable-next-line no-control-regex
 const CONTROL_CHARS_REGEX = /[\u0000-\u001f\u007f]/
 
+// Decorative letters and digits (circled, negative circled, squared, sub/superscript
+// and mathematical alphanumerics). Spammers use them to spell out contact details
+// while evading filters, and they never occur in real names. Regional indicators
+// (flag emoji) are deliberately excluded from the enclosed alphanumeric supplement.
+// Must be kept in sync with `STYLIZED_CHARS_REGEX` in the backend.
+const STYLIZED_CHARS_REGEX = new RegExp(
+  '[' +
+    '\\u2070-\\u209f' + // superscripts and subscripts
+    '\\u2460-\\u24ff' + // enclosed alphanumerics
+    '\\u2776-\\u2793' + // dingbat circled digits
+    '\\u3251-\\u32bf' + // enclosed CJK numbers 21-50
+    '\\u{1d400}-\\u{1d7ff}' + // mathematical alphanumeric symbols
+    '\\u{1f100}-\\u{1f1e5}' + // enclosed alphanumeric supplement
+    ']',
+  'u'
+)
+// Contact IDs (QQ, WhatsApp, phone numbers) embedded in a name to advertise them via
+// transactional emails. Short numbers like `Team 2026` or `2025-2026` stay allowed.
+const LONG_DIGIT_RUN_REGEX = /\d{6,}/
+
 export const nameContainsNoUrl = (value) =>
-  !URL_LIKE_NAME_REGEX.test(value) && !CONTROL_CHARS_REGEX.test(value)
+  !URL_LIKE_NAME_REGEX.test(value.normalize('NFKC')) &&
+  !CONTROL_CHARS_REGEX.test(value)
+
+export const nameContainsNoSpam = (value) =>
+  !STYLIZED_CHARS_REGEX.test(value) &&
+  !LONG_DIGIT_RUN_REGEX.test(value.normalize('NFKC'))
 
 export const nameIsNotEmail = (value) =>
   !EMAIL_LIKE_NAME_REGEX.test(value.trim())

--- a/web-frontend/test/unit/core/validators.spec.js
+++ b/web-frontend/test/unit/core/validators.spec.js
@@ -1,4 +1,5 @@
 import {
+  nameContainsNoSpam,
   nameContainsNoUrl,
   nameIsNotEmail,
 } from '@baserow/modules/core/validators'
@@ -33,6 +34,7 @@ describe('nameContainsNoUrl', () => {
     'unknown-tld.weirdtld/path',
     'bad\nname',
     'bad\tname',
+    'ｅｖｉｌ．ｃｏｍ',
   ]
 
   test.each(validNames)('accepts %j', (name) => {
@@ -41,6 +43,40 @@ describe('nameContainsNoUrl', () => {
 
   test.each(invalidNames)('rejects %j', (name) => {
     expect(nameContainsNoUrl(name)).toBe(false)
+  })
+})
+
+describe('nameContainsNoSpam', () => {
+  const validNames = [
+    'Dr. Smith',
+    "Mary-Jane O'Neil",
+    'Zoë Müller',
+    '山田太郎',
+    'Team 2026',
+    '2025-2026 Budget',
+    '12345 Main',
+    '🚀 Marketing',
+    '🇳🇱 Sales',
+    'Area m²',
+    'Ｊｏｈｎ',
+  ]
+
+  const invalidNames = [
+    '🅰🅱🅲-❶❷❸❹❺❻◆⓿◆🅐❶❷',
+    '💬🅰🅱🅲-❶❷❸-₁₂₃🅂❹❺.',
+    '𝐉𝐨𝐢𝐧 𝐦𝐞 𝐧𝐨𝐰',
+    '①②③④⑤⑥',
+    '群1234567890聯絡加入',
+    '優惠活動1234567890加群12',
+    'call 0612345678',
+  ]
+
+  test.each(validNames)('accepts %j', (name) => {
+    expect(nameContainsNoSpam(name)).toBe(true)
+  })
+
+  test.each(invalidNames)('rejects %j', (name) => {
+    expect(nameContainsNoSpam(name)).toBe(false)
   })
 })
 

--- a/web-frontend/test/unit/core/validators.spec.js
+++ b/web-frontend/test/unit/core/validators.spec.js
@@ -35,6 +35,7 @@ describe('nameContainsNoUrl', () => {
     'bad\nname',
     'bad\tname',
     'ｅｖｉｌ．ｃｏｍ',
+    'evil\u200b.com',
   ]
 
   test.each(validNames)('accepts %j', (name) => {
@@ -59,6 +60,7 @@ describe('nameContainsNoSpam', () => {
     '🇳🇱 Sales',
     'Area m²',
     'Ｊｏｈｎ',
+    '👨\u200d👩\u200d👧 Family',
   ]
 
   const invalidNames = [
@@ -69,6 +71,7 @@ describe('nameContainsNoSpam', () => {
     '群1234567890聯絡加入',
     '優惠活動1234567890加群12',
     'call 0612345678',
+    'call 0\u200b6\u200b1\u200b2\u200b3\u200b4\u200b5\u200b6',
   ]
 
   test.each(validNames)('accepts %j', (name) => {


### PR DESCRIPTION
### What is in this PR

Rejects decorative characters like `🅰🅱🅲-❶❷❸❹❺❻◆⓿◆🅐❶❷` and long sequence of numbers as user name and workspace name. This is to prevent some of the invite spam that we're seeing.

### How to test this PR

- Confirm that the create user backend endpoint does not accept such characters and long numbers.
- Confirm that the create workspace backend endpoint does not accept such characters and long numbers.
- Confirm that signup page rejects such characters and long numbers in the validation.
- Confirm that create workspace modal rejects such characters and long numbers in the validation.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
